### PR TITLE
Add transport timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "checksums"
 version = "0.1.0"
 dependencies = [
@@ -380,7 +386,7 @@ dependencies = [
 name = "daemon"
 version = "0.1.0"
 dependencies = [
- "nix",
+ "nix 0.27.1",
  "tempfile",
  "transport",
 ]
@@ -437,7 +443,7 @@ dependencies = [
  "filetime",
  "filters",
  "meta",
- "nix",
+ "nix 0.27.1",
  "posix-acl",
  "tempfile",
  "thiserror",
@@ -810,7 +816,7 @@ version = "0.1.0"
 dependencies = [
  "filetime",
  "libc",
- "nix",
+ "nix 0.27.1",
  "posix-acl",
  "tempfile",
  "xattr",
@@ -833,6 +839,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -872,7 +890,7 @@ dependencies = [
  "filetime",
  "filters",
  "logging",
- "nix",
+ "nix 0.27.1",
  "oc-rsync-cli",
  "posix-acl",
  "predicates",
@@ -907,7 +925,7 @@ dependencies = [
  "engine",
  "filters",
  "meta",
- "nix",
+ "nix 0.27.1",
  "protocol",
  "shell-words",
  "tempfile",
@@ -1467,6 +1485,7 @@ name = "transport"
 version = "0.1.0"
 dependencies = [
  "compress",
+ "nix 0.28.0",
  "protocol",
  "tempfile",
 ]

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 protocol = { path = "../protocol" }
 compress = { path = "../compress" }
+nix = { version = "0.28", default-features = false, features = ["poll"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -34,6 +34,14 @@ impl<R, W> LocalPipeTransport<R, W> {
     pub fn into_inner(self) -> (R, W) {
         (self.reader, self.writer)
     }
+
+    pub fn reader_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    pub fn writer_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
 }
 
 impl<R: Read, W: Write> Transport for LocalPipeTransport<R, W> {

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -24,7 +24,10 @@ impl TcpTransport {
         }
         .ok_or_else(|| io::Error::other("invalid address"))?;
         let stream = if let Some(dur) = timeout {
-            TcpStream::connect_timeout(&addr, dur)?
+            let stream = TcpStream::connect_timeout(&addr, dur)?;
+            stream.set_read_timeout(Some(dur))?;
+            stream.set_write_timeout(Some(dur))?;
+            stream
         } else {
             TcpStream::connect(addr)?
         };
@@ -74,6 +77,10 @@ impl TcpTransport {
 
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
         self.stream.set_read_timeout(dur)
+    }
+
+    pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
+        self.stream.set_write_timeout(dur)
     }
 }
 

--- a/crates/transport/tests/ssh_capabilities.rs
+++ b/crates/transport/tests/ssh_capabilities.rs
@@ -44,7 +44,7 @@ fn handshake_reads_capabilities_in_multiple_chunks() {
     let version_bytes = LATEST_VERSION.to_be_bytes().to_vec();
     let mut transport = ChunkedTransport::new(vec![version_bytes, vec![0], vec![0, 0, 0]]);
 
-    let codecs =
+    let (codecs, _caps) =
         SshStdioTransport::handshake(&mut transport, &[], None, LATEST_VERSION).expect("handshake");
 
     assert_eq!(codecs, vec![Codec::Zlib]);


### PR DESCRIPTION
## Summary
- add configurable connect and I/O timeouts to TCP and SSH transports
- cover timeout behavior in integration tests for client (SSH) and daemon (TCP)

## Testing
- `cargo test -p transport`
- `cargo test --test timeout`

------
https://chatgpt.com/codex/tasks/task_e_68b39efb92908323a36f967086ca5dfe