### PR TITLE
Fix codec negotiation test to borrow slice

### DIFF
--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -37,7 +37,7 @@ fn server_negotiates_version() {
 #[test]
 fn server_falls_back_to_legacy_version() {
     let legacy = LATEST_VERSION - 1;
-    let payload = encode_codecs(available_codecs());
+    let payload = encode_codecs(&available_codecs(false));
     let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
@@ -50,9 +50,9 @@ fn server_falls_back_to_legacy_version() {
     });
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
-    let peer_codecs = srv.handshake().unwrap();
+    let peer_codecs = srv.handshake(&available_codecs(false)).unwrap();
     assert_eq!(srv.version, legacy);
-    assert_eq!(peer_codecs, available_codecs());
+    assert_eq!(peer_codecs, available_codecs(false));
     let expected = {
         let mut v = legacy.to_be_bytes().to_vec();
         v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());


### PR DESCRIPTION
## Summary
- Adjust protocol server test to use `available_codecs(false)` and borrow slice when encoding
- Pass explicit codec list to server handshake in legacy version test

## Testing
- `cargo test -p protocol`


------
https://chatgpt.com/codex/tasks/task_e_68b3772ee56c8323b3a8896bceab2a29