### PR TITLE
Implement token bucket rate limiting for transport

### DIFF
--- a/crates/transport/src/rate.rs
+++ b/crates/transport/src/rate.rs
@@ -7,8 +7,8 @@ use crate::Transport;
 pub struct RateLimitedTransport<T> {
     inner: T,
     bwlimit: u64,
-    start: Instant,
-    sent: u64,
+    debt: i64,
+    prior: Option<Instant>,
 }
 
 impl<T> RateLimitedTransport<T> {
@@ -16,8 +16,8 @@ impl<T> RateLimitedTransport<T> {
         Self {
             inner,
             bwlimit,
-            start: Instant::now(),
-            sent: 0,
+            debt: 0,
+            prior: None,
         }
     }
 
@@ -28,13 +28,34 @@ impl<T> RateLimitedTransport<T> {
 
 impl<T: Transport> Transport for RateLimitedTransport<T> {
     fn send(&mut self, data: &[u8]) -> io::Result<()> {
+        const ONE_SEC_MICROS: i64 = 1_000_000;
+        const MIN_SLEEP: i64 = ONE_SEC_MICROS / 10; // 100ms
+
         self.inner.send(data)?;
-        self.sent += data.len() as u64;
-        let elapsed = self.start.elapsed();
-        let expected = Duration::from_secs_f64(self.sent as f64 / self.bwlimit as f64);
-        if expected > elapsed {
-            std::thread::sleep(expected - elapsed);
+
+        self.debt += data.len() as i64;
+        let now = Instant::now();
+        if let Some(prior) = self.prior {
+            let elapsed_us = now.duration_since(prior).as_micros() as i64;
+            let allowance = elapsed_us * self.bwlimit as i64 / ONE_SEC_MICROS;
+            self.debt -= allowance;
+            if self.debt < 0 {
+                self.debt = 0;
+            }
         }
+
+        let sleep_us = self.debt * ONE_SEC_MICROS / self.bwlimit as i64;
+        if sleep_us >= MIN_SLEEP {
+            std::thread::sleep(Duration::from_micros(sleep_us as u64));
+            let after = Instant::now();
+            let slept_us = after.duration_since(now).as_micros() as i64;
+            let leftover = sleep_us - slept_us;
+            self.debt = leftover * self.bwlimit as i64 / ONE_SEC_MICROS;
+            self.prior = Some(after);
+        } else {
+            self.prior = Some(now);
+        }
+
         Ok(())
     }
 

--- a/crates/transport/tests/bwlimit.rs
+++ b/crates/transport/tests/bwlimit.rs
@@ -5,14 +5,33 @@ use std::time::{Duration, Instant};
 use transport::{LocalPipeTransport, RateLimitedTransport, Transport};
 
 #[test]
-fn rate_limited_transport_caps_speed() {
+fn sustained_transfer_is_limited() {
     let reader = io::empty();
     let writer = Vec::new();
     let inner = LocalPipeTransport::new(reader, writer);
     let mut t = RateLimitedTransport::new(inner, 1024);
-    let data = vec![0u8; 1024];
+    let data = vec![0u8; 2048];
     let start = Instant::now();
     t.send(&data).unwrap();
     let elapsed = start.elapsed();
+    assert!(elapsed >= Duration::from_millis(1900));
+}
+
+#[test]
+fn short_burst_is_initially_allowed() {
+    let reader = io::empty();
+    let writer = Vec::new();
+    let inner = LocalPipeTransport::new(reader, writer);
+    let mut t = RateLimitedTransport::new(inner, 1024);
+
+    let small = vec![0u8; 50];
+    let start = Instant::now();
+    t.send(&small).unwrap();
+    assert!(start.elapsed() < Duration::from_millis(100));
+
+    let large = vec![0u8; 974];
+    let start2 = Instant::now();
+    t.send(&large).unwrap();
+    let elapsed = start2.elapsed();
     assert!(elapsed >= Duration::from_millis(900));
 }


### PR DESCRIPTION
## Summary
- implement token-bucket behavior in RateLimitedTransport
- add integration tests for sustained and burst traffic

## Testing
- `cargo test -p transport --test bwlimit -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b39ef46b948323aaf6964275e49e74