### PR TITLE
Add Makefile targets mirroring CI checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,15 @@ Thank you for your interest in contributing to oc_rsync!
 - Use the workspace `Cargo.lock` at the repository root; do not commit lockfiles in individual crates.
 - For wrapper Rust source files outside of `crates/` and `tests/`, begin the file with a comment containing its relative path, e.g. `// src/lib.rs`, and avoid any other comments. Run `scripts/check-comments.sh` to ensure compliance.
 
+## Makefile targets
+
+The Makefile offers shortcuts for common CI checks:
+
+- `make verify-comments` – run `scripts/check-comments.sh` to enforce comment headers.
+- `make lint` – run `cargo fmt --all --check` for formatting.
+- `make coverage` – execute `cargo tarpaulin --all --features blake3` to gather test coverage.
+- `make interop` – run the interoperability matrix with `tests/interop/run_matrix.sh`.
+
 ## Pull Request Process
 1. Fork the repository and create a topic branch.
 2. Ensure your branch is up to date with the `main` branch.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
-.PHONY: test-golden
+.PHONY: verify-comments lint coverage interop test-golden
+
+verify-comments:
+	bash scripts/check-comments.sh
+
+lint:
+	cargo fmt --all --check
+
+coverage:
+	cargo tarpaulin --all --features blake3
+
+interop:
+	bash tests/interop/run_matrix.sh
 
 test-golden:
 	cargo build --quiet -p oc-rsync-bin --bin oc-rsync --features blake3


### PR DESCRIPTION
## Summary
- add `verify-comments`, `lint`, `coverage`, and `interop` Makefile targets
- document local CI targets in `CONTRIBUTING.md`

## Testing
- `make verify-comments`
- `make lint` *(fails: formatting differences)*
- `make coverage` *(timeout)*
- `make interop` *(failed: curl error 56)*

------
https://chatgpt.com/codex/tasks/task_e_68b38d623e748323b2915a2e2e35dd69