### PR TITLE
Improve daemon authentication token handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,7 @@ name = "daemon"
 version = "0.1.0"
 dependencies = [
  "nix",
+ "tempfile",
  "transport",
 ]
 

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -6,3 +6,6 @@ edition = "2021"
 [dependencies]
 transport = { path = "../transport" }
 nix = { version = "0.27", features = ["user", "fs"] }
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
## Summary
- Read authentication tokens in a loop until newline or EOF
- Reject tokens exceeding 256 bytes or lacking a newline terminator
- Test multi-read tokens and oversized token errors

## Testing
- `cargo test -p daemon`

------
https://chatgpt.com/codex/tasks/task_e_68b39285509483239899b44048d80263