### PR TITLE
Advertise modern protocol version

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -19,7 +19,7 @@ use engine::human_bytes;
 use engine::{sync, DeleteMode, EngineError, Result, Stats, StrongHash, SyncOptions};
 use filters::{default_cvs_rules, parse, Matcher, Rule};
 use meta::{parse_chmod, parse_chown};
-use protocol::{negotiate_version, LATEST_VERSION};
+use protocol::{negotiate_version, LATEST_VERSION, LEGACY_VERSION};
 use shell_words::split as shell_split;
 use transport::{AddressFamily, RateLimitedTransport, SshStdioTransport, TcpTransport, Transport};
 
@@ -934,7 +934,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     opts.timeout,
                     opts.contimeout,
                     addr_family,
-                    opts.protocol.unwrap_or(LATEST_VERSION),
+                    opts.protocol.unwrap_or(if opts.modern {
+                        LATEST_VERSION
+                    } else {
+                        LEGACY_VERSION
+                    }),
                 )?;
                 sync(
                     &src.path,
@@ -966,7 +970,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     opts.contimeout,
                     addr_family,
                     opts.modern,
-                    opts.protocol.unwrap_or(LATEST_VERSION),
+                    opts.protocol.unwrap_or(if opts.modern {
+                        LATEST_VERSION
+                    } else {
+                        LEGACY_VERSION
+                    }),
                 )
                 .map_err(|e| EngineError::Other(e.to_string()))?;
                 let (err, _) = session.stderr();
@@ -992,7 +1000,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     opts.timeout,
                     opts.contimeout,
                     addr_family,
-                    opts.protocol.unwrap_or(LATEST_VERSION),
+                    opts.protocol.unwrap_or(if opts.modern {
+                        LATEST_VERSION
+                    } else {
+                        LEGACY_VERSION
+                    }),
                 )?;
                 sync(
                     &src.path,
@@ -1024,7 +1036,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     opts.contimeout,
                     addr_family,
                     opts.modern,
-                    opts.protocol.unwrap_or(LATEST_VERSION),
+                    opts.protocol.unwrap_or(if opts.modern {
+                        LATEST_VERSION
+                    } else {
+                        LEGACY_VERSION
+                    }),
                 )
                 .map_err(|e| EngineError::Other(e.to_string()))?;
                 let (err, _) = session.stderr();
@@ -1130,7 +1146,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             opts.timeout,
                             opts.contimeout,
                             addr_family,
-                            opts.protocol.unwrap_or(LATEST_VERSION),
+                            opts.protocol.unwrap_or(if opts.modern {
+                                LATEST_VERSION
+                            } else {
+                                LEGACY_VERSION
+                            }),
                         )?;
                         let mut src_session = spawn_daemon_session(
                             &src_host,
@@ -1141,7 +1161,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             opts.timeout,
                             opts.contimeout,
                             addr_family,
-                            opts.protocol.unwrap_or(LATEST_VERSION),
+                            opts.protocol.unwrap_or(if opts.modern {
+                                LATEST_VERSION
+                            } else {
+                                LEGACY_VERSION
+                            }),
                         )?;
                         if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
@@ -1177,7 +1201,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             opts.timeout,
                             opts.contimeout,
                             addr_family,
-                            opts.protocol.unwrap_or(LATEST_VERSION),
+                            opts.protocol.unwrap_or(if opts.modern {
+                                LATEST_VERSION
+                            } else {
+                                LEGACY_VERSION
+                            }),
                         )?;
                         if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
@@ -1212,7 +1240,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             opts.timeout,
                             opts.contimeout,
                             addr_family,
-                            opts.protocol.unwrap_or(LATEST_VERSION),
+                            opts.protocol.unwrap_or(if opts.modern {
+                                LATEST_VERSION
+                            } else {
+                                LEGACY_VERSION
+                            }),
                         )?;
                         let mut src_session = SshStdioTransport::spawn_with_rsh(
                             &src_host,

--- a/crates/engine/tests/resume.rs
+++ b/crates/engine/tests/resume.rs
@@ -30,7 +30,14 @@ fn resume_from_partial_file() {
 
     let mut opts = SyncOptions::default();
     opts.partial = true;
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(false),
+        &opts,
+    )
+    .unwrap();
 
     let out = fs::read(dst.join("file.bin")).unwrap();
     assert_eq!(out, src_data);
@@ -73,6 +80,13 @@ fn resume_large_file_minimal_network_io() {
     let mut opts = SyncOptions::default();
     opts.partial = true;
     opts.block_size = block_size;
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(false),
+        &opts,
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("big.bin")).unwrap(), data);
 }

