### PR TITLE
Remove legacy manifest migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ Performance benchmarks and CPU feature detection details are documented in
 ## Manifest
 
 Content-defined chunking persists a manifest of seen chunks to
-`~/.oc-rsync/manifest`. If a manifest exists at the legacy location,
-`oc-rsync` will automatically migrate it to this path.
+`~/.oc-rsync/manifest`. Users upgrading from earlier releases should
+manually move any existing manifest from `~/.rsync-rs/manifest` to this
+path.
 
 ## License
 This project is dual-licensed under the terms of the [MIT](LICENSE-MIT) and [Apache-2.0](LICENSE-APACHE) licenses.

--- a/crates/engine/src/cdc.rs
+++ b/crates/engine/src/cdc.rs
@@ -42,19 +42,6 @@ impl Manifest {
     pub fn load() -> Self {
         let home = std::env::var("HOME").unwrap_or_else(|_| String::from("."));
         let path = Path::new(&home).join(".oc-rsync/manifest");
-        if !path.exists() {
-            let legacy = Path::new(&home).join(".rsync-rs/manifest");
-            if legacy.exists() {
-                if let Some(parent) = path.parent() {
-                    let _ = fs::create_dir_all(parent);
-                }
-                if fs::rename(&legacy, &path).is_err() {
-                    if fs::copy(&legacy, &path).is_ok() {
-                        let _ = fs::remove_file(&legacy);
-                    }
-                }
-            }
-        }
         let mut entries = HashMap::new();
         if let Ok(contents) = fs::read_to_string(&path) {
             for line in contents.lines() {
@@ -88,33 +75,5 @@ impl Manifest {
     pub fn insert(&mut self, hash: &Hash, path: &Path) {
         self.entries
             .insert(hash.to_hex().to_string(), path.to_path_buf());
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::tempdir;
-
-    #[test]
-    fn migrates_legacy_manifest() {
-        let home = tempdir().unwrap();
-        std::env::set_var("HOME", home.path());
-
-        let legacy_dir = home.path().join(".rsync-rs");
-        fs::create_dir_all(&legacy_dir).unwrap();
-        let legacy_manifest = legacy_dir.join("manifest");
-
-        let hash = blake3::hash(b"hello");
-        fs::write(
-            &legacy_manifest,
-            format!("{} {}\n", hash.to_hex(), "/some/path"),
-        )
-        .unwrap();
-
-        let manifest = Manifest::load();
-
-        assert_eq!(manifest.lookup(&hash), Some(PathBuf::from("/some/path")));
-        assert!(home.path().join(".oc-rsync/manifest").exists());
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,8 +16,9 @@ crate boundaries, data flow, and the key algorithms that power `oc-rsync`.
   block matching.
 - [`engine`](../crates/engine) – orchestrates scanning, delta calculation, and
   application of differences between sender and receiver. It also maintains a
-  content-defined chunking manifest at `~/.oc-rsync/manifest`, automatically
-  migrating manifests from the legacy location if present.
+  content-defined chunking manifest at `~/.oc-rsync/manifest`. Users upgrading
+  from older versions should move any existing manifest from
+  `~/.rsync-rs/manifest` to this path.
 - [`compress`](../crates/compress) – offers optional compression of file data
   during transfer.
 - [`filters`](../crates/filters) – parses include/exclude rules controlling

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -14,5 +14,5 @@ See [gaps.md](gaps.md) and [feature_matrix.md](feature_matrix.md) for any remain
 ## Manifest location
 
 The content-defined chunking manifest now resides at `~/.oc-rsync/manifest`.
-Previous versions stored it at `~/.rsync-rs/manifest`; `oc-rsync` automatically
-migrates existing manifests.
+Previous versions stored it at `~/.rsync-rs/manifest`. To continue using an
+existing manifest, move it to the new location.


### PR DESCRIPTION
## Summary
- drop migration logic for legacy `$HOME/.rsync-rs/manifest`
- document manual steps for moving manifests to `~/.oc-rsync/manifest`

## Testing
- `cargo test` *(fails: filter_corpus_parity)*

------
https://chatgpt.com/codex/tasks/task_e_68b40abebbdc8323abf73dce09382839