### PR TITLE
engine: remove stray assignment

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -784,7 +784,6 @@ impl Receiver {
                 }
             }
         }
-        let mut out = if self.opts.inplace
         let cfg = ChecksumConfigBuilder::new()
             .strong(self.opts.strong)
             .seed(self.opts.checksum_seed)


### PR DESCRIPTION
## Summary
- remove leftover partial assignment prior to checksum config
- verified decompression calls rely on `Decompressor`

## Testing
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68b3af1c8564832393dc331f8c17d0c4