### PR TITLE
Unify transport timeout handling and update timeout tests

### DIFF
--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -1,5 +1,6 @@
 // crates/transport/src/lib.rs
 use std::io::{self, Read, Write};
+use std::time::Duration;
 
 mod rate;
 pub mod ssh;
@@ -19,6 +20,14 @@ pub trait Transport {
     fn send(&mut self, data: &[u8]) -> io::Result<()>;
 
     fn receive(&mut self, buf: &mut [u8]) -> io::Result<usize>;
+
+    fn set_read_timeout(&mut self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn set_write_timeout(&mut self, _dur: Option<Duration>) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 pub struct LocalPipeTransport<R, W> {

--- a/crates/transport/src/rate.rs
+++ b/crates/transport/src/rate.rs
@@ -62,4 +62,12 @@ impl<T: Transport> Transport for RateLimitedTransport<T> {
     fn receive(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.receive(buf)
     }
+
+    fn set_read_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        self.inner.set_read_timeout(dur)
+    }
+
+    fn set_write_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        self.inner.set_write_timeout(dur)
+    }
 }

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -415,13 +415,6 @@ impl SshStdioTransport {
         Ok(inner.into_inner())
     }
 
-    pub fn set_read_timeout(&mut self, dur: Option<Duration>) {
-        self.read_timeout = dur;
-    }
-
-    pub fn set_write_timeout(&mut self, dur: Option<Duration>) {
-        self.write_timeout = dur;
-    }
 }
 
 type InnerPipe = LocalPipeTransport<BufReader<ChildStdout>, ChildStdin>;
@@ -485,6 +478,16 @@ impl Transport for SshStdioTransport {
                 Err(err)
             }
         }
+    }
+
+    fn set_read_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        self.read_timeout = dur;
+        Ok(())
+    }
+
+    fn set_write_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        self.write_timeout = dur;
+        Ok(())
     }
 }
 

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -77,14 +77,6 @@ impl TcpTransport {
         }
         self.stream.write_all(b"\n")
     }
-
-    pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
-        self.stream.set_read_timeout(dur)
-    }
-
-    pub fn set_write_timeout(&self, dur: Option<Duration>) -> io::Result<()> {
-        self.stream.set_write_timeout(dur)
-    }
 }
 
 fn host_matches(ip: &IpAddr, pat: &str) -> bool {
@@ -111,6 +103,14 @@ impl Transport for TcpTransport {
 
     fn receive(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.stream.read(buf)
+    }
+
+    fn set_read_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        self.stream.set_read_timeout(dur)
+    }
+
+    fn set_write_timeout(&mut self, dur: Option<Duration>) -> io::Result<()> {
+        self.stream.set_write_timeout(dur)
     }
 }
 

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -16,13 +16,8 @@ fn tcp_read_timeout() {
         let (_sock, _) = listener.accept().unwrap();
         thread::sleep(Duration::from_secs(5));
     });
-    let mut t = TcpTransport::connect(
-        &addr.ip().to_string(),
-        addr.port(),
-        Some(Duration::from_millis(100)),
-        None,
-    )
-    .unwrap();
+    let mut t = TcpTransport::connect(&addr.ip().to_string(), addr.port(), None, None).unwrap();
+    t.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
     let mut buf = [0u8; 1];
     let err = t.receive(&mut buf).err().expect("error");
     assert!(err.kind() == io::ErrorKind::WouldBlock || err.kind() == io::ErrorKind::TimedOut);
@@ -31,7 +26,7 @@ fn tcp_read_timeout() {
 #[test]
 fn ssh_read_timeout() {
     let mut t = SshStdioTransport::spawn("sh", ["-c", "sleep 5"]).unwrap();
-    t.set_read_timeout(Some(Duration::from_millis(100)));
+    t.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
     let mut buf = [0u8; 1];
     let err = t.receive(&mut buf).err().expect("error");
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);


### PR DESCRIPTION
## Summary
- extend `Transport` trait with configurable read and write timeouts
- implement timeout methods for SSH, TCP, and rate-limited transports
- refresh timeout tests to use unified API

## Testing
- `cargo check --workspace --quiet`
- `cargo test --test timeout --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b419436624832393c33bf532b5c3ef