### PR TITLE
transport: refine bandwidth throttling

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -9,6 +9,12 @@ pub use rate::RateLimitedTransport;
 pub use ssh::SshStdioTransport;
 pub use tcp::TcpTransport;
 
+/// Wrap a [`Transport`] with a bandwidth limiter using rsync's
+/// token-bucket algorithm.
+pub fn rate_limited<T: Transport>(inner: T, bwlimit: u64) -> RateLimitedTransport<T> {
+    RateLimitedTransport::new(inner, bwlimit)
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum AddressFamily {
     V4,

--- a/crates/transport/src/rate.rs
+++ b/crates/transport/src/rate.rs
@@ -4,10 +4,15 @@ use std::time::{Duration, Instant};
 
 use crate::Transport;
 
+/// A transport wrapper that throttles outgoing bytes using
+/// an rsync-style token bucket. The `bwlimit` value is measured
+/// in bytes per second.
 pub struct RateLimitedTransport<T> {
     inner: T,
     bwlimit: u64,
-    debt: i64,
+    /// Amount of data that has been written but not yet
+    /// accounted for by elapsed time.
+    backlog: u64,
     prior: Option<Instant>,
 }
 
@@ -16,7 +21,7 @@ impl<T> RateLimitedTransport<T> {
         Self {
             inner,
             bwlimit,
-            debt: 0,
+            backlog: 0,
             prior: None,
         }
     }
@@ -28,33 +33,31 @@ impl<T> RateLimitedTransport<T> {
 
 impl<T: Transport> Transport for RateLimitedTransport<T> {
     fn send(&mut self, data: &[u8]) -> io::Result<()> {
-        const ONE_SEC_MICROS: i64 = 1_000_000;
-        const MIN_SLEEP: i64 = ONE_SEC_MICROS / 10; // 100ms
+        const ONE_SEC: u64 = 1_000_000; // microseconds
+        const MIN_SLEEP: u64 = ONE_SEC / 10; // 100ms
 
         self.inner.send(data)?;
 
-        self.debt += data.len() as i64;
-        let now = Instant::now();
+        self.backlog += data.len() as u64;
+        let start = Instant::now();
         if let Some(prior) = self.prior {
-            let elapsed_us = now.duration_since(prior).as_micros() as i64;
-            let allowance = elapsed_us * self.bwlimit as i64 / ONE_SEC_MICROS;
-            self.debt -= allowance;
-            if self.debt < 0 {
-                self.debt = 0;
-            }
+            let elapsed_us = start.duration_since(prior).as_micros() as u64;
+            let allowance = elapsed_us.saturating_mul(self.bwlimit) / ONE_SEC;
+            self.backlog = self.backlog.saturating_sub(allowance);
         }
 
-        let sleep_us = self.debt * ONE_SEC_MICROS / self.bwlimit as i64;
-        if sleep_us >= MIN_SLEEP {
-            std::thread::sleep(Duration::from_micros(sleep_us as u64));
-            let after = Instant::now();
-            let slept_us = after.duration_since(now).as_micros() as i64;
-            let leftover = sleep_us - slept_us;
-            self.debt = leftover * self.bwlimit as i64 / ONE_SEC_MICROS;
-            self.prior = Some(after);
-        } else {
-            self.prior = Some(now);
+        let sleep_us = self.backlog.saturating_mul(ONE_SEC) / self.bwlimit;
+        if sleep_us < MIN_SLEEP {
+            self.prior = Some(start);
+            return Ok(());
         }
+
+        std::thread::sleep(Duration::from_micros(sleep_us));
+        let after = Instant::now();
+        let elapsed_us = after.duration_since(start).as_micros() as u64;
+        let leftover = sleep_us.saturating_sub(elapsed_us);
+        self.backlog = leftover.saturating_mul(self.bwlimit) / ONE_SEC;
+        self.prior = Some(after);
 
         Ok(())
     }

--- a/crates/transport/tests/bwlimit.rs
+++ b/crates/transport/tests/bwlimit.rs
@@ -2,14 +2,14 @@
 use std::io;
 use std::time::{Duration, Instant};
 
-use transport::{LocalPipeTransport, RateLimitedTransport, Transport};
+use transport::{rate_limited, LocalPipeTransport, Transport};
 
 #[test]
 fn sustained_transfer_is_limited() {
     let reader = io::empty();
     let writer = Vec::new();
     let inner = LocalPipeTransport::new(reader, writer);
-    let mut t = RateLimitedTransport::new(inner, 1024);
+    let mut t = rate_limited(inner, 1024);
     let data = vec![0u8; 2048];
     let start = Instant::now();
     t.send(&data).unwrap();
@@ -22,7 +22,7 @@ fn short_burst_is_initially_allowed() {
     let reader = io::empty();
     let writer = Vec::new();
     let inner = LocalPipeTransport::new(reader, writer);
-    let mut t = RateLimitedTransport::new(inner, 1024);
+    let mut t = rate_limited(inner, 1024);
 
     let small = vec![0u8; 50];
     let start = Instant::now();
@@ -34,4 +34,41 @@ fn short_burst_is_initially_allowed() {
     t.send(&large).unwrap();
     let elapsed = start2.elapsed();
     assert!(elapsed >= Duration::from_millis(900));
+}
+
+#[test]
+fn idle_time_refills_bucket() {
+    let reader = io::empty();
+    let writer = Vec::new();
+    let inner = LocalPipeTransport::new(reader, writer);
+    let mut t = rate_limited(inner, 1024);
+
+    let block = vec![0u8; 1024];
+    t.send(&block).unwrap(); // burns 1s of bandwidth
+    std::thread::sleep(Duration::from_millis(1100));
+
+    let start = Instant::now();
+    t.send(&block).unwrap();
+    // After idling long enough, the second send should be near immediate.
+    assert!(start.elapsed() < Duration::from_millis(150));
+}
+
+#[test]
+fn partial_refill_shortens_sleep() {
+    let reader = io::empty();
+    let writer = Vec::new();
+    let inner = LocalPipeTransport::new(reader, writer);
+    let mut t = rate_limited(inner, 1024);
+
+    let block = vec![0u8; 1024];
+    t.send(&block).unwrap();
+    // Allow half the bandwidth to replenish.
+    std::thread::sleep(Duration::from_millis(500));
+
+    let start = Instant::now();
+    t.send(&block).unwrap();
+    let elapsed = start.elapsed();
+    // Should take roughly half a second to drain the remaining debt.
+    assert!(elapsed >= Duration::from_millis(400));
+    assert!(elapsed < Duration::from_millis(800));
 }


### PR DESCRIPTION
## Summary
- use rsync-style token bucket in `RateLimitedTransport`
- expose `rate_limited` helper for wrapping a transport
- extend bandwidth limit tests for idle and partial refill behaviour

## Testing
- `cargo test -p transport`

------
https://chatgpt.com/codex/tasks/task_e_68b41909752883239afc009a6bbb4a6a