### PR TITLE
Align CDC block-size with rsync heuristics

### DIFF
--- a/crates/engine/src/cdc.rs
+++ b/crates/engine/src/cdc.rs
@@ -7,6 +7,42 @@ use std::path::{Path, PathBuf};
 use blake3::Hash;
 use fastcdc::v2020::StreamCDC;
 
+const RSYNC_BLOCK_SIZE: usize = 700;
+const RSYNC_MAX_BLOCK_SIZE: usize = 1 << 17; // protocol >= 30
+
+/// Calculate the delta block size using the same heuristics as upstream rsync.
+///
+/// The algorithm chooses a rounded square-root of the file length and caps the
+/// result to `RSYNC_MAX_BLOCK_SIZE`.  Files smaller than `RSYNC_BLOCK_SIZE`
+/// squared use the fixed `RSYNC_BLOCK_SIZE` default.  The returned value is
+/// always a multiple of 8, matching rsync's behaviour.
+pub fn block_size(len: u64) -> usize {
+    if len <= (RSYNC_BLOCK_SIZE * RSYNC_BLOCK_SIZE) as u64 {
+        return RSYNC_BLOCK_SIZE;
+    }
+
+    let mut c: usize = 1;
+    let mut l = len;
+    while l >> 2 > 0 {
+        l >>= 2;
+        c <<= 1;
+    }
+
+    if c >= RSYNC_MAX_BLOCK_SIZE || c == 0 {
+        RSYNC_MAX_BLOCK_SIZE
+    } else {
+        let mut blength: usize = 0;
+        while c >= 8 {
+            blength |= c;
+            if len < (blength as u64).wrapping_mul(blength as u64) {
+                blength &= !c;
+            }
+            c >>= 1;
+        }
+        blength.max(RSYNC_BLOCK_SIZE)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Chunk {
     pub hash: Hash,

--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -2,7 +2,7 @@
 
 use assert_cmd::Command;
 use checksums::ChecksumConfigBuilder;
-use engine::{compute_delta, Op};
+use engine::{cdc, compute_delta, Op};
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::tempdir;
@@ -19,6 +19,22 @@ fn parse_literal(stats: &str) -> usize {
         }
     }
     panic!("no literal data in stats: {stats}");
+}
+
+#[test]
+fn cdc_block_size_heuristics() {
+    let cases = [
+        (100u64, 700usize),
+        (500_000, 704),
+        (1_048_576, 1024),
+        (10_000_000, 3160),
+        (100_000_000, 10_000),
+        (1_000_000_000, 31_616),
+        (1_000_000_000_000, 131_072),
+    ];
+    for (len, expected) in cases {
+        assert_eq!(cdc::block_size(len), expected, "len={len}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `cdc::block_size` that mirrors rsync’s square-root block sizing algorithm
- validate block-size heuristics across multiple file sizes in tests

## Testing
- `cargo test --test block_size --test cdc`

------
https://chatgpt.com/codex/tasks/task_e_68b419035d148323b94310c4283935a4