### PR TITLE
Document coverage exclusions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --locked
       - name: Generate coverage report
+        # See docs/coverage_exclusions.md for intentional exclusions
         run: cargo llvm-cov --all-features --workspace --doctests --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path lcov.info
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/docs/coverage_exclusions.md
+++ b/docs/coverage_exclusions.md
@@ -1,0 +1,16 @@
+# Coverage Exclusions
+
+This document lists code that is intentionally excluded from the project's
+coverage requirements. The coverage workflow enforces a 95% threshold for both
+line and function coverage.
+
+The following areas are excluded when interpreting coverage reports:
+
+- `fuzz/` – fuzzing harnesses run with `cargo fuzz` live outside the workspace
+  and are not included in coverage metrics.
+- Shell-based integration and golden tests in `tests/` invoke external
+  binaries and are not tracked by code coverage tools.
+- Generated build scripts (`build.rs`) in workspace crates.
+
+If additional code must be ignored by coverage, document it here to maintain
+transparency around the enforced thresholds.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -33,3 +33,6 @@ cargo llvm-cov --all-features --workspace --doctests \
 
 The command above enforces a 95% threshold for both line and function coverage,
 matching the CI gate.
+
+See [coverage_exclusions.md](coverage_exclusions.md) for modules or lines that
+are intentionally omitted from these coverage targets.


### PR DESCRIPTION
## Summary
- Add `docs/coverage_exclusions.md` detailing modules omitted from coverage calculations.
- Reference the exclusions file in coverage workflow and performance documentation.

## Testing
- `cargo test --workspace --all-features` *(fails: crates/daemon/src/lib.rs contains an unclosed delimiter)*

------
https://chatgpt.com/codex/tasks/task_e_68b3951c42c08323bf80ad06d07cdcdb