### PR TITLE
Pass modern flag to available_codecs in SSH transport

### DIFF
--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -203,7 +203,7 @@ impl SshStdioTransport {
 
         let mut peer_codecs = vec![Codec::Zlib];
         if caps & CAP_CODECS != 0 {
-            let payload = compress::encode_codecs(available_codecs());
+            let payload = compress::encode_codecs(&available_codecs(modern));
             let frame = Message::Codecs(payload).to_frame(0);
             let mut buf = Vec::new();
             frame


### PR DESCRIPTION
## Summary
- ensure SSH handshake uses modern-aware codec list

## Testing
- `cargo test -p transport`

------
https://chatgpt.com/codex/tasks/task_e_68b3772e21e88323bd1dadae86d7930d