### PR TITLE
Honor filter rule flags in matcher

### DIFF
--- a/crates/filters/tests/rule_modifiers.rs
+++ b/crates/filters/tests/rule_modifiers.rs
@@ -23,6 +23,25 @@ fn perishable_ignored_on_delete() {
 }
 
 #[test]
+fn receiver_risk_applies_on_delete() {
+    let mut v = HashSet::new();
+    let rules = parse("R debug.log\n- *.log\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(!matcher.is_included("debug.log").unwrap());
+    assert!(matcher.is_included_for_delete("debug.log").unwrap());
+}
+
+#[test]
+fn xattr_rule_only_affects_xattrs() {
+    let mut v = HashSet::new();
+    let rules = parse("-x user.secret\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("file").unwrap());
+    assert!(matcher.is_xattr_included("user.open").unwrap());
+    assert!(!matcher.is_xattr_included("user.secret").unwrap());
+}
+
+#[test]
 fn per_dir_merge_precedence() {
     let tmp = tempdir().unwrap();
     let root = tmp.path();

--- a/tests/filter_rule_precedence.sh
+++ b/tests/filter_rule_precedence.sh
@@ -5,7 +5,7 @@ ROOT="$(git rev-parse --show-toplevel)"
 OC_RSYNC="$ROOT/target/debug/oc-rsync"
 
 # Ensure binary is built
-cargo build --quiet -p oc-rsync-bin --bin oc-rsync --features blake3
+cargo build --quiet --bin oc-rsync --features blake3
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
@@ -20,12 +20,16 @@ echo skip > "$TMP/src/skip/file.txt"
 echo root > "$TMP/src/root.tmp"
 echo core > "$TMP/src/core"
 echo obj > "$TMP/src/foo.o"
+echo debug > "$TMP/src/debug.log"
+echo info > "$TMP/src/info.log"
 
 # Run reference rsync
 rsync_output=$(rsync --quiet --recursive \
   --filter='+ core' \
   --filter='-C' \
   --filter='- *.tmp' \
+  --filter='S debug.log' \
+  --filter='- *.log' \
   --filter='+ keep/tmp/file.tmp' \
   --filter='- skip/' \
   --filter='+ keep/***' \
@@ -39,6 +43,8 @@ oc_rsync_raw=$("$OC_RSYNC" --local --recursive \
   --filter='+ core' \
   --filter='-C' \
   --filter='- *.tmp' \
+  --filter='S debug.log' \
+  --filter='- *.log' \
   --filter='+ keep/tmp/file.tmp' \
   --filter='- skip/' \
   --filter='+ keep/***' \


### PR DESCRIPTION
## Summary
- apply sender/receiver/perishable/xattr flags during filter evaluation
- expand rule modifier tests for receiver and xattr handling
- cover sender-only filter precedence in parity script

## Testing
- `cargo test -p filters`
- `tests/filter_rule_precedence.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b3aaae90048323a64efa958e7af68b