### PR TITLE
Fix daemon IPv6 test network skip logic

### DIFF
--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -192,6 +192,8 @@ fn daemon_binds_with_ipv4_flag() {
 fn daemon_binds_with_ipv6_flag() {
     if require_network().is_err() {
         eprintln!("skipping daemon test: network access required");
+        return;
+    }
     if !supports_ipv6() {
         eprintln!("IPv6 unsupported; skipping test");
         return;


### PR DESCRIPTION
## Summary
- fix IPv6 daemon test to return when network unavailable
- move IPv6 support check outside network block

## Testing
- `cargo test tests/daemon.rs`

------
https://chatgpt.com/codex/tasks/task_e_68b3799968d8832398b66dee372ea32f