### PR TITLE
cli: add tests for remote-option and secluded-args

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -205,9 +205,17 @@ struct ClientOpts {
     modern_hash: Option<ModernHashArg>,
     #[arg(long = "modern-cdc", value_enum, help_heading = "Compression")]
     modern_cdc: Option<ModernCdcArg>,
-    #[arg(long = "modern-cdc-min", value_name = "BYTES", help_heading = "Compression")]
+    #[arg(
+        long = "modern-cdc-min",
+        value_name = "BYTES",
+        help_heading = "Compression"
+    )]
     modern_cdc_min: Option<usize>,
-    #[arg(long = "modern-cdc-max", value_name = "BYTES", help_heading = "Compression")]
+    #[arg(
+        long = "modern-cdc-max",
+        value_name = "BYTES",
+        help_heading = "Compression"
+    )]
     modern_cdc_max: Option<usize>,
     #[arg(long, help_heading = "Misc")]
     partial: bool,
@@ -308,10 +316,16 @@ struct ClientOpts {
         short = 'M',
         long = "remote-option",
         value_name = "OPT",
-        allow_hyphen_values = true
+        allow_hyphen_values = true,
+        help = "send OPTION to the remote side only"
     )]
     remote_option: Vec<String>,
-    #[arg(short = 's', long = "secluded-args", help_heading = "Misc")]
+    #[arg(
+        short = 's',
+        long = "secluded-args",
+        help_heading = "Misc",
+        help = "use the protocol to safely send the args"
+    )]
     secluded_args: bool,
     #[arg(
         long = "sockopts",

--- a/tests/remote_option.rs
+++ b/tests/remote_option.rs
@@ -88,7 +88,7 @@ fn ssh_remote_option_forwarded() {
 
 #[cfg(unix)]
 #[test]
-#[ignore]
+#[ignore] // requires network daemon setup
 fn daemon_remote_option_forwarded() {
     let dir = tempdir().unwrap();
     let module_dir = dir.path().join("module");

--- a/tests/secluded_args.rs
+++ b/tests/secluded_args.rs
@@ -21,3 +21,23 @@ fn accepts_secluded_args() {
         .assert()
         .success();
 }
+
+#[test]
+fn accepts_s_alias() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(src.join("f"), b"data").unwrap();
+    let dst = dir.path().join("dst");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "-s",
+            "-r",
+            src.to_str().unwrap(),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary
- document and parse `--remote-option` and `--secluded-args`
- exercise remote option forwarding and secluded args short flag in integration tests

## Testing
- `cargo test --test remote_option`
- `cargo test --test secluded_args`


------
https://chatgpt.com/codex/tasks/task_e_68b3aa94805c8323b96cd3a1260229ed