### PR TITLE
refactor: strip comments from tests

### DIFF
--- a/scripts/check-comments.sh
+++ b/scripts/check-comments.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-files=$(git ls-files '*.rs' | grep -v '^crates/' | grep -v '^tests/')
+files=$(git ls-files '*.rs' | grep -v '^crates/')
 cargo run --quiet --bin strip-comments -- --check $files

--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -1,4 +1,5 @@
 // tests/block_size.rs
+
 use assert_cmd::Command;
 use checksums::ChecksumConfigBuilder;
 use engine::{compute_delta, Op};

--- a/tests/cdc.rs
+++ b/tests/cdc.rs
@@ -1,4 +1,5 @@
 // tests/cdc.rs
+
 use compress::available_codecs;
 use engine::{sync, ModernCdc, SyncOptions};
 use filters::Matcher;

--- a/tests/checksum_seed.rs
+++ b/tests/checksum_seed.rs
@@ -1,3 +1,4 @@
+// tests/checksum_seed.rs
 use checksums::ChecksumConfigBuilder;
 
 #[test]

--- a/tests/checksum_seed_cli.rs
+++ b/tests/checksum_seed_cli.rs
@@ -1,3 +1,4 @@
+// tests/checksum_seed_cli.rs
 use assert_cmd::Command;
 use std::fs;
 use tempfile::tempdir;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,5 @@
 // tests/cli.rs
+
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use filetime::{set_file_mtime, FileTime};

--- a/tests/cvs_exclude.rs
+++ b/tests/cvs_exclude.rs
@@ -1,4 +1,5 @@
 // tests/cvs_exclude.rs
+
 use assert_cmd::Command;
 use std::fs;
 use std::process::Command as StdCommand;
