### PR TITLE
Support writing to device outputs

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -867,6 +867,15 @@ impl Receiver {
 
 impl Receiver {
     fn copy_metadata(&self, src: &Path, dest: &Path) -> Result<()> {
+        #[cfg(unix)]
+        if self.opts.write_devices {
+            if let Ok(meta) = fs::symlink_metadata(dest) {
+                let ft = meta.file_type();
+                if ft.is_char_device() || ft.is_block_device() {
+                    return Ok(());
+                }
+            }
+        }
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         {
             let chown_uid = self.opts.chown.map(|(u, _)| u).flatten();


### PR DESCRIPTION
## Summary
- Skip metadata updates for block and character devices when `--write-devices` is active

## Testing
- `cargo test --test write_devices`


------
https://chatgpt.com/codex/tasks/task_e_68b4195080c88323b8ae0fca704654f9