### PR TITLE
Fix handling of modern compression option in transport handshake

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1054,7 +1054,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     opts.port,
                     opts.contimeout,
                     addr_family,
-                    opts.modern,
+                    modern_compress,
                     opts.protocol.unwrap_or(if opts.modern {
                         LATEST_VERSION
                     } else {
@@ -1122,7 +1122,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     opts.port,
                     opts.contimeout,
                     addr_family,
-                    opts.modern,
+                    modern_compress,
                     opts.protocol.unwrap_or(if opts.modern {
                         LATEST_VERSION
                     } else {

--- a/crates/engine/tests/resume.rs
+++ b/crates/engine/tests/resume.rs
@@ -34,7 +34,7 @@ fn resume_from_partial_file() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &opts,
     )
     .unwrap();
@@ -84,7 +84,7 @@ fn resume_large_file_minimal_network_io() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &opts,
     )
     .unwrap();

--- a/crates/engine/tests/update.rs
+++ b/crates/engine/tests/update.rs
@@ -25,7 +25,7 @@ fn update_skips_newer_dest() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &opts,
     )
     .unwrap();
@@ -51,7 +51,7 @@ fn update_replaces_older_dest() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &opts,
     )
     .unwrap();

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -194,7 +194,16 @@ impl SshStdioTransport {
         let peer = u32::from_be_bytes(ver_buf);
         negotiate_version(peer).map_err(|e| io::Error::other(e.to_string()))?;
 
-        let local_caps = if modern { SUPPORTED_CAPS } else { CAP_CODECS };
+        // If a modern compression algorithm is requested, advertise support for all
+        // capabilities (including modern compression). Otherwise, only advertise
+        // support for the legacy codecs capability. The `modern` argument is an
+        // `Option`, so we check for the presence of a value rather than treating it
+        // as a boolean directly.
+        let local_caps = if modern.is_some() {
+            SUPPORTED_CAPS
+        } else {
+            CAP_CODECS
+        };
         transport.send(&local_caps.to_be_bytes())?;
 
         let mut cap_buf = [0u8; 4];

--- a/tests/cdc.rs
+++ b/tests/cdc.rs
@@ -27,7 +27,7 @@ fn cdc_skips_renamed_file() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &opts,
     )
     .unwrap();
@@ -39,7 +39,7 @@ fn cdc_skips_renamed_file() {
         &src,
         &dst,
         &Matcher::default(),
-        &available_codecs(false),
+        &available_codecs(None),
         &opts,
     )
     .unwrap();


### PR DESCRIPTION
## Summary
- fix feature negotiation to check for modern compression flag
- pass computed modern compression option through CLI
- update tests to use `available_codecs(None)`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b38211e5fc8323bb53a1190a4b290d