### PR TITLE
refactor: remove unused codec import

### DIFF
--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -3,7 +3,7 @@ use std::io::{self, Read, Write};
 use std::time::Duration;
 
 use crate::{negotiate_version, Demux, Frame, Message, Mux, CAP_CODECS, SUPPORTED_CAPS};
-use compress::{available_codecs, decode_codecs, encode_codecs, Codec};
+use compress::{decode_codecs, encode_codecs, Codec};
 
 pub struct Server<R: Read, W: Write> {
     reader: R,


### PR DESCRIPTION
## Summary
- remove unused `available_codecs` import from protocol server

## Testing
- `cargo test -p protocol` *(fails: function takes 1 argument but 0 arguments supplied in tests)*
- `cargo check -p protocol --lib`


------
https://chatgpt.com/codex/tasks/task_e_68b3773004788323a4f8c3b457775cf0