### PR TITLE
Add modern compression, hash, and cdc flags

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -9,6 +9,12 @@ cpufeatures::new!(avx2, "avx2");
 cpufeatures::new!(avx512, "avx512f");
 
 #[derive(Clone, Copy, Debug)]
+pub enum ModernHash {
+    #[cfg(feature = "blake3")]
+    Blake3,
+}
+
+#[derive(Clone, Copy, Debug)]
 pub enum StrongHash {
     Md5,
     Sha1,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -14,9 +14,13 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use clap::{ArgAction, ArgMatches, CommandFactory, FromArgMatches, Parser};
-use compress::{available_codecs, Codec};
+use compress::{available_codecs, Codec, ModernCompress};
 use engine::human_bytes;
-use engine::{sync, DeleteMode, EngineError, Result, Stats, StrongHash, SyncOptions};
+use engine::{
+    sync, DeleteMode, EngineError, ModernCdc, Result, Stats, StrongHash, SyncOptions,
+};
+#[cfg(feature = "blake3")]
+use engine::ModernHash;
 use filters::{default_cvs_rules, parse, Matcher, Rule};
 use meta::{parse_chmod, parse_chown};
 use protocol::{negotiate_version, LATEST_VERSION};
@@ -30,6 +34,25 @@ fn parse_filters(s: &str) -> std::result::Result<Vec<Rule>, filters::ParseError>
 
 fn parse_duration(s: &str) -> std::result::Result<Duration, std::num::ParseIntError> {
     Ok(Duration::from_secs(s.parse()?))
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum ModernCompressArg {
+    Auto,
+    Zstd,
+    Lz4,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum ModernHashArg {
+    #[cfg(feature = "blake3")]
+    Blake3,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug)]
+enum ModernCdcArg {
+    Fastcdc,
+    Off,
 }
 
 #[derive(Parser, Debug)]
@@ -176,6 +199,12 @@ struct ClientOpts {
     /// Enable modern compression (zstd or lz4) and BLAKE3 checksums (requires `blake3` feature)
     #[arg(long, help_heading = "Compression")]
     modern: bool,
+    #[arg(long = "modern-compress", value_enum, help_heading = "Compression")]
+    modern_compress: Option<ModernCompressArg>,
+    #[arg(long = "modern-hash", value_enum, help_heading = "Compression")]
+    modern_hash: Option<ModernHashArg>,
+    #[arg(long = "modern-cdc", value_enum, help_heading = "Compression")]
+    modern_cdc: Option<ModernCdcArg>,
     #[arg(long, help_heading = "Misc")]
     partial: bool,
     #[arg(long = "partial-dir", value_name = "DIR", help_heading = "Misc")]
@@ -691,17 +720,51 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         rsync_env.push(("RSYNC_TIMEOUT".into(), to.as_secs().to_string()));
     }
 
+    let modern_compress = if opts.modern || opts.modern_compress.is_some() {
+        Some(
+            match opts.modern_compress.unwrap_or(ModernCompressArg::Auto) {
+                ModernCompressArg::Auto => ModernCompress::Auto,
+                ModernCompressArg::Zstd => ModernCompress::Zstd,
+                ModernCompressArg::Lz4 => ModernCompress::Lz4,
+            },
+        )
+    } else {
+        None
+    };
+    #[cfg(feature = "blake3")]
+    let modern_hash = if opts.modern || matches!(opts.modern_hash, Some(ModernHashArg::Blake3)) {
+        Some(ModernHash::Blake3)
+    } else {
+        None
+    };
+    #[cfg(not(feature = "blake3"))]
+    let modern_hash = None;
+    let modern_cdc_arg = opts.modern_cdc.unwrap_or_else(|| {
+        if opts.modern {
+            ModernCdcArg::Fastcdc
+        } else {
+            ModernCdcArg::Off
+        }
+    });
+    let modern_cdc = match modern_cdc_arg {
+        ModernCdcArg::Fastcdc => ModernCdc::Fastcdc,
+        ModernCdcArg::Off => ModernCdc::Off,
+    };
+    let modern_enabled = modern_compress.is_some()
+        || modern_hash.is_some()
+        || matches!(modern_cdc, ModernCdc::Fastcdc);
+
     if !rsync_env.iter().any(|(k, _)| k == "RSYNC_CHECKSUM_LIST") {
         #[cfg_attr(not(feature = "blake3"), allow(unused_mut))]
         let mut list = vec!["md5", "sha1"];
         #[cfg(feature = "blake3")]
-        if opts.modern || matches!(opts.checksum_choice.as_deref(), Some("blake3")) {
+        if modern_hash.is_some() || matches!(opts.checksum_choice.as_deref(), Some("blake3")) {
             list.insert(0, "blake3");
         }
         rsync_env.push(("RSYNC_CHECKSUM_LIST".into(), list.join(",")));
     }
 
-    if opts.modern {
+    if modern_enabled {
         rsync_env.push(("RSYNC_MODERN".into(), "1".into()));
     }
 
@@ -718,12 +781,17 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                 return Err(EngineError::Other(format!("unknown checksum {other}")));
             }
         }
+    } else if let Some(h) = modern_hash {
+        match h {
+            #[cfg(feature = "blake3")]
+            ModernHash::Blake3 => StrongHash::Blake3,
+        }
     } else if let Ok(list) = env::var("RSYNC_CHECKSUM_LIST") {
         let mut chosen = StrongHash::Md5;
         for name in list.split(',') {
             match name {
                 #[cfg(feature = "blake3")]
-                "blake3" if opts.modern => {
+                "blake3" if modern_enabled => {
                     chosen = StrongHash::Blake3;
                     break;
                 }
@@ -785,7 +853,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                         return Err(EngineError::Other(format!("unknown codec {other}")));
                     }
                 };
-                if !available_codecs(true).contains(&codec) {
+                if !available_codecs(Some(ModernCompress::Auto)).contains(&codec) {
                     return Err(EngineError::Other(format!(
                         "codec {name} not supported by this build"
                     )));
@@ -803,10 +871,10 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     let compress = if opts.compress_choice.as_deref() == Some("none") {
         false
     } else {
-        opts.modern
-            || opts.compress
+        opts.compress
             || opts.compress_level.map_or(false, |l| l > 0)
             || compress_choice.is_some()
+            || modern_compress.is_some()
     };
     let mut delete_mode = if opts.delete_before {
         Some(DeleteMode::Before)
@@ -835,8 +903,9 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         delete_excluded: opts.delete_excluded,
         checksum: opts.checksum,
         compress,
-        modern: opts.modern,
-        cdc: opts.modern,
+        modern_compress,
+        modern_hash,
+        modern_cdc,
         dirs: opts.dirs,
         list_only: opts.list_only,
         update: opts.update,
@@ -905,7 +974,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                 &src.path,
                 &dst.path,
                 &matcher,
-                &available_codecs(opts.modern),
+                &available_codecs(modern_compress),
                 &sync_opts,
             )?,
             _ => return Err(EngineError::Other("local sync requires local paths".into())),
@@ -940,7 +1009,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     &src.path,
                     &dst.path,
                     &matcher,
-                    &available_codecs(opts.modern),
+                    &available_codecs(modern_compress),
                     &sync_opts,
                 )?
             }
@@ -965,7 +1034,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     opts.port,
                     opts.contimeout,
                     addr_family,
-                    opts.modern,
+                    modern_compress,
                     opts.protocol.unwrap_or(LATEST_VERSION),
                 )
                 .map_err(|e| EngineError::Other(e.to_string()))?;
@@ -998,7 +1067,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     &src.path,
                     &dst.path,
                     &matcher,
-                    &available_codecs(opts.modern),
+                    &available_codecs(modern_compress),
                     &sync_opts,
                 )?
             }
