### PR TITLE
Run CDC tests serially

### DIFF
--- a/tests/cdc.rs
+++ b/tests/cdc.rs
@@ -3,10 +3,12 @@
 use compress::available_codecs;
 use engine::{sync, ModernCdc, SyncOptions};
 use filters::Matcher;
+use serial_test::serial;
 use std::fs;
 use tempfile::tempdir;
 
 #[test]
+#[serial]
 fn cdc_skips_renamed_file() {
     let home = tempdir().unwrap();
     std::env::set_var("HOME", home.path());
@@ -49,6 +51,7 @@ fn cdc_skips_renamed_file() {
 }
 
 #[test]
+#[serial]
 fn cdc_reuses_manifest_with_custom_sizes() {
     let home = tempdir().unwrap();
     std::env::set_var("HOME", home.path());


### PR DESCRIPTION
## Summary
- ensure CDC tests run serially to avoid concurrent interference

## Testing
- `cargo test --test cdc`

------
https://chatgpt.com/codex/tasks/task_e_68b3a5bd39f48323b52fe0e9ff9a039a