### PR TITLE
Skip IPv6-only test when environment lacks IPv6

### DIFF
--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -96,6 +96,10 @@ fn spawn_daemon_ipv6() -> (Child, u16) {
     (child, port)
 }
 
+fn supports_ipv6() -> bool {
+    TcpListener::bind(("::1", 0)).is_ok()
+}
+
 fn wait_for_daemon_v6(port: u16) {
     for _ in 0..20 {
         if TcpStream::connect(("::1", port)).is_ok() {
@@ -156,6 +160,10 @@ fn daemon_binds_with_ipv4_flag() {
 #[test]
 #[serial]
 fn daemon_binds_with_ipv6_flag() {
+    if !supports_ipv6() {
+        eprintln!("IPv6 unsupported; skipping test");
+        return;
+    }
     let (mut child, port) = spawn_daemon_ipv6();
     wait_for_daemon_v6(port);
     TcpStream::connect(("::1", port)).unwrap();


### PR DESCRIPTION
## Summary
- add helper to detect IPv6 support
- skip IPv6 daemon binding test when IPv6 is unavailable

## Testing
- `cargo test --test daemon` *(fails: function takes 1 argument but 0 arguments were supplied)*

------
https://chatgpt.com/codex/tasks/task_e_68b3750555088323bc155cf7d924dfc1