### PR TITLE
Add logging crate and initialize early in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,12 +779,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "logging"
+version = "0.1.0"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -842,6 +859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +909,7 @@ version = "0.1.0"
 dependencies = [
  "cli",
  "engine",
+ "logging",
 ]
 
 [[package]]
@@ -1252,6 +1279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1368,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1384,80 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -1385,6 +1504,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -1442,6 +1567,15 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/daemon",
     "crates/cli",
     "bin/oc-rsync",
+    "crates/logging",
 ]
 resolver = "2"
 

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 [dependencies]
 cli = { path = "../../crates/cli" }
 engine = { path = "../../crates/engine" }
+logging = { path = "../../crates/logging" }
 
 [features]
 default = []

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,6 +1,26 @@
 // bin/oc-rsync/src/main.rs
 use engine::Result;
+use logging::LogFormat;
+use std::env;
 
 fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let mut verbose = 0u8;
+    let mut info = false;
+    let mut debug = false;
+    for arg in &args {
+        if arg == "--info" || arg.starts_with("--info=") {
+            info = true;
+        } else if arg == "--debug" || arg.starts_with("--debug=") {
+            debug = true;
+        } else if arg.starts_with('-') && !arg.starts_with("--") {
+            for ch in arg.chars().skip(1) {
+                if ch == 'v' {
+                    verbose += 1;
+                }
+            }
+        }
+    }
+    logging::init(LogFormat::Text, verbose, info, debug);
     cli::run()
 }

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "logging"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,0 +1,46 @@
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{
+    fmt,
+    layer::{Layer as _, SubscriberExt},
+    util::SubscriberInitExt,
+    EnvFilter,
+};
+
+/// Output format for log records.
+#[derive(Clone, Copy)]
+pub enum LogFormat {
+    Text,
+    Json,
+}
+
+/// Build a `tracing` subscriber with the requested configuration.
+pub fn subscriber(
+    format: LogFormat,
+    verbose: u8,
+    info: bool,
+    debug: bool,
+) -> impl tracing::Subscriber + Send + Sync {
+    let level = if debug || verbose > 1 {
+        LevelFilter::DEBUG
+    } else if info || verbose > 0 {
+        LevelFilter::INFO
+    } else {
+        LevelFilter::WARN
+    };
+    let filter = EnvFilter::builder()
+        .with_default_directive(level.into())
+        .from_env_lossy();
+
+    let fmt_layer = fmt::layer();
+    let fmt_layer = match format {
+        LogFormat::Json => fmt_layer.json().boxed(),
+        LogFormat::Text => fmt_layer.boxed(),
+    };
+
+    tracing_subscriber::registry().with(filter).with(fmt_layer)
+}
+
+/// Initialize global logging.
+pub fn init(format: LogFormat, verbose: u8, info: bool, debug: bool) {
+    subscriber(format, verbose, info, debug).init();
+}

--- a/crates/logging/tests/levels.rs
+++ b/crates/logging/tests/levels.rs
@@ -1,0 +1,43 @@
+use logging::{subscriber, LogFormat};
+use tracing::Level;
+use tracing::subscriber::with_default;
+
+#[test]
+fn info_not_emitted_by_default() {
+    let sub = subscriber(LogFormat::Text, 0, false, false);
+    with_default(sub, || {
+        assert!(!tracing::enabled!(Level::INFO));
+    });
+}
+
+#[test]
+fn verbose_enables_info() {
+    let sub = subscriber(LogFormat::Text, 1, false, false);
+    with_default(sub, || {
+        assert!(tracing::enabled!(Level::INFO));
+    });
+}
+
+#[test]
+fn debug_enables_debug() {
+    let sub = subscriber(LogFormat::Text, 0, false, true);
+    with_default(sub, || {
+        assert!(tracing::enabled!(Level::DEBUG));
+    });
+}
+
+#[test]
+fn debug_with_two_v() {
+    let sub = subscriber(LogFormat::Text, 2, false, false);
+    with_default(sub, || {
+        assert!(tracing::enabled!(Level::DEBUG));
+    });
+}
+
+#[test]
+fn info_flag_enables_info() {
+    let sub = subscriber(LogFormat::Text, 0, true, false);
+    with_default(sub, || {
+        assert!(tracing::enabled!(Level::INFO));
+    });
+}


### PR DESCRIPTION
## Summary
- introduce new `logging` crate using `tracing` with text or JSON formatting
- parse verbosity flags in `oc-rsync` binary and initialize logging before CLI runs
- verify level filtering with dedicated tests

## Testing
- `cargo test -p logging`
- `cargo test -p oc-rsync-bin`


------
https://chatgpt.com/codex/tasks/task_e_68b37b6931588323856ecf8d6ea3725a