### PR TITLE
feat: add verify-comments and rename strip comments tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
         run: |
           bash scripts/generate-manpages.sh
           git diff --exit-code man
-      - name: Check comments
+      - name: Verify comments
         if: matrix.os == 'ubuntu-latest' && matrix.use-cross == false
-        run: bash scripts/check-comments.sh
+        run: make verify-comments
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ name = "gen-completions"
 path = "tools/gen_completions.rs"
 
 [[bin]]
-name = "strip-comments"
-path = "tools/strip-comments.rs"
+name = "strip-rs-comments"
+path = "tools/strip_rs_comments.rs"
 
 [features]
 default = []

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-golden
+.PHONY: test-golden verify-comments
 
 test-golden:
 	cargo build --quiet -p oc-rsync-bin --bin oc-rsync --features blake3
@@ -11,3 +11,6 @@ test-golden:
 	bash tests/filter_rule_precedence.sh; \
 	echo "Running tests/partial_transfer_resume.sh"; \
 	bash tests/partial_transfer_resume.sh
+
+verify-comments:
+	bash scripts/check-comments.sh

--- a/scripts/check-comments.sh
+++ b/scripts/check-comments.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-files=$(git ls-files '*.rs' | grep -v '^crates/' | grep -v '^tests/')
-cargo run --quiet --bin strip-comments -- --check $files
+files=$(git ls-files '*.rs')
+cargo run --quiet --bin strip-rs-comments -- --check $files
+

--- a/tools/strip_rs_comments.rs
+++ b/tools/strip_rs_comments.rs
@@ -1,4 +1,4 @@
-// tools/strip-comments.rs
+// tools/strip_rs_comments.rs
 use std::env;
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
## Summary
- rename comment-stripping tool to `strip-rs-comments`
- check all Rust files for stray comments
- add `make verify-comments` and run it in CI

## Testing
- `make verify-comments` *(fails: cargo: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b38d4f8cd88323b9321fbecd418bb6