### PR TITLE
Implement daemon module auth and host filtering

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -7,7 +7,9 @@ use std::net::{IpAddr, TcpStream};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
-use daemon::{chroot_and_drop_privileges, parse_config_file};
+use daemon::{
+    authenticate_token, chroot_and_drop_privileges, parse_config_file, parse_module, Module,
+};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -290,27 +292,6 @@ struct ClientOpts {
     files_from: Vec<PathBuf>,
     #[arg(long)]
     from0: bool,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct Module {
-    name: String,
-    path: PathBuf,
-}
-
-fn parse_module(s: &str) -> std::result::Result<Module, String> {
-    let mut parts = s.splitn(2, '=');
-    let name = parts
-        .next()
-        .ok_or_else(|| "missing module name".to_string())?
-        .to_string();
-    let path = parts
-        .next()
-        .ok_or_else(|| "missing module path".to_string())?;
-    Ok(Module {
-        name,
-        path: PathBuf::from(path),
-    })
 }
 
 #[doc(hidden)]
@@ -1427,7 +1408,7 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
 }
 
 fn run_daemon(opts: DaemonOpts) -> Result<()> {
-    let mut modules = HashMap::new();
+    let mut modules: HashMap<String, Module> = HashMap::new();
     let mut secrets = opts.secrets_file.clone();
     let mut hosts_allow = opts.hosts_allow.clone();
     let mut hosts_deny = opts.hosts_deny.clone();
@@ -1441,7 +1422,7 @@ fn run_daemon(opts: DaemonOpts) -> Result<()> {
     if let Some(cfg_path) = &opts.config {
         let cfg = parse_config_file(cfg_path).map_err(|e| EngineError::Other(e.to_string()))?;
         for m in cfg.modules {
-            modules.insert(m.name.clone(), m.path);
+            modules.insert(m.name.clone(), m);
         }
         if let Some(p) = cfg.port {
             port = p;
@@ -1464,7 +1445,7 @@ fn run_daemon(opts: DaemonOpts) -> Result<()> {
     }
 
     for m in opts.module {
-        modules.insert(m.name, m.path);
+        modules.insert(m.name.clone(), m);
     }
     let addr_family = if opts.ipv4 {
         Some(AddressFamily::V4)
@@ -1522,7 +1503,7 @@ fn run_daemon(opts: DaemonOpts) -> Result<()> {
 
 fn handle_connection<T: Transport>(
     transport: &mut T,
-    modules: &HashMap<String, PathBuf>,
+    modules: &HashMap<String, Module>,
     secrets: Option<&Path>,
     log_file: Option<&Path>,
     log_format: Option<&str>,
@@ -1538,7 +1519,13 @@ fn handle_connection<T: Transport>(
     transport.send(&LATEST_VERSION.to_be_bytes())?;
     negotiate_version(peer_ver).map_err(|e| EngineError::Other(e.to_string()))?;
 
-    let allowed = authenticate(transport, secrets).map_err(EngineError::from)?;
+    let mut tok_buf = [0u8; 256];
+    let tn = transport.receive(&mut tok_buf)?;
+    let token = if tn == 0 {
+        None
+    } else {
+        Some(String::from_utf8_lossy(&tok_buf[..tn]).trim().to_string())
+    };
 
     if let Some(mpath) = motd {
         if let Ok(content) = fs::read_to_string(mpath) {
@@ -1553,8 +1540,33 @@ fn handle_connection<T: Transport>(
     let mut name_buf = [0u8; 256];
     let n = transport.receive(&mut name_buf)?;
     let name = String::from_utf8_lossy(&name_buf[..n]).trim().to_string();
-    if let Some(path) = modules.get(&name) {
+    if let Some(module) = modules.get(&name) {
+        if let Ok(ip) = peer.parse::<IpAddr>() {
+            if !host_allowed(&ip, &module.hosts_allow, &module.hosts_deny) {
+                let _ = transport.send(b"@ERROR: access denied");
+                return Err(EngineError::Other("host denied".into()));
+            }
+        }
+        let secrets_path = module.secrets_file.as_deref().or(secrets);
+        let allowed = if let Some(path) = secrets_path {
+            match token.as_deref() {
+                Some(tok) => match authenticate_token(tok, path) {
+                    Ok(list) => list,
+                    Err(e) => {
+                        let _ = transport.send(b"@ERROR: access denied");
+                        return Err(EngineError::Other(e.to_string()));
+                    }
+                },
+                None => {
+                    let _ = transport.send(b"@ERROR: access denied");
+                    return Err(EngineError::Other("missing token".into()));
+                }
+            }
+        } else {
+            Vec::new()
+        };
         if !allowed.is_empty() && !allowed.iter().any(|m| m == &name) {
+            let _ = transport.send(b"@ERROR: access denied");
             return Err(EngineError::Other("unauthorized module".into()));
         }
         if let Some(path) = log_file {
@@ -1566,7 +1578,7 @@ fn handle_connection<T: Transport>(
         }
         #[cfg(unix)]
         {
-            chroot_and_drop_privileges(path, 65534, 65534)
+            chroot_and_drop_privileges(&module.path, 65534, 65534)
                 .map_err(|e| EngineError::Other(e.to_string()))?;
         }
         sync(
@@ -1580,52 +1592,21 @@ fn handle_connection<T: Transport>(
     Ok(())
 }
 
-pub fn parse_auth_token(token: &str, contents: &str) -> Option<Vec<String>> {
-    for line in contents.lines() {
-        let mut parts = line.split_whitespace();
-        if let Some(tok) = parts.next() {
-            if tok == token {
-                return Some(parts.map(|s| s.to_string()).collect());
-            }
-        }
+fn host_matches(ip: &IpAddr, pat: &str) -> bool {
+    if pat == "*" {
+        return true;
     }
-    None
+    pat.parse::<IpAddr>().map_or(false, |p| &p == ip)
 }
 
-fn authenticate<T: Transport>(t: &mut T, path: Option<&Path>) -> std::io::Result<Vec<String>> {
-    let auth_path = path.unwrap_or(Path::new("auth"));
-    if !auth_path.exists() {
-        return Ok(Vec::new());
+fn host_allowed(ip: &IpAddr, allow: &[String], deny: &[String]) -> bool {
+    if !allow.is_empty() && !allow.iter().any(|p| host_matches(ip, p)) {
+        return false;
     }
-    #[cfg(unix)]
-    {
-        let mode = fs::metadata(auth_path)?.permissions().mode();
-        if mode & 0o077 != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "auth file permissions are too open",
-            ));
-        }
+    if deny.iter().any(|p| host_matches(ip, p)) {
+        return false;
     }
-    let contents = fs::read_to_string(auth_path)?;
-    let mut buf = [0u8; 256];
-    let n = t.receive(&mut buf)?;
-    if n == 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "missing token",
-        ));
-    }
-    let token = String::from_utf8_lossy(&buf[..n]).trim().to_string();
-    if let Some(allowed) = parse_auth_token(&token, &contents) {
-        Ok(allowed)
-    } else {
-        let _ = t.send(b"@ERROR: access denied");
-        Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "unauthorized",
-        ))
-    }
+    true
 }
 
 fn run_probe(opts: ProbeOpts) -> Result<()> {

--- a/fuzz/fuzz_targets/daemon_auth_token_parser.rs
+++ b/fuzz/fuzz_targets/daemon_auth_token_parser.rs
@@ -1,6 +1,6 @@
 // fuzz/fuzz_targets/daemon_auth_token_parser.rs
 #![no_main]
-use cli::parse_auth_token;
+use daemon::parse_auth_token;
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
## Summary
- Serve daemon modules with per-module configuration and secrets-file auth
- Enforce host allow/deny lists and drop privileges before syncing
- Add integration test for module-level secrets-file authentication

## Testing
- `cargo test`
- `cargo test daemon_config_module_secrets_file --test daemon_config`


------
https://chatgpt.com/codex/tasks/task_e_68b36ccddd308323a0be50de99975005