@@ -1023,7 +1092,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     opts.port,
                     opts.contimeout,
                     addr_family,
-                    opts.modern,
+                    modern_compress,
                     opts.protocol.unwrap_or(LATEST_VERSION),
                 )
                 .map_err(|e| EngineError::Other(e.to_string()))?;
@@ -1605,13 +1674,27 @@ fn handle_connection<T: Transport>(
                 .map_err(|e| EngineError::Other(e.to_string()))?;
         }
         let modern = env::var("RSYNC_MODERN").ok().as_deref() == Some("1");
+        let mc = if modern {
+            Some(ModernCompress::Auto)
+        } else {
+            None
+        };
+        #[cfg(feature = "blake3")]
+        let mh = if modern {
+            Some(ModernHash::Blake3)
+        } else {
+            None
+        };
+        #[cfg(not(feature = "blake3"))]
+        let mh = None;
         sync(
             Path::new("."),
             Path::new("."),
             &Matcher::default(),
-            &available_codecs(modern),
+            &available_codecs(mc),
             &SyncOptions {
-                modern,
+                modern_compress: mc,
+                modern_hash: mh,
                 ..Default::default()
             },
         )?;
@@ -1664,7 +1747,12 @@ fn run_server() -> Result<()> {
         .map(Duration::from_secs)
         .unwrap_or(Duration::from_secs(30));
     let modern = env::var("RSYNC_MODERN").ok().as_deref() == Some("1");
-    let codecs = available_codecs(modern);
+    let mc = if modern {
+        Some(ModernCompress::Auto)
+    } else {
+        None
+    };
+    let codecs = available_codecs(mc);
     let mut srv = Server::new(stdin.lock(), stdout.lock(), timeout);
     let _ = srv
         .handshake(&codecs)

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -7,6 +7,13 @@ cpufeatures::new!(avx2, "avx2");
 cpufeatures::new!(avx512, "avx512f");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModernCompress {
+    Auto,
+    Zstd,
+    Lz4,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Codec {
     Zlib,
     Zstd,
@@ -35,13 +42,26 @@ impl Codec {
     }
 }
 
-pub fn available_codecs(modern: bool) -> Vec<Codec> {
+pub fn available_codecs(modern: Option<ModernCompress>) -> Vec<Codec> {
     let mut codecs = vec![Codec::Zlib];
-    if modern {
-        codecs.push(Codec::Zstd);
-        #[cfg(feature = "lz4")]
-        {
-            codecs.push(Codec::Lz4);
+    if let Some(mode) = modern {
+        match mode {
+            ModernCompress::Auto => {
+                codecs.push(Codec::Zstd);
+                #[cfg(feature = "lz4")]
+                {
+                    codecs.push(Codec::Lz4);
+                }
+            }
+            ModernCompress::Zstd => {
+                codecs.push(Codec::Zstd);
+            }
+            ModernCompress::Lz4 => {
+                #[cfg(feature = "lz4")]
+                {
+                    codecs.push(Codec::Lz4);
+                }
+            }
         }
     }
     codecs

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -8,11 +8,13 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-pub use checksums::StrongHash;
 use checksums::{ChecksumConfig, ChecksumConfigBuilder};
+pub use checksums::{ModernHash, StrongHash};
 #[cfg(feature = "lz4")]
 use compress::Lz4;
-use compress::{available_codecs, should_compress, Codec, Compressor, Decompressor, Zlib, Zstd};
+use compress::{
+    available_codecs, should_compress, Codec, Compressor, Decompressor, ModernCompress, Zlib, Zstd,
+};
 use filters::Matcher;
 use thiserror::Error;
 
@@ -903,14 +905,21 @@ pub enum DeleteMode {
     After,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModernCdc {
+    Fastcdc,
+    Off,
+}
+
 #[derive(Debug, Clone)]
 pub struct SyncOptions {
     pub delete: Option<DeleteMode>,
     pub delete_excluded: bool,
     pub checksum: bool,
     pub compress: bool,
-    pub modern: bool,
-    pub cdc: bool,
+    pub modern_compress: Option<ModernCompress>,
+    pub modern_hash: Option<ModernHash>,
+    pub modern_cdc: ModernCdc,
     pub dirs: bool,
     pub list_only: bool,
     pub update: bool,
@@ -974,8 +983,9 @@ impl Default for SyncOptions {
             delete_excluded: false,
             checksum: false,
             compress: false,
-            modern: false,
-            cdc: false,
+            modern_compress: None,
+            modern_hash: None,
+            modern_cdc: ModernCdc::Off,
             perms: false,
             executability: false,
             times: false,
@@ -1058,21 +1068,46 @@ pub fn select_codec(remote: &[Codec], opts: &SyncOptions) -> Option<Codec> {
     if let Some(choice) = &opts.compress_choice {
         return choice.iter().copied().find(|c| remote.contains(c));
     }
-    if !opts.modern {
-        return remote.contains(&Codec::Zlib).then_some(Codec::Zlib);
-    }
-    let local = available_codecs(true);
-    let prefer_lz4 = cpu_prefers_lz4();
-    if prefer_lz4 && local.contains(&Codec::Lz4) && remote.contains(&Codec::Lz4) {
-        Some(Codec::Lz4)
-    } else if local.contains(&Codec::Zstd) && remote.contains(&Codec::Zstd) {
-        Some(Codec::Zstd)
-    } else if local.contains(&Codec::Lz4) && remote.contains(&Codec::Lz4) {
-        Some(Codec::Lz4)
-    } else if remote.contains(&Codec::Zlib) {
-        Some(Codec::Zlib)
-    } else {
-        None
+    let modern = match opts.modern_compress {
+        Some(m) => m,
+        None => return remote.contains(&Codec::Zlib).then_some(Codec::Zlib),
+    };
+    let local = available_codecs(Some(modern));
+    match modern {
+        ModernCompress::Auto => {
+            let prefer_lz4 = cpu_prefers_lz4();
+            if prefer_lz4 && local.contains(&Codec::Lz4) && remote.contains(&Codec::Lz4) {
+                Some(Codec::Lz4)
+            } else if local.contains(&Codec::Zstd) && remote.contains(&Codec::Zstd) {
+                Some(Codec::Zstd)
+            } else if local.contains(&Codec::Lz4) && remote.contains(&Codec::Lz4) {
+                Some(Codec::Lz4)
+            } else if remote.contains(&Codec::Zlib) {
+                Some(Codec::Zlib)
+            } else {
+                None
+            }
+        }
+        ModernCompress::Zstd => {
+            if remote.contains(&Codec::Zstd) {
+                Some(Codec::Zstd)
+            } else if remote.contains(&Codec::Zlib) {
+                Some(Codec::Zlib)
+            } else {
+                None
+            }
+        }
+        ModernCompress::Lz4 => {
+            if remote.contains(&Codec::Lz4) {
+                Some(Codec::Lz4)
+            } else if remote.contains(&Codec::Zstd) {
+                Some(Codec::Zstd)
+            } else if remote.contains(&Codec::Zlib) {
+                Some(Codec::Zlib)
+            } else {
+                None
+            }
+        }
     }
 }
 
@@ -1166,7 +1201,7 @@ pub fn sync(
     let mut sender = Sender::new(opts.block_size, matcher.clone(), codec, opts.clone());
     let mut receiver = Receiver::new(codec, opts.clone());
     let mut stats = Stats::default();
-    let mut manifest = if opts.cdc {
+    let mut manifest = if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
         Manifest::load()
     } else {
         Manifest::default()
@@ -1235,7 +1270,7 @@ pub fn sync(
                         false
                     };
                     if !dest_path.exists() && !partial_exists {
-                        if opts.cdc {
+                        if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
                             if let Ok(chunks) = chunk_file(&path) {
                                 if !chunks.is_empty() {
                                     if let Some(existing) = manifest.lookup(&chunks[0].hash) {
@@ -1293,7 +1328,7 @@ pub fn sync(
                         if opts.itemize_changes {
                             println!(">f+++++++++ {}", rel.display());
                         }
-                        if opts.cdc {
+                        if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
                             if let Ok(chunks) = chunk_file(&dest_path) {
                                 for c in &chunks {
                                     manifest.insert(&c.hash, &dest_path);
@@ -1413,7 +1448,7 @@ pub fn sync(
     ) {
         delete_extraneous(src, dst, &matcher, opts, &mut stats)?;
     }
-    if opts.cdc {
+    if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
         manifest.save()?;
     }
     Ok(stats)
@@ -1549,7 +1584,7 @@ mod tests {
             &src,
             &dst,
             &Matcher::default(),
-            &available_codecs(false),
+            &available_codecs(None),
             &SyncOptions::default(),
         )
         .unwrap();

--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -29,7 +29,7 @@ fn perms_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             perms: true,
             ..Default::default()
@@ -54,7 +54,7 @@ fn chmod_applies() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             perms: true,
             chmod: Some(parse_chmod("F600").unwrap()),
@@ -79,7 +79,7 @@ fn chown_applies() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             owner: true,
             group: true,
@@ -108,7 +108,7 @@ fn times_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             times: true,
             ..Default::default()
@@ -135,7 +135,7 @@ fn omit_dir_times_skips_dirs() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             times: true,
             omit_dir_times: true,
@@ -165,7 +165,7 @@ fn omit_link_times_skips_symlinks() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             times: true,
             links: true,
@@ -194,7 +194,7 @@ fn atimes_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             atimes: true,
             ..Default::default()
@@ -233,7 +233,7 @@ fn crtimes_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             crtimes: true,
             ..Default::default()
@@ -271,7 +271,7 @@ fn owner_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             owner: true,
             ..Default::default()
@@ -297,7 +297,7 @@ fn group_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             group: true,
             ..Default::default()
@@ -322,7 +322,7 @@ fn links_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             links: true,
             ..Default::default()
@@ -352,7 +352,7 @@ fn hard_links_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             hard_links: true,
             ..Default::default()
@@ -379,7 +379,7 @@ fn xattrs_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             xattrs: true,
             ..Default::default()
@@ -411,7 +411,7 @@ fn acls_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             acls: true,
             ..Default::default()
@@ -443,7 +443,7 @@ fn devices_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             devices: true,
             ..Default::default()
@@ -468,7 +468,7 @@ fn specials_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             specials: true,
             ..Default::default()
@@ -496,7 +496,7 @@ fn sparse_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             sparse: true,
             ..Default::default()
@@ -527,7 +527,7 @@ fn sparse_creation_from_zeros() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             sparse: true,
             ..Default::default()
@@ -559,7 +559,7 @@ fn metadata_matches_rsync() {
         &src,
         &dst_rrs,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             owner: true,
             group: true,

--- a/crates/engine/tests/backup.rs
+++ b/crates/engine/tests/backup.rs
@@ -23,7 +23,7 @@ fn backups_replaced_and_deleted_files() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             delete: Some(DeleteMode::During),
             backup: true,

--- a/crates/engine/tests/checksum.rs
+++ b/crates/engine/tests/checksum.rs
@@ -28,7 +28,7 @@ fn checksum_forces_transfer() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions::default(),
     )
     .unwrap();
@@ -39,7 +39,7 @@ fn checksum_forces_transfer() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             checksum: true,
             ..Default::default()
@@ -72,7 +72,7 @@ fn checksum_skips_transfer_when_unchanged() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions {
             checksum: true,
             ..Default::default()

--- a/crates/engine/tests/compress.rs
+++ b/crates/engine/tests/compress.rs
@@ -1,7 +1,7 @@
 // crates/engine/tests/compress.rs
 use std::fs;
 
-use compress::Codec;
+use compress::{Codec, ModernCompress};
 use engine::{select_codec, sync, SyncOptions};
 use filters::Matcher;
 use tempfile::tempdir;
@@ -41,7 +41,7 @@ fn zstd_roundtrip() {
         &[Codec::Zstd],
         &SyncOptions {
             compress: true,
-            modern: true,
+            modern_compress: Some(ModernCompress::Auto),
             ..Default::default()
         },
     )
@@ -64,7 +64,7 @@ fn lz4_roundtrip() {
         &[Codec::Lz4],
         &SyncOptions {
             compress: true,
-            modern: true,
+            modern_compress: Some(ModernCompress::Auto),
             ..Default::default()
         },
     )
@@ -76,7 +76,7 @@ fn lz4_roundtrip() {
 fn codec_selection_prefers_zstd() {
     let opts = SyncOptions {
         compress: true,
-        modern: true,
+        modern_compress: Some(ModernCompress::Auto),
         ..Default::default()
     };
     assert_eq!(
@@ -86,7 +86,7 @@ fn codec_selection_prefers_zstd() {
     assert_eq!(select_codec(&[Codec::Zlib], &opts), Some(Codec::Zlib));
     let opts = SyncOptions {
         compress: true,
-        modern: true,
+        modern_compress: Some(ModernCompress::Auto),
         compress_level: Some(0),
         ..Default::default()
     };

--- a/crates/engine/tests/filter.rs
+++ b/crates/engine/tests/filter.rs
@@ -23,7 +23,7 @@ fn excluded_paths_are_skipped() {
         &src,
         &dst,
         &matcher,
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions::default(),
     )
     .unwrap();

--- a/crates/engine/tests/resume.rs
+++ b/crates/engine/tests/resume.rs
@@ -30,7 +30,14 @@ fn resume_from_partial_file() {
 
     let mut opts = SyncOptions::default();
     opts.partial = true;
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
 
     let out = fs::read(dst.join("file.bin")).unwrap();
     assert_eq!(out, src_data);
@@ -73,6 +80,13 @@ fn resume_large_file_minimal_network_io() {
     let mut opts = SyncOptions::default();
     opts.partial = true;
     opts.block_size = block_size;
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("big.bin")).unwrap(), data);
 }

--- a/crates/engine/tests/streaming.rs
+++ b/crates/engine/tests/streaming.rs
@@ -22,7 +22,7 @@ fn sync_large_file_streaming() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions::default(),
     )
     .unwrap();

--- a/crates/engine/tests/update.rs
+++ b/crates/engine/tests/update.rs
@@ -21,7 +21,14 @@ fn update_skips_newer_dest() {
     set_file_mtime(dst.join("file.txt"), dst_time).unwrap();
     let mut opts = SyncOptions::default();
     opts.update = true;
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"old");
 }
 
@@ -40,6 +47,13 @@ fn update_replaces_older_dest() {
     set_file_mtime(dst.join("file.txt"), dst_time).unwrap();
     let mut opts = SyncOptions::default();
     opts.update = true;
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"new");
 }

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 #[test]
 fn server_negotiates_version() {
-    let local = available_codecs(false);
+    let local = available_codecs(None);
     let payload = encode_codecs(&local);
     let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
     let mut codecs_buf = Vec::new();
@@ -37,7 +37,7 @@ fn server_negotiates_version() {
 #[test]
 fn server_falls_back_to_legacy_version() {
     let legacy = LATEST_VERSION - 1;
-    let payload = encode_codecs(&available_codecs(false));
+    let payload = encode_codecs(&available_codecs(None));
     let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
@@ -50,9 +50,9 @@ fn server_falls_back_to_legacy_version() {
     });
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
-    let peer_codecs = srv.handshake(&available_codecs(false)).unwrap();
+    let peer_codecs = srv.handshake(&available_codecs(None)).unwrap();
     assert_eq!(srv.version, legacy);
-    assert_eq!(peer_codecs, available_codecs(false));
+    assert_eq!(peer_codecs, available_codecs(None));
     let expected = {
         let mut v = legacy.to_be_bytes().to_vec();
         v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-use compress::{available_codecs, Codec};
+use compress::{available_codecs, Codec, ModernCompress};
 use protocol::{
     negotiate_version, Frame, FrameHeader, Message, Msg, Tag, CAP_CODECS, SUPPORTED_CAPS,
 };
@@ -168,7 +168,7 @@ impl SshStdioTransport {
     fn handshake<T: Transport>(
         transport: &mut T,
         env: &[(String, String)],
-        modern: bool,
+        modern: Option<ModernCompress>,
         version: u32,
     ) -> io::Result<Vec<Codec>> {
         for (k, v) in env {
@@ -348,7 +348,7 @@ impl SshStdioTransport {
         port: Option<u16>,
         connect_timeout: Option<Duration>,
         family: Option<AddressFamily>,
-        modern: bool,
+        modern: Option<ModernCompress>,
         version: u32,
     ) -> io::Result<(Self, Vec<Codec>)> {
         let mut t = Self::spawn_with_rsh(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,6 +155,9 @@ The table below mirrors the full `rsync(1)` flag set. Defaults show the behavior
 |  | `--min-size` | off |  | [matrix](feature_matrix.md#--min-size) |
 |  | `--mkpath` | off |  | [matrix](feature_matrix.md#--mkpath) |
 |  | `--modern` | off | oc-rsync only; negotiates zstd or lz4 compression based on CPU features and BLAKE3 checksums; requires `blake3` feature | [matrix](feature_matrix.md#--modern) |
+|  | `--modern-compress` | auto | oc-rsync only; select `auto`, `zstd`, or `lz4` compression | [matrix](feature_matrix.md#--modern-compress) |
+|  | `--modern-hash` | off | oc-rsync only; choose `blake3` strong hash | [matrix](feature_matrix.md#--modern-hash) |
+|  | `--modern-cdc` | off | oc-rsync only; enable `fastcdc` chunking | [matrix](feature_matrix.md#--modern-cdc) |
 | `-@` | `--modify-window` | off |  | [matrix](feature_matrix.md#--modify-window) |
 |  | `--munge-links` | off |  | [matrix](feature_matrix.md#--munge-links) |
 |  | `--no-D` | off | alias for `--no-devices --no-specials` | [matrix](feature_matrix.md#--no-d) |

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -24,6 +24,9 @@ classic `rsync` behavior. For a complete listing see
 | `--compress-choice` | ✅ choose zstd or zlib | [tests/golden/cli_parity/compress-choice.sh](../tests/golden/cli_parity/compress-choice.sh) | n/a |
 | `--compress-level` | ✅ maps numeric levels | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) | applies to zlib or zstd |
 | `-c`, `--checksum` | ✅ strong hashes: MD5 (default), SHA-1, BLAKE3 | [tests/cli.rs](../tests/cli.rs) | `--modern` selects BLAKE3 |
+| `--modern-compress` | oc-rsync only | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | choose `auto`, `zstd`, or `lz4` |
+| `--modern-hash` | oc-rsync only | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | select BLAKE3 hash |
+| `--modern-cdc` | oc-rsync only | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | enable `fastcdc` chunking |
 | `-a`, `--archive` | ✅ sets perms, times, owner, group, links, devices, specials | [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) | n/a |
 | `-R`, `--relative` | ✅ preserves ancestor directories | [tests/cli.rs](../tests/cli.rs) | n/a |
 | `-P` | ✅ keeps partial files and shows progress | [tests/cli.rs](../tests/cli.rs) | n/a |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -93,6 +93,9 @@ See [differences.md](differences.md) for a summary of notable behavioral differe
 | `--min-size` | — | ❌ | — | — |  | ≤3.2 |
 | `--mkpath` | — | ❌ | — | — |  | ≤3.2 |
 | `--modern` | — | ✅ | ✅ | [tests/interop/modern.rs](../tests/interop/modern.rs) | oc-rsync only; enables zstd compression and BLAKE3 checksums (requires `blake3` feature) | — |
+| `--modern-compress` | — | ✅ | ✅ | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | oc-rsync only; choose `auto`, `zstd`, or `lz4` compression | — |
+| `--modern-hash` | — | ✅ | ✅ | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | oc-rsync only; select BLAKE3 hash (requires `blake3` feature) | — |
+| `--modern-cdc` | — | ✅ | ✅ | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | oc-rsync only; enable `fastcdc` chunking | — |
 | `--modify-window` | `-@` | ❌ | — | — |  | ≤3.2 |
 | `--munge-links` | — | ❌ | — | — |  | ≤3.2 |
 | `--no-D` | — | ❌ | — | [gaps.md](gaps.md) | alias for `--no-devices --no-specials` | ≤3.2 |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
         src,
         dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &SyncOptions::default(),
     )?;
     Ok(())

--- a/tests/cdc.rs
+++ b/tests/cdc.rs
@@ -1,6 +1,6 @@
 // tests/cdc.rs
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{sync, ModernCdc, SyncOptions};
 use filters::Matcher;
 use std::fs;
 use tempfile::tempdir;
@@ -20,16 +20,29 @@ fn cdc_skips_renamed_file() {
     fs::write(&file_a, b"hello world").unwrap();
 
     let opts = SyncOptions {
-        cdc: true,
-        modern: false,
+        modern_cdc: ModernCdc::Fastcdc,
         ..Default::default()
     };
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
 
     let file_b = src.join("b.txt");
     fs::rename(&file_a, &file_b).unwrap();
 
-    let stats = sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    let stats = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
     assert_eq!(stats.bytes_transferred, 0);
     assert_eq!(fs::read(dst.join("b.txt")).unwrap(), b"hello world");
 }

--- a/tests/golden/cli_parity/modern_flags.sh
+++ b/tests/golden/cli_parity/modern_flags.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+OC_RSYNC="$ROOT/target/debug/oc-rsync"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src" "$TMP/rsync_dst" "$TMP/oc_rsync_dst"
+
+echo data > "$TMP/src/a.txt"
+
+rsync_output=$(rsync --quiet --recursive "$TMP/src/" "$TMP/rsync_dst" 2>&1)
+rsync_status=$?
+
+oc_rsync_raw=$("$OC_RSYNC" --local --recursive --modern-compress=zstd --modern-hash=blake3 --modern-cdc=fastcdc "$TMP/src/" "$TMP/oc_rsync_dst" 2>&1)
+oc_rsync_status=$?
+oc_rsync_output=$(echo "$oc_rsync_raw" | grep -v -e 'recursive mode enabled' || true)
+
+if [ "$rsync_status" -ne "$oc_rsync_status" ]; then
+  echo "Exit codes differ: rsync=$rsync_status oc-rsync=$oc_rsync_status" >&2
+  exit 1
+fi
+
+if [ "$rsync_output" != "$oc_rsync_output" ]; then
+  echo "Outputs differ" >&2
+  diff -u <(printf "%s" "$rsync_output") <(printf "%s" "$oc_rsync_output") >&2 || true
+  exit 1
+fi
+
+if ! diff -r "$TMP/rsync_dst" "$TMP/oc_rsync_dst" >/dev/null; then
+  echo "Directory trees differ" >&2
+  diff -r "$TMP/rsync_dst" "$TMP/oc_rsync_dst" >&2 || true
+  exit 1
+fi

--- a/tests/modern.rs
+++ b/tests/modern.rs
@@ -1,17 +1,18 @@
 // tests/modern.rs
 #![cfg(feature = "blake3")]
 use checksums::{strong_digest, StrongHash};
-use compress::{available_codecs, Codec};
-use engine::{select_codec, SyncOptions};
+use compress::{available_codecs, Codec, ModernCompress};
+use engine::{select_codec, ModernHash, SyncOptions};
 
 #[test]
 fn modern_negotiates_blake3_and_zstd() {
-    let codecs = available_codecs(true);
+    let codecs = available_codecs(Some(ModernCompress::Auto));
     let negotiated = select_codec(
         &codecs,
         &SyncOptions {
             compress: true,
-            modern: true,
+            modern_compress: Some(ModernCompress::Auto),
+            modern_hash: Some(ModernHash::Blake3),
             ..Default::default()
         },
     )
@@ -23,12 +24,12 @@ fn modern_negotiates_blake3_and_zstd() {
 
 #[test]
 fn modern_falls_back_without_compress() {
-    let codecs = available_codecs(true);
+    let codecs = available_codecs(Some(ModernCompress::Auto));
     let negotiated = select_codec(
         &codecs,
         &SyncOptions {
             compress: false,
-            modern: true,
+            modern_compress: Some(ModernCompress::Auto),
             ..Default::default()
         },
     );

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -133,12 +133,12 @@ fn custom_rsh_negotiates_codecs() {
         None,
         None,
         None,
-        false,
+        None,
         LATEST_VERSION,
     )
     .unwrap();
     drop(session);
-    assert_eq!(codecs, available_codecs(false));
+    assert_eq!(codecs, available_codecs(None));
 }
 
 #[cfg(unix)]

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -51,7 +51,7 @@ fn server_handshake_succeeds() {
     stdout.read_exact(&mut cap_buf).unwrap();
     assert_eq!(u32::from_be_bytes(cap_buf) & CAP_CODECS, CAP_CODECS);
 
-    let codecs = available_codecs(false);
+    let codecs = available_codecs(None);
     let payload = encode_codecs(&codecs);
     let frame = Message::Codecs(payload).to_frame(0);
     let mut buf = Vec::new();


### PR DESCRIPTION
## Summary
- expose --modern-compress, --modern-hash, and --modern-cdc flags
- plumb modern compression/hash/cdc through SyncOptions and codec negotiation
- document new modern flags and add golden tests

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37b8a0524832383274f0169d1c5c8