### PR TITLE
filters: support existing/prune-empty-dirs directives

### DIFF
--- a/crates/filters/tests/existing_prune.rs
+++ b/crates/filters/tests/existing_prune.rs
@@ -1,0 +1,32 @@
+// crates/filters/tests/existing_prune.rs
+use filters::{parse, Matcher};
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn existing_skips_missing_files() {
+    let tmp = tempdir().unwrap();
+    fs::write(tmp.path().join("present"), b"").unwrap();
+    let mut v = HashSet::new();
+    let rules = parse("existing\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules).with_root(tmp.path());
+    assert!(matcher.is_included("present").unwrap());
+    assert!(!matcher.is_included("absent").unwrap());
+}
+
+#[test]
+fn prune_empty_dirs_removes_empty_chains() {
+    let tmp = tempdir().unwrap();
+    fs::create_dir(tmp.path().join("empty")).unwrap();
+    fs::create_dir(tmp.path().join("only_excluded")).unwrap();
+    fs::write(tmp.path().join("only_excluded/secret"), b"").unwrap();
+    fs::create_dir(tmp.path().join("with_files")).unwrap();
+    fs::write(tmp.path().join("with_files/file"), b"").unwrap();
+    let mut v = HashSet::new();
+    let rules = parse("prune-empty-dirs\n- secret\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules).with_root(tmp.path());
+    assert!(!matcher.is_included("empty").unwrap());
+    assert!(!matcher.is_included("only_excluded").unwrap());
+    assert!(matcher.is_included("with_files").unwrap());
+}

--- a/fuzz/fuzz_targets/filters.rs
+++ b/fuzz/fuzz_targets/filters.rs
@@ -4,13 +4,18 @@ use filters::{parse, Matcher};
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;
 use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
 
 fuzz_target!(|data: &[u8]| {
     if let Some(s) = helpers::as_str(data) {
         let mut v = HashSet::new();
         if let Ok(rules) = parse(s, &mut v, 0) {
-            let matcher = Matcher::new(rules);
-            let _ = matcher.is_included("test");
+            let tmp = tempdir().unwrap();
+            fs::write(tmp.path().join("existing"), b"").ok();
+            let matcher = Matcher::new(rules).with_root(tmp.path());
+            let _ = matcher.is_included("existing");
+            let _ = matcher.is_included("missing");
         }
     }
 });

--- a/fuzz/fuzz_targets/filters_merge_fuzz.rs
+++ b/fuzz/fuzz_targets/filters_merge_fuzz.rs
@@ -1,9 +1,11 @@
 // fuzz/fuzz_targets/filters_merge_fuzz.rs
 #![no_main]
 use filters::{parse, Matcher};
-use std::collections::HashSet;
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
 
 fuzz_target!(|data: &[u8]| {
     if let Some(s) = helpers::as_str(data) {
@@ -12,11 +14,13 @@ fuzz_target!(|data: &[u8]| {
         let second = parts.get(1).copied().unwrap_or("");
         let (mut v1, mut v2, mut v3) = (HashSet::new(), HashSet::new(), HashSet::new());
         if let (Ok(r1), Ok(r2)) = (parse(first, &mut v1, 0), parse(second, &mut v2, 0)) {
-            let mut merged = Matcher::new(r1.clone());
+            let tmp = tempdir().unwrap();
+            fs::write(tmp.path().join("a"), b"").ok();
+            let mut merged = Matcher::new(r1.clone()).with_root(tmp.path());
             merged.merge(r2.clone());
             let combined = format!("{}\n{}", first, second);
             if let Ok(all) = parse(&combined, &mut v3, 0) {
-                let m2 = Matcher::new(all);
+                let m2 = Matcher::new(all).with_root(tmp.path());
                 for path in ["a", "a.txt", "dir/file", "dir/sub/file.txt"] {
                     let _ = assert_eq!(merged.is_included(path), m2.is_included(path));
                 }

--- a/fuzz/fuzz_targets/filters_parse_fuzz.rs
+++ b/fuzz/fuzz_targets/filters_parse_fuzz.rs
@@ -1,9 +1,9 @@
 // fuzz/fuzz_targets/filters_parse_fuzz.rs
 #![no_main]
+use filters::parse;
 use fuzz::helpers;
 use libfuzzer_sys::fuzz_target;
 use std::collections::HashSet;
-use filters::parse;
 
 fuzz_target!(|data: &[u8]| {
     if let Some(s) = helpers::as_str(data) {


### PR DESCRIPTION
## Summary
- handle `existing` and `prune-empty-dirs` directives in filter engine
- fuzz filters with filesystem roots exercising new flags
- cover existing/prune behaviour with regression tests

## Testing
- `cargo test -p filters`


------
https://chatgpt.com/codex/tasks/task_e_68b3a0f6efd88323851f01d02eaca652