### PR TITLE
Gate Zstd auto selection on SIMD features

### DIFF
--- a/docs/modern.md
+++ b/docs/modern.md
@@ -13,8 +13,11 @@ remaining fast.
 ## Enhanced compression
 
 Modern mode prefers zstd compression and also supports lz4 through the
-`--modern-compress` option.  When both peers support the algorithm the most
-efficient codec is selected automatically.
+`--modern-compress` option. `--modern-compress=auto` inspects the CPU at
+runtime: zstd is chosen only when AVX2 or AVX-512 are available on x86, or when
+NEON or SVE are present on aarch64. Without those SIMD features the code falls
+back to lz4 if enabled, otherwise compression is disabled. When both peers
+support the algorithm the most efficient codec is selected automatically.
 
 ## Content-defined chunking
 


### PR DESCRIPTION
## Summary
- detect AVX2/AVX-512 or NEON/SVE at runtime and only advertise Zstd when available
- fall back to Lz4 or no compression when SIMD is missing
- document auto compression negotiation in modern mode
- test codec negotiation with and without SIMD support

## Testing
- `cargo test -p compress`

------
https://chatgpt.com/codex/tasks/task_e_68b39ecfeac48323869c2b04240ad24a