### PR TITLE
Rename CLI crate to oc-rsync-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,23 +287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
-name = "cli"
-version = "0.1.0"
-dependencies = [
- "clap",
- "compress",
- "daemon",
- "engine",
- "filters",
- "meta",
- "nix",
- "protocol",
- "shell-words",
- "tempfile",
- "transport",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,13 +867,13 @@ dependencies = [
  "assert_cmd",
  "checksums",
  "clap_complete",
- "cli",
  "compress",
  "engine",
  "filetime",
  "filters",
  "logging",
  "nix",
+ "oc-rsync-cli",
  "posix-acl",
  "predicates",
  "protocol",
@@ -909,9 +892,26 @@ dependencies = [
 name = "oc-rsync-bin"
 version = "0.1.0"
 dependencies = [
- "cli",
  "engine",
  "logging",
+ "oc-rsync-cli",
+]
+
+[[package]]
+name = "oc-rsync-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "compress",
+ "daemon",
+ "engine",
+ "filters",
+ "meta",
+ "nix",
+ "protocol",
+ "shell-words",
+ "tempfile",
+ "transport",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2021"
 [dependencies]
 protocol = { path = "crates/protocol" }
 checksums = { path = "crates/checksums" }
-cli = { path = "crates/cli" }
+oc-rsync-cli = { path = "crates/cli" }
 engine = { path = "crates/engine" }
 filters = { path = "crates/filters" }
 compress = { path = "crates/compress" }
@@ -61,6 +61,6 @@ path = "tools/strip_rs_comments.rs"
 [features]
 default = []
 lz4 = ["engine/lz4"]
-xattr = ["engine/xattr", "cli/xattr"]
-acl = ["engine/acl", "cli/acl"]
-blake3 = ["checksums/blake3", "engine/blake3", "cli/blake3"]
+xattr = ["engine/xattr", "oc-rsync-cli/xattr"]
+acl = ["engine/acl", "oc-rsync-cli/acl"]
+blake3 = ["checksums/blake3", "engine/blake3", "oc-rsync-cli/blake3"]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The project is organized as a set of focused crates:
 - `compress` – offers traits and implementations for optional compression of file data during transfer.
 - `engine` – orchestrates scanning, delta calculation, and application of differences between sender and receiver.
 - `transport` – abstracts local and remote I/O, multiplexing channels over SSH, TCP, or other transports.
-- `cli` – exposes a user-facing command line built on top of the engine and transport layers.
+- `oc-rsync-cli` – exposes a user-facing command line built on top of the engine and transport layers.
 - `fuzz` – houses fuzz targets that stress protocol and parser logic for robustness.
 
 ## Building

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -8,11 +8,11 @@ name = "oc-rsync"
 path = "src/main.rs"
 
 [dependencies]
-cli = { path = "../../crates/cli" }
+oc-rsync-cli = { path = "../../crates/cli" }
 engine = { path = "../../crates/engine" }
 logging = { path = "../../crates/logging" }
 
 [features]
 default = []
-xattr = ["engine/xattr", "cli/xattr"]
-acl = ["engine/acl", "cli/acl"]
+xattr = ["engine/xattr", "oc-rsync-cli/xattr"]
+acl = ["engine/acl", "oc-rsync-cli/acl"]

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -22,5 +22,5 @@ fn main() -> Result<()> {
         }
     }
     logging::init(LogFormat::Text, verbose, info, debug);
-    cli::run()
+    oc_rsync_cli::run()
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cli"
+name = "oc-rsync-cli"
 version = "0.1.0"
 edition = "2021"
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ crate boundaries, data flow, and the key algorithms that power `oc-rsync`.
   which files participate in a transfer.
 - [`meta`](../crates/meta) – models file metadata (permissions, timestamps,
   ownership) and provides helper utilities.
-- [`cli`](../crates/cli) – exposes a user-facing command line built on top of
+- [`oc-rsync-cli`](../crates/cli) – exposes a user-facing command line built on top of
   the engine and transport layers.
 - [`fuzz`](../fuzz) – houses fuzz targets that stress protocol and parser
   logic for robustness.

--- a/docs/project_overview.md
+++ b/docs/project_overview.md
@@ -12,7 +12,7 @@ The upstream rsync(1) and rsyncd.conf(5) man pages from rsync 3.4.x are included
 - **compress**: compression codecs and negotiation helpers.
 - **engine**: delta-transfer and synchronization engine.
 - **transport**: blocking transport implementations including SSH and TCP.
-- **cli**: command-line interface driving client, daemon, and probe modes.
+- **oc-rsync-cli**: command-line interface driving client, daemon, and probe modes.
 - **oc-rsync (root library)**: convenience wrapper around the engine's synchronization.
 - **fuzz**: fuzz targets validating protocol and filter robustness.
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ libfuzzer-sys = "0.4"
 protocol = { path = "../crates/protocol" }
 filters = { path = "../crates/filters" }
 walk = { path = "../crates/walk" }
-cli = { path = "../crates/cli" }
+oc-rsync-cli = { path = "../crates/cli" }
 tempfile = "3"
 
 [[bin]]

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -5,7 +5,7 @@ use assert_cmd::cargo::cargo_bin;
 #[cfg(unix)]
 use assert_cmd::Command as AssertCommand;
 #[cfg(unix)]
-use cli::parse_rsh;
+use oc_rsync_cli::parse_rsh;
 #[cfg(unix)]
 use compress::available_codecs;
 use protocol::LATEST_VERSION;

--- a/tools/gen_completions.rs
+++ b/tools/gen_completions.rs
@@ -10,7 +10,7 @@ use clap_complete::{
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = env::args().nth(1).unwrap_or_else(|| "man".into());
     fs::create_dir_all(&out_dir)?;
-    let mut cmd = cli::cli_command();
+    let mut cmd = oc_rsync_cli::cli_command();
     generate_to(Bash, &mut cmd, "oc-rsync", &out_dir)?;
     generate_to(Zsh, &mut cmd, "oc-rsync", &out_dir)?;
     generate_to(Fish, &mut cmd, "oc-rsync", &out_dir)?;


### PR DESCRIPTION
## Summary
- Rename `cli` crate to `oc-rsync-cli`
- Update workspace dependencies, features, and imports for new crate name
- Refresh documentation references to `oc-rsync-cli`

## Testing
- `cargo test` *(fails: unclosed delimiter in crates/daemon/src/lib.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b3975fb2a88323bd61cdb75b1bef57