### PR TITLE
Handle missing SSH transport inner

### DIFF
--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -386,17 +386,27 @@ impl SshStdioTransport {
         }
     }
 
-    pub fn into_inner(mut self) -> (BufReader<ChildStdout>, ChildStdin) {
+    pub fn into_inner(mut self) -> io::Result<(BufReader<ChildStdout>, ChildStdin)> {
         if let Some(handle) = self.handle.take() {
             std::mem::forget(handle);
         }
-        self.inner.take().expect("inner").into_inner()
+        let inner = self
+            .inner
+            .take()
+            .ok_or_else(|| io::Error::other("missing inner transport"))?;
+        Ok(inner.into_inner())
     }
+}
+
+type InnerPipe = LocalPipeTransport<BufReader<ChildStdout>, ChildStdin>;
+
+fn inner_pipe<'a>(inner: Option<&'a mut InnerPipe>) -> io::Result<&'a mut InnerPipe> {
+    inner.ok_or_else(|| io::Error::other("missing inner transport"))
 }
 
 impl Transport for SshStdioTransport {
     fn send(&mut self, data: &[u8]) -> io::Result<()> {
-        match self.inner.as_mut().expect("inner").send(data) {
+        match inner_pipe(self.inner.as_mut())?.send(data) {
             Ok(()) => Ok(()),
             Err(err) => {
                 let (stderr, _) = self.stderr();
@@ -412,7 +422,7 @@ impl Transport for SshStdioTransport {
     }
 
     fn receive(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match self.inner.as_mut().expect("inner").receive(buf) {
+        match inner_pipe(self.inner.as_mut())?.receive(buf) {
             Ok(n) => Ok(n),
             Err(err) => {
                 let (stderr, _) = self.stderr();
@@ -436,5 +446,36 @@ impl Drop for SshStdioTransport {
         if let Some(handle) = self.handle.take() {
             drop(handle);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty() -> SshStdioTransport {
+        SshStdioTransport {
+            inner: None,
+            stderr: Arc::new(Mutex::new(CapturedStderr::default())),
+            handle: None,
+        }
+    }
+
+    #[test]
+    fn send_fails_without_inner() {
+        let mut t = empty();
+        assert!(t.send(b"data").is_err());
+    }
+
+    #[test]
+    fn receive_fails_without_inner() {
+        let mut t = empty();
+        assert!(t.receive(&mut [0u8; 1]).is_err());
+    }
+
+    #[test]
+    fn into_inner_fails_without_inner() {
+        let t = empty();
+        assert!(t.into_inner().is_err());
     }
 }

--- a/crates/transport/tests/ssh_backpressure.rs
+++ b/crates/transport/tests/ssh_backpressure.rs
@@ -8,7 +8,7 @@ use transport::ssh::SshStdioTransport;
 #[test]
 fn backpressure_blocks_until_read() {
     let transport = SshStdioTransport::spawn("sh", ["-c", "cat"]).expect("spawn");
-    let (mut reader, mut writer) = transport.into_inner();
+    let (mut reader, mut writer) = transport.into_inner().expect("into_inner");
 
     let data = vec![0x55u8; 200_000];
     let handle = thread::spawn({

--- a/tests/remote_remote.rs
+++ b/tests/remote_remote.rs
@@ -170,8 +170,8 @@ fn remote_to_remote_pipes_data() {
         SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
     let dst_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);
@@ -212,8 +212,8 @@ fn remote_to_remote_large_transfer() {
         SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
     let dst_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);
@@ -238,8 +238,8 @@ fn remote_to_remote_reports_errors() {
         SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
     let dst_session = SshStdioTransport::spawn("sh", ["-c", "exec 0<&-; echo ready"]).unwrap();
 
-    let (mut src_reader, _) = src_session.into_inner();
-    let (mut dst_reader, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (mut dst_reader, mut dst_writer) = dst_session.into_inner().expect("into_inner");
 
     let mut ready = [0u8; 6];
     dst_reader.read_exact(&mut ready).unwrap();
@@ -260,8 +260,8 @@ fn remote_to_remote_empty_file() {
         SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
     let dst_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);
@@ -283,8 +283,8 @@ fn remote_to_remote_different_block_sizes() {
         SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
     let dst_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
 
     let mut read_buf = vec![0u8; 1024];
     let mut write_buf = Vec::with_capacity(4096);
@@ -332,8 +332,8 @@ fn remote_to_remote_partial_and_resume() {
     .unwrap();
     let dst_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);
@@ -356,8 +356,8 @@ fn remote_to_remote_partial_and_resume() {
     .unwrap();
     let dst_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat >> {}", dst_file.display())]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);
@@ -391,8 +391,8 @@ fn remote_partial_transfer_resumed_by_cli() {
     .unwrap();
     let dst_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", partial.display())]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);
@@ -417,8 +417,8 @@ fn remote_to_remote_failure_and_reconnect() {
     let src_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
     let dst_session = SshStdioTransport::spawn("sh", ["-c", "exec 0<&-; echo ready"]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (mut dst_reader, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (mut dst_reader, mut dst_writer) = dst_session.into_inner().expect("into_inner");
 
     let mut ready = [0u8; 6];
     dst_reader.read_exact(&mut ready).unwrap();
@@ -434,8 +434,8 @@ fn remote_to_remote_failure_and_reconnect() {
         SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src_file.display())]).unwrap();
     let dst_session =
         SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst_file.display())]).unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -34,8 +34,8 @@ fn rsh_remote_pair_syncs() {
 
     let src_session = spawn_reader(&format!("cat {}", src.display()));
     let dst_session = spawn_writer(&format!("cat > {}", dst.display()));
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);
@@ -74,8 +74,8 @@ fn custom_rsh_matches_stock_rsync() {
         ],
     )
     .unwrap();
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     std::io::copy(&mut src_reader, &mut dst_writer).unwrap();
     drop(dst_writer);
     drop(src_reader);

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -23,8 +23,8 @@ fn server_remote_pair_reports_error() {
 
     let src_session = spawn_reader(&format!("cat {}", src.display()));
     let dst_session = spawn_writer("exec 0<&-; sleep 1");
-    let (mut src_reader, _) = src_session.into_inner();
-    let (_, mut dst_writer) = dst_session.into_inner();
+    let (mut src_reader, _) = src_session.into_inner().expect("into_inner");
+    let (_, mut dst_writer) = dst_session.into_inner().expect("into_inner");
     let res = std::io::copy(&mut src_reader, &mut dst_writer);
     assert!(res.is_err());
 }


### PR DESCRIPTION
## Summary
- return `io::Error` instead of panicking when `SshStdioTransport` inner transport is missing
- add helper to convert optional inner transport to `io::Result`
- add tests for error cases when inner transport is absent

## Testing
- `cargo test -p transport`


------
https://chatgpt.com/codex/tasks/task_e_68b3927a4df88323a906f8b6c076dfa5