### PR TITLE
Add Rust source comment stripping tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
         run: |
           bash scripts/generate-manpages.sh
           git diff --exit-code man
+      - name: Check comments
+        if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
+        run: bash scripts/check-comments.sh
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing to oc_rsync!
 - Lint with `cargo clippy --all-targets --all-features -- -D warnings` before committing.
 - Keep contributions focused and document any new functionality.
 - Use the workspace `Cargo.lock` at the repository root; do not commit lockfiles in individual crates.
+- For wrapper Rust source files outside of `crates/` and `tests/`, begin the file with a comment containing its relative path, e.g. `// src/lib.rs`, and avoid any other comments. Run `scripts/check-comments.sh` to ensure compliance.
 
 ## Pull Request Process
 1. Fork the repository and create a topic branch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "posix-acl",
  "predicates",
  "protocol",
+ "rustc_lexer",
  "serde",
  "serde_json",
  "serial_test",
@@ -1128,6 +1129,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "rustc_lexer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86aae0c77166108c01305ee1a36a1e77289d7dc6ca0a3cd91ff4992de2d16a5"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,6 +1373,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ compress = { path = "crates/compress" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap_complete = "4"
+rustc_lexer = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
@@ -50,6 +51,10 @@ path = "tools/flag_matrix.rs"
 [[bin]]
 name = "gen-completions"
 path = "tools/gen_completions.rs"
+
+[[bin]]
+name = "strip-comments"
+path = "tools/strip-comments.rs"
 
 [features]
 default = []

--- a/scripts/check-comments.sh
+++ b/scripts/check-comments.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+files=$(git ls-files '*.rs' | grep -v '^crates/' | grep -v '^tests/')
+cargo run --quiet --bin strip-comments -- --check $files

--- a/tools/strip-comments.rs
+++ b/tools/strip-comments.rs
@@ -1,0 +1,68 @@
+// tools/strip-comments.rs
+use std::env;
+use std::fs;
+use std::path::Path;
+
+use rustc_lexer::{tokenize, TokenKind};
+
+fn strip_comments(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut pos = 0;
+    let tokens = tokenize(src);
+    let mut keep_first_comment = true;
+    for token in tokens {
+        let text = &src[pos..pos + token.len];
+        match token.kind {
+            TokenKind::LineComment | TokenKind::BlockComment { .. } => {
+                if keep_first_comment {
+                    out.push_str(text);
+                }
+            }
+            _ => out.push_str(text),
+        }
+        if text.contains('\n') {
+            keep_first_comment = false;
+        }
+        pos += token.len;
+    }
+    out
+}
+
+fn process_file(path: &Path, check: bool) -> Result<bool, Box<dyn std::error::Error>> {
+    let orig = fs::read_to_string(path)?;
+    let stripped = strip_comments(&orig);
+    if check {
+        if orig != stripped {
+            eprintln!("{}: contains disallowed comments", path.display());
+            return Ok(false);
+        }
+    } else if orig != stripped {
+        fs::write(path, stripped)?;
+    }
+    Ok(true)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args().skip(1);
+    let mut check = false;
+    let mut paths = Vec::new();
+    while let Some(arg) = args.next() {
+        if arg == "--check" {
+            check = true;
+        } else {
+            paths.push(arg);
+        }
+    }
+    let mut success = true;
+    for path in paths {
+        let path = Path::new(&path);
+        let ok = process_file(path, check)?;
+        if !ok {
+            success = false;
+        }
+    }
+    if check && !success {
+        std::process::exit(1);
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `strip-comments` tool using rustc_lexer to drop all comments except the first path line
- check wrapper sources for stray comments in CI
- document path comment policy for top-level Rust files

## Testing
- `bash scripts/check-comments.sh`
- `cargo test --all --features blake3` *(fails: tests::strong_digests)*


------
https://chatgpt.com/codex/tasks/task_e_68b36cbcef088323a6799d499c86bc3d