### PR TITLE
Use cargo-llvm-cov for coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,8 @@ jobs:
         run: cargo install cargo-llvm-cov --locked
       - name: Generate coverage report
         # See docs/coverage_exclusions.md for intentional exclusions
-        run: cargo llvm-cov --all-features --workspace --doctests --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path lcov.info
+        run: cargo llvm-cov --workspace --features blake3 --doctests \
+          --fail-under-lines 95 --fail-under-functions 95 --lcov --output-path lcov.info
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ The Makefile offers shortcuts for common CI checks:
 
 - `make verify-comments` – run `scripts/check-comments.sh` to enforce comment headers.
 - `make lint` – run `cargo fmt --all --check` for formatting.
-- `make coverage` – execute `cargo tarpaulin --all --features blake3` to gather test coverage.
+- `make coverage` – execute `cargo llvm-cov --workspace --features blake3 --doctests \
+  --fail-under-lines 95 --fail-under-functions 95` to gather test coverage.
 - `make interop` – run the interoperability matrix with `tests/interop/run_matrix.sh`.
 
 ## Pull Request Process

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ lint:
 	cargo fmt --all --check
 
 coverage:
-	cargo tarpaulin --all --features blake3
+       cargo llvm-cov --workspace --features blake3 --doctests \
+               --fail-under-lines 95 --fail-under-functions 95
 
 interop:
 	bash tests/interop/run_matrix.sh

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -27,7 +27,7 @@ unit tests, integration tests, and documentation examples into a unified coverag
 Run locally with:
 
 ```
-cargo llvm-cov --all-features --workspace --doctests \
+cargo llvm-cov --workspace --features blake3 --doctests \
   --fail-under-lines 95 --fail-under-functions 95
 ```
 


### PR DESCRIPTION
## Summary
- switch `make coverage` to cargo-llvm-cov with blake3 feature and 95% gate
- document cargo-llvm-cov usage and threshold
- run cargo-llvm-cov in coverage workflow

## Testing
- `cargo fmt --all --check` *(fails: unclosed delimiter in crates/daemon/src/lib.rs)*
- `cargo test --all --features blake3` *(fails: unclosed delimiter in crates/daemon/src/lib.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b39785bab483238f621b334e4bb6ee