### PR TITLE
Simplify filter shorthand rule parsing

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1590,19 +1590,11 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
     if matches.contains_id("filter_shorthand") {
         if let Some(idx) = matches.index_of("filter_shorthand") {
             let count = matches.get_count("filter_shorthand");
-            if count >= 1 {
-                add_rules(
-                    idx,
-                    parse_filters("-F").map_err(|e| EngineError::Other(format!("{:?}", e)))?,
-                );
-            }
-            if count >= 2 {
-                add_rules(
-                    idx,
-                    parse_filters("- .rsync-filter")
-                        .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
-                );
-            }
+            let rule_str = if count >= 2 { "-FF" } else { "-F" };
+            add_rules(
+                idx,
+                parse_filters(rule_str).map_err(|e| EngineError::Other(format!("{:?}", e)))?,
+            );
         }
     }
     if !opts.files_from.is_empty() {


### PR DESCRIPTION
## Summary
- consolidate `-F` shorthand handling by generating `-FF` when invoked twice, removing redundant filter parsing

## Testing
- `cargo build`
- `cargo test --test filter_corpus` *(fails: directory trees differ for tests/filter_corpus/perdir_sign.rules)*

------
https://chatgpt.com/codex/tasks/task_e_68b4097051b883238c9206b8b83fbf64