### PR TITLE
Add logging dependency to workspace root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "engine",
  "filetime",
  "filters",
+ "logging",
  "nix",
  "posix-acl",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap_complete = "4"
 rustc_lexer = "0.1"
+logging = { path = "crates/logging" }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- add logging crate dependency so oc-rsync binary can compile

## Testing
- `cargo test` *(fails: daemon tests run longer than 60s and were interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b37e8b8b808323b98cf133be39be3d