### PR TITLE
Handle metadata for links and devices

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1348,6 +1348,7 @@ pub fn sync(
                     if created && opts.itemize_changes {
                         println!("cd+++++++++ {}/", rel.display());
                     }
+                    receiver.copy_metadata(&path, &dest_path)?;
                 } else if file_type.is_symlink() {
                     let created = !dest_path.exists();
                     let target = fs::read_link(&path)?;
@@ -1404,6 +1405,7 @@ pub fn sync(
                                 std::os::windows::fs::symlink_file(&target, &dest_path)?;
                             }
                         }
+                        receiver.copy_metadata(&path, &dest_path)?;
                         if created {
                             stats.files_transferred += 1;
                             if opts.itemize_changes {
@@ -1434,11 +1436,13 @@ pub fn sync(
 
                             mknod(&dest_path, kind, perm, rdev)
                                 .map_err(|e| EngineError::Other(e.to_string()))?;
+                            receiver.copy_metadata(&path, &dest_path)?;
                         } else if file_type.is_fifo() && opts.specials {
                             use nix::sys::stat::Mode;
                             use nix::unistd::mkfifo;
                             mkfifo(&dest_path, Mode::from_bits_truncate(0o644))
                                 .map_err(|e| EngineError::Other(e.to_string()))?;
+                            receiver.copy_metadata(&path, &dest_path)?;
                         }
                     }
                 }

--- a/crates/meta/src/stub.rs
+++ b/crates/meta/src/stub.rs
@@ -38,6 +38,7 @@ pub struct Options {
     pub owner: bool,
     pub group: bool,
     pub perms: bool,
+    pub executability: bool,
     pub times: bool,
     pub atimes: bool,
     pub crtimes: bool,
@@ -56,6 +57,7 @@ impl std::fmt::Debug for Options {
             .field("owner", &self.owner)
             .field("group", &self.group)
             .field("perms", &self.perms)
+            .field("executability", &self.executability)
             .field("times", &self.times)
             .field("atimes", &self.atimes)
             .field("crtimes", &self.crtimes)
@@ -75,6 +77,7 @@ impl Options {
             || self.owner
             || self.group
             || self.perms
+            || self.executability
             || self.times
             || self.atimes
             || self.crtimes


### PR DESCRIPTION
## Summary
- Preserve metadata for symlinks and device nodes
- Apply ownership and permission mapping during sync
- Mirror metadata options in stub implementation

## Testing
- `cargo test --test local_sync_tree`
- `cargo test --test daemon --test daemon_config --test daemon_sync_attrs` *(fails: running for over 60 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a0f14ea08323bb4d3ce74971831a