### PR TITLE
Stream CDC chunking and add large-file test

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -18,7 +18,7 @@ use compress::{
 use filters::Matcher;
 use thiserror::Error;
 
-mod cdc;
+pub mod cdc;
 use cdc::{chunk_file, Manifest};
 
 #[derive(Debug, Error)]

--- a/crates/engine/tests/cdc.rs
+++ b/crates/engine/tests/cdc.rs
@@ -1,0 +1,11 @@
+// crates/engine/tests/cdc.rs
+use engine::cdc::chunk_bytes;
+
+#[test]
+#[ignore]
+fn chunk_bytes_multi_gb() {
+    let block = vec![0u8; 1024 * 1024]; // 1MB block
+    let iter = std::iter::repeat(block.as_slice()).take(2048); // 2GB total
+    let chunks = chunk_bytes(iter, 64 * 1024, 128 * 1024, 256 * 1024);
+    assert!(!chunks.is_empty());
+}


### PR DESCRIPTION
## Summary
- chunk files via `Read` using `StreamCDC` instead of reading entire file into memory
- allow `chunk_bytes` to operate on iterators of byte slices
- expose CDC module and add regression test for multi-GB CDC streams (ignored by default)

## Testing
- `cargo test` *(fails: filter_corpus_parity)*
- `cargo test -p engine --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b4120d8a4c8323ad553b68e00e445a