--- a/crates/engine/tests/update.rs
+++ b/crates/engine/tests/update.rs
@@ -21,7 +21,14 @@ fn update_skips_newer_dest() {
     set_file_mtime(dst.join("file.txt"), dst_time).unwrap();
     let mut opts = SyncOptions::default();
     opts.update = true;
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(false),
+        &opts,
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"old");
 }
 
@@ -40,6 +47,13 @@ fn update_replaces_older_dest() {
     set_file_mtime(dst.join("file.txt"), dst_time).unwrap();
     let mut opts = SyncOptions::default();
     opts.update = true;
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(false),
+        &opts,
+    )
+    .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"new");
 }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -11,10 +11,14 @@ pub use demux::Demux;
 pub use mux::Mux;
 pub use server::Server;
 
-pub const LATEST_VERSION: u32 = 32;
+pub const LATEST_VERSION: u32 = 73;
+pub const LEGACY_VERSION: u32 = 32;
 pub const MIN_VERSION: u32 = 29;
+
 pub const CAP_CODECS: u32 = 1 << 0;
-pub const SUPPORTED_CAPS: u32 = CAP_CODECS;
+pub const CAP_BLAKE3: u32 = 1 << 1;
+pub const CAP_ZSTD: u32 = 1 << 2;
+pub const SUPPORTED_CAPS: u32 = CAP_CODECS | CAP_BLAKE3 | CAP_ZSTD;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VersionError(pub u32);
@@ -36,6 +40,10 @@ impl From<VersionError> for io::Error {
 pub fn negotiate_version(peer: u32) -> Result<u32, VersionError> {
     if peer >= LATEST_VERSION {
         Ok(LATEST_VERSION)
+    } else if peer >= LEGACY_VERSION {
+        Ok(LEGACY_VERSION)
+    } else if peer >= 31 {
+        Ok(31)
     } else if peer >= MIN_VERSION {
         Ok(peer)
     } else {
@@ -434,6 +442,8 @@ mod tests {
 
     #[test]
     fn version_negotiation() {
+        assert_eq!(negotiate_version(80), Ok(73));
+        assert_eq!(negotiate_version(73), Ok(73));
         assert_eq!(negotiate_version(40), Ok(32));
         assert_eq!(negotiate_version(32), Ok(32));
         assert_eq!(negotiate_version(31), Ok(31));

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -194,12 +194,13 @@ impl SshStdioTransport {
         let peer = u32::from_be_bytes(ver_buf);
         negotiate_version(peer).map_err(|e| io::Error::other(e.to_string()))?;
 
-        transport.send(&SUPPORTED_CAPS.to_be_bytes())?;
+        let local_caps = if modern { SUPPORTED_CAPS } else { CAP_CODECS };
+        transport.send(&local_caps.to_be_bytes())?;
 
         let mut cap_buf = [0u8; 4];
         transport.receive(&mut cap_buf)?;
         let server_caps = u32::from_be_bytes(cap_buf);
-        let caps = server_caps & SUPPORTED_CAPS;
+        let caps = server_caps & local_caps;
 
         let mut peer_codecs = vec![Codec::Zlib];
         if caps & CAP_CODECS != 0 {

--- a/tests/cdc.rs
+++ b/tests/cdc.rs
@@ -24,12 +24,26 @@ fn cdc_skips_renamed_file() {
         modern: false,
         ..Default::default()
     };
-    sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(false),
+        &opts,
+    )
+    .unwrap();
 
     let file_b = src.join("b.txt");
     fs::rename(&file_a, &file_b).unwrap();
 
-    let stats = sync(&src, &dst, &Matcher::default(), &available_codecs(false), &opts).unwrap();
+    let stats = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(false),
+        &opts,
+    )
+    .unwrap();
     assert_eq!(stats.bytes_transferred, 0);
     assert_eq!(fs::read(dst.join("b.txt")).unwrap(), b"hello world");
 }

--- a/tests/interop/modern.rs
+++ b/tests/interop/modern.rs
@@ -1,2 +1,10 @@
 // tests/interop/modern.rs
 include!("../modern.rs");
+
+use protocol::negotiate_version;
+
+#[test]
+fn falls_back_to_legacy_versions() {
+    assert_eq!(negotiate_version(32), Ok(32));
+    assert_eq!(negotiate_version(31), Ok(31));
+}


### PR DESCRIPTION
## Summary
- add capability flags and raise latest protocol version to 73
- only advertise modern features to peers opting into them
- verify modern sessions fall back to legacy versions with stock peers

## Testing
- `cargo test` *(failed: daemon tests hung; see log)*

------
https://chatgpt.com/codex/tasks/task_e_68b37b77cfec832390bced6b2516fa40