### PR TITLE
docs: update manifest path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,8 @@ Performance benchmarks and CPU feature detection details are documented in
 ## Manifest
 
 Content-defined chunking persists a manifest of seen chunks to
-`~/.oc-rsync/manifest`. If a legacy manifest exists at
-`~/.rsync-rs/manifest`, `oc-rsync` will automatically migrate it to the new
-location.
+`~/.oc-rsync/manifest`. If a manifest exists at the legacy location,
+`oc-rsync` will automatically migrate it to this path.
 
 ## License
 This project is dual-licensed under the terms of the [MIT](LICENSE-MIT) and [Apache-2.0](LICENSE-APACHE) licenses.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,8 +16,8 @@ crate boundaries, data flow, and the key algorithms that power `oc-rsync`.
   block matching.
 - [`engine`](../crates/engine) – orchestrates scanning, delta calculation, and
   application of differences between sender and receiver. It also maintains a
-  content-defined chunking manifest at `~/.oc-rsync/manifest`, migrating any
-  legacy `~/.rsync-rs/manifest` if present.
+  content-defined chunking manifest at `~/.oc-rsync/manifest`, automatically
+  migrating manifests from the legacy location if present.
 - [`compress`](../crates/compress) – offers optional compression of file data
   during transfer.
 - [`filters`](../crates/filters) – parses include/exclude rules controlling

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -10,3 +10,9 @@ See [gaps.md](gaps.md) and [feature_matrix.md](feature_matrix.md) for any remain
 - BLAKE3 strong checksums negotiated via `--modern` or `--modern-hash`.
 - zstd and lz4 compression via `--modern` or `--modern-compress`.
 - Optional FastCDC chunking with `--modern-cdc`.
+
+## Manifest location
+
+The content-defined chunking manifest now resides at `~/.oc-rsync/manifest`.
+Previous versions stored it at `~/.rsync-rs/manifest`; `oc-rsync` automatically
+migrates existing manifests.


### PR DESCRIPTION
## Summary
- update manifest references to `~/.oc-rsync/manifest`
- document migration from previous manifest location

## Testing
- `cargo test` *(terminated early: saw test passes but command did not complete in time)*

------
https://chatgpt.com/codex/tasks/task_e_68b39ee29c788323a2d27b5540f95e29