### PR TITLE
feat(engine): stream file reads

### DIFF
--- a/crates/engine/tests/streaming.rs
+++ b/crates/engine/tests/streaming.rs
@@ -29,3 +29,28 @@ fn sync_large_file_streaming() {
     let out = fs::read(dst.join("file.bin")).unwrap();
     assert_eq!(out, data);
 }
+
+#[test]
+fn sync_very_large_file_streaming() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+
+    let mut data = vec![0u8; 1 * 1024 * 1024];
+    for (i, b) in data.iter_mut().enumerate() {
+        *b = (i % 256) as u8;
+    }
+    fs::write(src.join("big.bin"), &data).unwrap();
+
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &SyncOptions::default(),
+    )
+    .unwrap();
+    let out = fs::read(dst.join("big.bin")).unwrap();
+    assert_eq!(out, data);
+}


### PR DESCRIPTION
## Summary
- stream sender data using buffered chunks instead of read_to_end
- stream receiver basis reads with temp-file handling and device checks
- add large-file streaming test

## Testing
- `cargo test -p engine`

------
https://chatgpt.com/codex/tasks/task_e_68b40aada20083238aecb765e567a9b7