### PR TITLE
Refactor synchronize return

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@ pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
         &Matcher::default(),
         &available_codecs(false),
         &SyncOptions::default(),
-    )
-    .map(|_| ())
+    )?;
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- simplify `synchronize` by returning on success

## Testing
- `cargo test` *(fails: unclosed delimiter in tests/daemon.rs)*
- `cargo test --lib`


------
https://chatgpt.com/codex/tasks/task_e_68b3799abc34832389c236aa8627c36f