@@ -6,9 +7,9 @@ use tempfile::tempdir;
 
 #[test]
 fn cvs_exclude_parity() {
-    // Older rsync releases (e.g. 2.x shipped on macOS) have different
-    // `--cvs-exclude` semantics. The parity check only makes sense when a
-    // modern rsync (>=3) is available, so skip the test otherwise.
+    
+    
+    
     let rsync_version = StdCommand::new("rsync")
         .arg("--version")
         .output()

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -1,11 +1,5 @@
-/* tests/daemon.rs
+// tests/daemon.rs
 
-These daemon tests need basic TCP networking. The `require_network` helper
-checks whether the current environment allows binding and connecting to the
-loopback interface and skips the test if it does not. To run the tests, make
-sure networking is permitted (e.g., not running in a sandbox without socket
-access).
-*/
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use protocol::LATEST_VERSION;

--- a/tests/daemon_config.rs
+++ b/tests/daemon_config.rs
@@ -1,4 +1,5 @@
 // tests/daemon_config.rs
+
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use protocol::LATEST_VERSION;

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -1,4 +1,5 @@
 // tests/daemon_sync_attrs.rs
+
 #[cfg(all(unix, any(feature = "xattr", feature = "acl")))]
 use assert_cmd::{cargo::CommandCargoExt, Command};
 #[cfg(all(unix, any(feature = "xattr", feature = "acl")))]

--- a/tests/filter_corpus.rs
+++ b/tests/filter_corpus.rs
@@ -1,4 +1,5 @@
 // tests/filter_corpus.rs
+
 use assert_cmd::Command;
 use shell_words::split;
 use std::fs;

--- a/tests/interop/codec_negotiation.rs
+++ b/tests/interop/codec_negotiation.rs
@@ -1,4 +1,5 @@
 // tests/interop/codec_negotiation.rs
+
 use compress::{negotiate_codec, Codec};
 
 #[test]

--- a/tests/interop/daemon_tests.rs
+++ b/tests/interop/daemon_tests.rs
@@ -1,2 +1,3 @@
 // tests/interop/daemon_tests.rs
+
 include!("../daemon.rs");

--- a/tests/interop/filter_complex.rs
+++ b/tests/interop/filter_complex.rs
@@ -1,4 +1,5 @@
 // tests/interop/filter_complex.rs
+
 use assert_cmd::Command;
 use std::fs;
 use std::process::Command as StdCommand;

--- a/tests/interop/modern.rs
+++ b/tests/interop/modern.rs
@@ -1,4 +1,5 @@
 // tests/interop/modern.rs
+
 include!("../modern.rs");
 
 use protocol::negotiate_version;

--- a/tests/interop/remote_remote_tests.rs
+++ b/tests/interop/remote_remote_tests.rs
@@ -1,2 +1,3 @@
 // tests/interop/remote_remote_tests.rs
+
 include!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/remote_remote.rs"));

--- a/tests/link_copy_compare_dest.rs
+++ b/tests/link_copy_compare_dest.rs
@@ -1,4 +1,5 @@
 // tests/link_copy_compare_dest.rs
+
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;

--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -1,4 +1,5 @@
 // tests/local_sync_tree.rs
+
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;
@@ -221,7 +222,7 @@ fn sync_preserves_crtimes() {
     let src_meta = fs::metadata(&file).unwrap();
     let src_crtime = match FileTime::from_creation_time(&src_meta) {
         Some(t) => t,
-        None => return, // creation times unsupported
+        None => return, 
     };
 
     let src_arg = format!("{}/", src.display());
@@ -237,7 +238,7 @@ fn sync_preserves_crtimes() {
     match FileTime::from_creation_time(&dst_meta) {
         Some(t) => {
             if cfg!(target_os = "linux") && t != src_crtime {
-                // Linux exposes creation times but cannot modify them.
+                
                 return;
             }
             assert_eq!(src_crtime, t)

--- a/tests/modern.rs
+++ b/tests/modern.rs
@@ -1,4 +1,5 @@
 // tests/modern.rs
+
 #![cfg(feature = "blake3")]
 use checksums::{strong_digest, StrongHash};
 use compress::{available_codecs, Codec, ModernCompress};

--- a/tests/remote_remote.rs
+++ b/tests/remote_remote.rs
@@ -1,4 +1,5 @@
 // tests/remote_remote.rs
+
 use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
 use std::fs;

--- a/tests/remote_utils.rs
+++ b/tests/remote_utils.rs
@@ -1,4 +1,5 @@
 // tests/remote_utils.rs
+
 #![cfg(unix)]
 use transport::ssh::SshStdioTransport;
 

--- a/tests/resume.rs
+++ b/tests/resume.rs
@@ -1,4 +1,5 @@
 // tests/resume.rs
+
 use assert_cmd::prelude::*;
 use std::process::Command;
 use std::thread;

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -1,4 +1,5 @@
 // tests/rsh.rs
+
 #[cfg(unix)]
 use assert_cmd::cargo::cargo_bin;
 #[cfg(unix)]

--- a/tests/rsync_path.rs
+++ b/tests/rsync_path.rs
@@ -1,4 +1,5 @@
 // tests/rsync_path.rs
+
 use assert_cmd::Command;
 use std::fs;
 #[cfg(unix)]

--- a/tests/rsync_zlib.rs
+++ b/tests/rsync_zlib.rs
@@ -1,4 +1,5 @@
 // tests/rsync_zlib.rs
+
 use compress::Codec;
 use protocol::{negotiate_version, CAP_CODECS, LATEST_VERSION};
 use transport::{ssh::SshStdioTransport, Transport};

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,4 +1,5 @@
 // tests/server.rs
+
 use assert_cmd::cargo::cargo_bin;
 use compress::{available_codecs, decode_codecs, encode_codecs};
 use protocol::{Frame, FrameHeader, Message, Msg, Tag, CAP_CODECS, LATEST_VERSION, MIN_VERSION};

--- a/tests/skip_compress.rs
+++ b/tests/skip_compress.rs
@@ -1,4 +1,5 @@
 // tests/skip_compress.rs
+
 use assert_cmd::Command;
 use std::fs;
 use tempfile::tempdir;

--- a/tests/symlink_resolution.rs
+++ b/tests/symlink_resolution.rs
@@ -1,4 +1,5 @@
 // tests/symlink_resolution.rs
+
 use assert_cmd::Command;
 use std::fs;
 use std::path::Path;

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -1,4 +1,5 @@
 // tests/timeout.rs
+
 use std::io;
 use std::net::TcpListener;
 use std::thread;

--- a/tests/transport.rs
+++ b/tests/transport.rs
@@ -1,4 +1,5 @@
 // tests/transport.rs
+
 use std::io::Write;
 use std::net::TcpListener;
 use std::thread;


### PR DESCRIPTION
## Summary
- ensure test files contain only a leading path comment
- extend comment check script to include tests

## Testing
- `cargo run --quiet --bin strip-comments -- --check $(find tests -name '*.rs')`
- `scripts/check-comments.sh`
- `cargo test` *(fails: test `client_respects_no_motd` and others running >60s, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b38d48ef448323b955841a8bab8f0b