### PR TITLE
Add interop grid script and docs

### DIFF
--- a/docs/interop-grid.md
+++ b/docs/interop-grid.md
@@ -1,0 +1,11 @@
+# Interoperability Grid
+
+`scripts/interop-grid.sh` compares `oc-rsync` with the stock `rsync` binary across a grid of common options. Every combination of `--archive`, `--compress`, and `--delete` is executed against a small local tree.
+
+For each flag set the script runs both implementations, recording exit codes and any stderr output. Differences are noted in the report.
+
+```
+scripts/interop-grid.sh
+```
+
+Results are written to `tests/interop/interop-grid.log` for inspection alongside other interoperability fixtures.

--- a/scripts/interop-grid.sh
+++ b/scripts/interop-grid.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+OC_RSYNC="$ROOT/target/debug/oc-rsync"
+OUT_DIR="$ROOT/tests/interop"
+OUT_FILE="$OUT_DIR/interop-grid.log"
+
+# Build oc-rsync if needed
+if [ ! -x "$OC_RSYNC" ]; then
+  echo "Building oc-rsync" >&2
+  cargo build --quiet -p oc-rsync-bin --bin oc-rsync
+fi
+
+FLAGS=(--archive --compress --delete)
+N=${#FLAGS[@]}
+
+mkdir -p "$OUT_DIR"
+: > "$OUT_FILE"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SRC="$TMP/src"
+mkdir -p "$SRC"
+echo "data" > "$SRC/file.txt"
+
+echo "Writing results to $OUT_FILE" | tee -a "$OUT_FILE"
+
+for ((mask=0; mask< (1<<N); mask++)); do
+  args=()
+  for ((i=0; i<N; i++)); do
+    if ((mask & (1<<i))); then
+      args+=("${FLAGS[i]}")
+    fi
+  done
+  combo="${args[*]:-(none)}"
+  echo "## Flags: $combo" | tee -a "$OUT_FILE"
+
+  RSYNC_DST="$TMP/rsync_dst"
+  OC_DST="$TMP/oc_dst"
+  mkdir -p "$RSYNC_DST" "$OC_DST"
+
+  RSYNC_ERR="$TMP/rsync.err"
+  set +e
+  rsync "${args[@]}" "$SRC/" "$RSYNC_DST/" 1>/dev/null 2>"$RSYNC_ERR"
+  RSYNC_EXIT=$?
+
+  OC_ERR="$TMP/oc.err"
+  "$OC_RSYNC" --local "${args[@]}" "$SRC/" "$OC_DST/" 1>/dev/null 2>"$OC_ERR"
+  OC_EXIT=$?
+  set -e
+
+  echo "rsync exit: $RSYNC_EXIT" | tee -a "$OUT_FILE"
+  echo "oc-rsync exit: $OC_EXIT" | tee -a "$OUT_FILE"
+
+  RSYNC_LINES="$(grep -v '^$' "$RSYNC_ERR" || true)"
+  OC_LINES="$(grep -v '^$' "$OC_ERR" || true)"
+
+  echo "rsync stderr:" | tee -a "$OUT_FILE"
+  if [ -n "$RSYNC_LINES" ]; then
+    echo "$RSYNC_LINES" | tee -a "$OUT_FILE"
+  fi
+  echo "oc-rsync stderr:" | tee -a "$OUT_FILE"
+  if [ -n "$OC_LINES" ]; then
+    echo "$OC_LINES" | tee -a "$OUT_FILE"
+  fi
+
+  if [[ "$RSYNC_EXIT" -ne "$OC_EXIT" ]] || [[ "$RSYNC_LINES" != "$OC_LINES" ]]; then
+    echo "!! Difference detected" | tee -a "$OUT_FILE"
+  else
+    echo "== Match" | tee -a "$OUT_FILE"
+  fi
+  echo | tee -a "$OUT_FILE"
+
+  rm -rf "$RSYNC_DST" "$OC_DST" "$RSYNC_ERR" "$OC_ERR"
+done
+

--- a/tests/interop/README.md
+++ b/tests/interop/README.md
@@ -8,6 +8,8 @@ filesystem trees for interoperability tests.
   `<client>_<server>_<transport>`.
 - `run_matrix.sh` runs a matrix of rsync 3.2.x client/server combinations over
   both SSH and rsync:// transports. Set `UPDATE=1` to regenerate goldens.
+- `interop-grid.log` is produced by `scripts/interop-grid.sh` and captures exit
+  codes and stderr comparisons for key flag combinations.
 
 The CI workflow executes `run_matrix.sh` as a required status check to ensure
 interoperability across supported rsync versions.


### PR DESCRIPTION
## Summary
- add `scripts/interop-grid.sh` to compare oc-rsync and stock rsync across common flag combinations
- document interop grid workflow and output location
- note new comparison log in interop test README

## Testing
- `scripts/interop-grid.sh >/tmp/interop-grid.output`
- `cargo test` *(some daemon tests exceeded 60s warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b3855f4b8c8323a0c4c159f1b7720d