### PR TITLE
engine: support batch logs and device writes

### DIFF
--- a/crates/engine/tests/write_batch.rs
+++ b/crates/engine/tests/write_batch.rs
@@ -1,0 +1,32 @@
+// crates/engine/tests/write_batch.rs
+use std::fs;
+
+use compress::available_codecs;
+use engine::{sync, SyncOptions};
+use filters::Matcher;
+use tempfile::tempdir;
+
+#[test]
+fn writes_batch_file() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file"), b"hi").unwrap();
+    let batch = tmp.path().join("batch.log");
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &SyncOptions {
+            write_batch: Some(batch.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let log = fs::read_to_string(batch).unwrap();
+    assert!(log.contains("files_transferred=1"));
+    assert!(log.contains("bytes_transferred=2"));
+}

--- a/crates/engine/tests/write_devices.rs
+++ b/crates/engine/tests/write_devices.rs
@@ -1,0 +1,54 @@
+// crates/engine/tests/write_devices.rs
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::FileTypeExt;
+
+use compress::available_codecs;
+use engine::{sync, SyncOptions};
+use filters::Matcher;
+use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+use tempfile::tempdir;
+
+#[test]
+fn requires_flag_to_write_devices() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file"), b"hi").unwrap();
+    let dev = dst.join("file");
+    mknod(
+        &dev,
+        SFlag::S_IFCHR,
+        Mode::from_bits_truncate(0o600),
+        makedev(1, 3),
+    )
+    .unwrap();
+
+    // should fail by default
+    let res = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &SyncOptions::default(),
+    );
+    assert!(res.is_err());
+
+    // succeeds with flag
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &SyncOptions {
+            write_devices: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let meta = fs::symlink_metadata(dev).unwrap();
+    assert!(meta.file_type().is_char_device());
+}


### PR DESCRIPTION
## Summary
- allow receiver to write to device files when `write_devices` is set
- verify batch logging and device write behavior in new tests

## Testing
- `cargo test -p engine`

------
https://chatgpt.com/codex/tasks/task_e_68b3aa9eb2d88323bd564f9984e2b799