### PR TITLE
Add oc_rsync_cli import in remote_option test

### DIFF
--- a/tests/remote_option.rs
+++ b/tests/remote_option.rs
@@ -5,6 +5,8 @@ use assert_cmd::prelude::*;
 #[cfg(unix)]
 use assert_cmd::Command;
 #[cfg(unix)]
+use oc_rsync_cli as cli;
+#[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Summary
- import `oc_rsync_cli` crate in `remote_option` integration test so `spawn_daemon_session` is in scope

## Testing
- `cargo test --test remote_option`


------
https://chatgpt.com/codex/tasks/task_e_68b39e054f908323b657d52e6f6105ad