### PR TITLE
feat: bump protocol to v32

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -11,9 +11,10 @@ pub use demux::Demux;
 pub use mux::Mux;
 pub use server::Server;
 
-pub const LATEST_VERSION: u32 = 31;
+pub const LATEST_VERSION: u32 = 32;
 pub const MIN_VERSION: u32 = 29;
 pub const CAP_CODECS: u32 = 1 << 0;
+pub const SUPPORTED_CAPS: u32 = CAP_CODECS;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VersionError(pub u32);
@@ -433,7 +434,8 @@ mod tests {
 
     #[test]
     fn version_negotiation() {
-        assert_eq!(negotiate_version(40), Ok(31));
+        assert_eq!(negotiate_version(40), Ok(32));
+        assert_eq!(negotiate_version(32), Ok(32));
         assert_eq!(negotiate_version(31), Ok(31));
         assert_eq!(negotiate_version(30), Ok(30));
         assert!(negotiate_version(28).is_err());

--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -2,7 +2,7 @@
 use std::io::{self, Read, Write};
 use std::time::Duration;
 
-use crate::{negotiate_version, Demux, Frame, Message, Mux, CAP_CODECS};
+use crate::{negotiate_version, Demux, Frame, Message, Mux, CAP_CODECS, SUPPORTED_CAPS};
 use compress::{available_codecs, decode_codecs, encode_codecs, Codec};
 
 pub struct Server<R: Read, W: Write> {
@@ -50,11 +50,8 @@ impl<R: Read, W: Write> Server<R, W> {
         self.reader.read_exact(&mut buf)?;
         let peer_caps = u32::from_be_bytes(buf);
 
-        let mut caps = 0u32;
-        if peer_caps & CAP_CODECS != 0 {
-            caps |= CAP_CODECS;
-        }
-        self.writer.write_all(&caps.to_be_bytes())?;
+        let caps = peer_caps & SUPPORTED_CAPS;
+        self.writer.write_all(&SUPPORTED_CAPS.to_be_bytes())?;
         self.writer.flush()?;
 
         let mut peer_codecs = vec![Codec::Zlib];

--- a/crates/protocol/tests/golden_frames.rs
+++ b/crates/protocol/tests/golden_frames.rs
@@ -3,11 +3,11 @@ use protocol::{Frame, Message, Msg, Tag};
 
 #[test]
 fn decode_version_golden() {
-    const VERSION: [u8; 12] = [0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 31];
+    const VERSION: [u8; 12] = [0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 32];
     let frame = Frame::decode(&VERSION[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Version);
     let msg = Message::from_frame(frame).unwrap();
-    assert_eq!(msg, Message::Version(31));
+    assert_eq!(msg, Message::Version(32));
 }
 
 #[test]

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -38,7 +38,8 @@ fn keepalive_roundtrip() {
 
 #[test]
 fn version_negotiation() {
-    assert_eq!(negotiate_version(40), Ok(31));
+    assert_eq!(negotiate_version(40), Ok(32));
+    assert_eq!(negotiate_version(32), Ok(32));
     assert_eq!(negotiate_version(31), Ok(31));
     assert_eq!(negotiate_version(30), Ok(30));
     assert!(negotiate_version(28).is_err());

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -1,6 +1,6 @@
 // crates/protocol/tests/server.rs
 use compress::{available_codecs, encode_codecs};
-use protocol::{Server, CAP_CODECS, LATEST_VERSION};
+use protocol::{Server, CAP_CODECS, LATEST_VERSION, SUPPORTED_CAPS};
 use std::io::Cursor;
 use std::time::Duration;
 
@@ -13,7 +13,7 @@ fn server_negotiates_version() {
     let mut input = Cursor::new({
         let mut v = vec![0];
         v.extend_from_slice(&LATEST_VERSION.to_be_bytes());
-        v.extend_from_slice(&CAP_CODECS.to_be_bytes());
+        v.extend_from_slice(&(CAP_CODECS | (1 << 1)).to_be_bytes());
         v.extend_from_slice(&codecs_buf);
         v
     });
@@ -24,7 +24,37 @@ fn server_negotiates_version() {
     assert_eq!(peer_codecs, available_codecs());
     let expected = {
         let mut v = LATEST_VERSION.to_be_bytes().to_vec();
+        v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
+        let mut out_frame = Vec::new();
+        codecs_frame.encode(&mut out_frame).unwrap();
+        v.extend_from_slice(&out_frame);
+        v
+    };
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn server_falls_back_to_legacy_version() {
+    let legacy = LATEST_VERSION - 1;
+    let payload = encode_codecs(available_codecs());
+    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
+    let mut codecs_buf = Vec::new();
+    codecs_frame.encode(&mut codecs_buf).unwrap();
+    let mut input = Cursor::new({
+        let mut v = vec![0];
+        v.extend_from_slice(&legacy.to_be_bytes());
         v.extend_from_slice(&CAP_CODECS.to_be_bytes());
+        v.extend_from_slice(&codecs_buf);
+        v
+    });
+    let mut output = Vec::new();
+    let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
+    let peer_codecs = srv.handshake().unwrap();
+    assert_eq!(srv.version, legacy);
+    assert_eq!(peer_codecs, available_codecs());
+    let expected = {
+        let mut v = legacy.to_be_bytes().to_vec();
+        v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
         let mut out_frame = Vec::new();
         codecs_frame.encode(&mut out_frame).unwrap();
         v.extend_from_slice(&out_frame);

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -4,6 +4,13 @@
 `--modern` flag, it intends zero behavioral differences from the traditional
 utility and mirrors the classic command line.
 
+## Protocol support
+
+`oc-rsync` speaks rsync protocol versions 29 through 32 and
+negotiates the highest version that both peers understand. Feature bits
+are advertised to newer implementations while older peers simply ignore
+unknown capabilities, allowing seamless fallback.
+
 The `--modern` convenience flag enables additional enhancements beyond
 classic `rsync` behavior. For a complete listing see
 [cli/flags.md](cli/flags.md). For detailed parity status see


### PR DESCRIPTION
## Summary
- bump protocol version to 32 and publish supported capability bits
- extend handshake to advertise and negotiate feature bits
- test negotiation with new and legacy versions and document protocol support

## Testing
- `cargo test` *(fails: test remote_remote_via_ssh_paths hung >60s)*

------
https://chatgpt.com/codex/tasks/task_e_68b36c9b24888323b0e8763f088e8f56