### PR TITLE
feat: add fastcdc chunking with tunable sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "checksums",
  "compress",
  "criterion",
+ "fastcdc",
  "filetime",
  "filters",
  "meta",
@@ -460,6 +461,12 @@ dependencies = [
  "libc",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "fastcdc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf51ceb43e96afbfe4dd5c6f6082af5dfd60e220820b8123792d61963f2ce6bc"
 
 [[package]]
 name = "fastrand"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -12,6 +12,7 @@ compress = { path = "../compress" }
 nix = { version = "0.27", features = ["user", "fs"] }
 meta = { path = "../meta", default-features = false }
 blake3 = "1"
+fastcdc = "3.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -158,6 +158,8 @@ The table below mirrors the full `rsync(1)` flag set. Defaults show the behavior
 |  | `--modern-compress` | auto | oc-rsync only; select `auto`, `zstd`, or `lz4` compression | [matrix](feature_matrix.md#--modern-compress) |
 |  | `--modern-hash` | off | oc-rsync only; choose `blake3` strong hash | [matrix](feature_matrix.md#--modern-hash) |
 |  | `--modern-cdc` | off | oc-rsync only; enable `fastcdc` chunking | [matrix](feature_matrix.md#--modern-cdc) |
+|  | `--modern-cdc-min` | 2048 | oc-rsync only; set FastCDC minimum chunk size | [matrix](feature_matrix.md#--modern-cdc-min) |
+|  | `--modern-cdc-max` | 16384 | oc-rsync only; set FastCDC maximum chunk size | [matrix](feature_matrix.md#--modern-cdc-max) |
 | `-@` | `--modify-window` | off |  | [matrix](feature_matrix.md#--modify-window) |
 |  | `--munge-links` | off |  | [matrix](feature_matrix.md#--munge-links) |
 |  | `--no-D` | off | alias for `--no-devices --no-specials` | [matrix](feature_matrix.md#--no-d) |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -102,6 +102,8 @@ negotiates version 73.
 | `--modern-compress` | — | ✅ | ✅ | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | oc-rsync only; choose `auto`, `zstd`, or `lz4` compression | — |
 | `--modern-hash` | — | ✅ | ✅ | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | oc-rsync only; select BLAKE3 hash (requires `blake3` feature) | — |
 | `--modern-cdc` | — | ✅ | ✅ | [tests/golden/cli_parity/modern_flags.sh](../tests/golden/cli_parity/modern_flags.sh) | oc-rsync only; enable `fastcdc` chunking | — |
+| `--modern-cdc-min` | — | ✅ | ✅ | [tests/cdc.rs](../tests/cdc.rs) | oc-rsync only; set FastCDC minimum chunk size | — |
+| `--modern-cdc-max` | — | ✅ | ✅ | [tests/cdc.rs](../tests/cdc.rs) | oc-rsync only; set FastCDC maximum chunk size | — |
 | `--modify-window` | `-@` | ❌ | — | — |  | ≤3.2 |
 | `--munge-links` | — | ❌ | — | — |  | ≤3.2 |
 | `--no-detach` | — | ❌ | — | — |  | ≤3.2 |

--- a/man/oc-rsync.1
+++ b/man/oc-rsync.1
@@ -1024,6 +1024,26 @@ T}@T{
 matrix
 T}
 T{
+T}@T{
+\f[V]--modern-cdc-min\f[R]
+T}@T{
+2048
+T}@T{
+oc-rsync only; set FastCDC minimum chunk size
+T}@T{
+matrix
+T}
+T{
+T}@T{
+\f[V]--modern-cdc-max\f[R]
+T}@T{
+16384
+T}@T{
+oc-rsync only; set FastCDC maximum chunk size
+T}@T{
+matrix
+T}
+T{
 \f[V]-\[at]\f[R]
 T}@T{
 \f[V]--modify-window\f[R]

--- a/man/oc-rsync.bash
+++ b/man/oc-rsync.bash
@@ -23,7 +23,7 @@ _oc-rsync() {
 
     case "${cmd}" in
         oc__rsync)
-            opts="-a -r -d -R -n -S -u -I -v -q -8 -i -b -c -E -U -N -O -J -L -k -z -T -P -4 -6 -B -W -e -f -F -C -h --local --archive --recursive --dirs --relative --dry-run --list-only --sparse --update --ignore-existing --size-only --ignore-times --verbose --human-readable --quiet --no-motd --8-bit-output --itemize-changes --delete --delete-before --delete-during --delete-after --delete-delay --delete-excluded --backup --backup-dir --checksum --cc --checksum-choice --checksum-seed --perms --executability --chmod --chown --times --atimes --crtimes --omit-dir-times --omit-link-times --owner --group --links --copy-links --copy-dirlinks --copy-unsafe-links --safe-links --hard-links --devices --specials --compress --zc --compress-choice --zl --compress-level --skip-compress --modern --modern-compress --modern-hash --modern-cdc --partial --partial-dir --temp-dir --progress --blocking-io --append --append-verify --inplace --bwlimit --timeout --contimeout --protocol --port --ipv4 --ipv6 --block-size --whole-file --no-whole-file --link-dest --copy-dest --compare-dest --numeric-ids --stats --config --known-hosts --no-host-key-checking --password-file --early-input --rsh --server --sender --rsync-path --filter --filter-file --cvs-exclude --include --exclude --include-from --exclude-from --files-from --from0 --help <SRC> <DST>"
+            opts="-a -r -d -R -n -S -u -I -v -q -8 -i -b -c -E -U -N -O -J -L -k -z -T -P -4 -6 -B -W -e -f -F -C -h --local --archive --recursive --dirs --relative --dry-run --list-only --sparse --update --ignore-existing --size-only --ignore-times --verbose --human-readable --quiet --no-motd --8-bit-output --itemize-changes --delete --delete-before --delete-during --delete-after --delete-delay --delete-excluded --backup --backup-dir --checksum --cc --checksum-choice --checksum-seed --perms --executability --chmod --chown --times --atimes --crtimes --omit-dir-times --omit-link-times --owner --group --links --copy-links --copy-dirlinks --copy-unsafe-links --safe-links --hard-links --devices --specials --compress --zc --compress-choice --zl --compress-level --skip-compress --modern --modern-compress --modern-hash --modern-cdc --modern-cdc-min --modern-cdc-max --partial --partial-dir --temp-dir --progress --blocking-io --append --append-verify --inplace --bwlimit --timeout --contimeout --protocol --port --ipv4 --ipv6 --block-size --whole-file --no-whole-file --link-dest --copy-dest --compare-dest --numeric-ids --stats --config --known-hosts --no-host-key-checking --password-file --early-input --rsh --server --sender --rsync-path --filter --filter-file --cvs-exclude --include --exclude --include-from --exclude-from --files-from --from0 --help <SRC> <DST>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -83,6 +83,10 @@ _oc-rsync() {
                     ;;
                 --modern-cdc)
                     COMPREPLY=($(compgen -W "fastcdc off" -- "${cur}"))
+                    return 0
+                    ;;
+                --modern-cdc-min|--modern-cdc-max)
+                    COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
                 --partial-dir)

--- a/man/oc-rsync.fish
+++ b/man/oc-rsync.fish
@@ -12,6 +12,8 @@ lz4\t''"
 complete -c oc-rsync -l modern-hash -r -f -a ""
 complete -c oc-rsync -l modern-cdc -r -f -a "fastcdc\t''
 off\t''"
+complete -c oc-rsync -l modern-cdc-min -r -f
+complete -c oc-rsync -l modern-cdc-max -r -f
 complete -c oc-rsync -l partial-dir -r -F
 complete -c oc-rsync -s T -l temp-dir -r -F
 complete -c oc-rsync -l bwlimit -r

--- a/man/oc-rsync.zsh
+++ b/man/oc-rsync.zsh
@@ -29,6 +29,8 @@ _oc-rsync() {
 '--modern-compress=[]:MODERN_COMPRESS:(auto zstd lz4)' \
 '--modern-hash=[]:MODERN_HASH:()' \
 '--modern-cdc=[]:MODERN_CDC:(fastcdc off)' \
+'--modern-cdc-min=[]:SIZE:_default' \
+'--modern-cdc-max=[]:SIZE:_default' \
 '--partial-dir=[]:DIR:_files' \
 '-T+[]:DIR:_files' \
 '--temp-dir=[]:DIR:_files' \

--- a/tests/cdc.rs
+++ b/tests/cdc.rs
@@ -47,3 +47,49 @@ fn cdc_skips_renamed_file() {
     assert_eq!(stats.bytes_transferred, 0);
     assert_eq!(fs::read(dst.join("b.txt")).unwrap(), b"hello world");
 }
+
+#[test]
+fn cdc_reuses_manifest_with_custom_sizes() {
+    let home = tempdir().unwrap();
+    std::env::set_var("HOME", home.path());
+
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+
+    let file_a = src.join("a.bin");
+    fs::write(&file_a, vec![0u8; 50 * 1024]).unwrap();
+
+    let opts = SyncOptions {
+        modern_cdc: ModernCdc::Fastcdc,
+        modern_cdc_min: 4096,
+        modern_cdc_max: 8192,
+        ..Default::default()
+    };
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
+
+    // manifest written
+    assert!(home.path().join(".oc-rsync/manifest").exists());
+
+    let file_b = src.join("b.bin");
+    fs::rename(&file_a, &file_b).unwrap();
+    let stats = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
+    assert_eq!(stats.bytes_transferred, 0);
+    assert!(dst.join("b.bin").exists());
+}


### PR DESCRIPTION
## Summary
- switch CDC to FastCDC and allow configurable min/max chunk sizes
- store manifests under `~/.oc-rsync/manifest`
- expose `--modern-cdc-min`/`--modern-cdc-max` CLI options and test manifest reuse

## Testing
- `cargo test` *(hangs: daemon tests running over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68b39edd25888323b9f6df28436620a6