### PR TITLE
refactor: update protocol negotiation and capabilities

### DIFF
--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -38,11 +38,11 @@ fn keepalive_roundtrip() {
 
 #[test]
 fn version_negotiation() {
-    assert_eq!(negotiate_version(40), Ok(32));
-    assert_eq!(negotiate_version(32), Ok(32));
-    assert_eq!(negotiate_version(31), Ok(31));
-    assert_eq!(negotiate_version(30), Ok(30));
-    assert!(negotiate_version(28).is_err());
+    assert_eq!(negotiate_version(73, 73), Ok(73));
+    assert_eq!(negotiate_version(73, 40), Ok(31));
+    assert_eq!(negotiate_version(31, 40), Ok(31));
+    assert_eq!(negotiate_version(29, 40), Ok(29));
+    assert!(negotiate_version(29, 28).is_err());
 }
 
 #[test]

--- a/tests/interop/modern.rs
+++ b/tests/interop/modern.rs
@@ -5,6 +5,6 @@ use protocol::negotiate_version;
 
 #[test]
 fn falls_back_to_legacy_versions() {
-    assert_eq!(negotiate_version(32), Ok(32));
-    assert_eq!(negotiate_version(31), Ok(31));
+    assert_eq!(negotiate_version(73, 32), Ok(31));
+    assert_eq!(negotiate_version(73, 31), Ok(31));
 }

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -120,7 +120,7 @@ fn custom_rsh_negotiates_codecs() {
         .filter(|(k, _)| k.starts_with("RSYNC_"))
         .collect();
     let remote_env: Vec<(String, String)> = Vec::new();
-    let (session, codecs) = SshStdioTransport::connect_with_rsh(
+    let (session, codecs, _caps) = SshStdioTransport::connect_with_rsh(
         "ignored",
         Path::new("."),
         &rsh_cmd,

--- a/tests/rsync_zlib.rs
+++ b/tests/rsync_zlib.rs
@@ -10,7 +10,7 @@ fn rsync_client_falls_back_to_zlib() {
     t.send(&LATEST_VERSION.to_be_bytes()).unwrap();
     let mut buf = [0u8; 4];
     t.receive(&mut buf).unwrap();
-    negotiate_version(u32::from_be_bytes(buf)).unwrap();
+    negotiate_version(LATEST_VERSION, u32::from_be_bytes(buf)).unwrap();
 
     t.send(&CAP_CODECS.to_be_bytes()).unwrap();
     t.receive(&mut buf).unwrap();

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -44,7 +44,7 @@ fn server_handshake_succeeds() {
 
     let mut ver_buf = [0u8; 4];
     stdout.read_exact(&mut ver_buf).unwrap();
-    assert_eq!(u32::from_be_bytes(ver_buf), LATEST_VERSION);
+    assert_eq!(u32::from_be_bytes(ver_buf), 31);
 
     stdin.write_all(&CAP_CODECS.to_be_bytes()).unwrap();
     let mut cap_buf = [0u8; 4];


### PR DESCRIPTION
## Summary
- remove legacy protocol version and negotiate v73 only when both peers advertise it
- propagate new BLAKE3, zstd and lz4 capability flags through the handshake
- extend protocol unit tests for new negotiation paths and capability exchange

## Testing
- `cargo test` *(fails: hung integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b38d8602948323840338e7b7eafc69