### PR TITLE
Align server version negotiation with rsync

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -41,7 +41,7 @@ pub fn negotiate_version(local: u32, peer: u32) -> Result<u32, VersionError> {
     if local >= LATEST_VERSION && peer >= LATEST_VERSION {
         Ok(LATEST_VERSION)
     } else {
-        let v = local.min(peer).min(32);
+        let v = local.min(peer);
         if v >= MIN_VERSION {
             Ok(v)
         } else {
@@ -443,9 +443,9 @@ mod tests {
     fn version_negotiation() {
         assert_eq!(negotiate_version(73, 80), Ok(73));
         assert_eq!(negotiate_version(73, 73), Ok(73));
-        assert_eq!(negotiate_version(73, 40), Ok(32));
-        assert_eq!(negotiate_version(32, 40), Ok(32));
-        for v in 27..=32 {
+        assert_eq!(negotiate_version(73, 40), Ok(40));
+        assert_eq!(negotiate_version(40, 73), Ok(40));
+        for v in 27..=40 {
             assert_eq!(negotiate_version(73, v), Ok(v));
         }
         assert!(negotiate_version(27, 26).is_err());

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -39,9 +39,9 @@ fn keepalive_roundtrip() {
 #[test]
 fn version_negotiation() {
     assert_eq!(negotiate_version(73, 73), Ok(73));
-    assert_eq!(negotiate_version(73, 40), Ok(32));
-    assert_eq!(negotiate_version(32, 40), Ok(32));
-    for v in 27..=32 {
+    assert_eq!(negotiate_version(73, 40), Ok(40));
+    assert_eq!(negotiate_version(40, 73), Ok(40));
+    for v in 27..=40 {
         assert_eq!(negotiate_version(73, v), Ok(v));
     }
     assert!(negotiate_version(27, 26).is_err());

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -38,7 +38,7 @@ fn server_negotiates_version() {
 }
 
 #[test]
-fn server_falls_back_to_v32() {
+fn server_accepts_legacy_version() {
     let legacy = LATEST_VERSION - 1;
     let payload = encode_codecs(&available_codecs(None));
     let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
@@ -56,11 +56,11 @@ fn server_falls_back_to_v32() {
     let (caps, peer_codecs) = srv
         .handshake(LATEST_VERSION, SUPPORTED_CAPS, &available_codecs(None))
         .unwrap();
-    assert_eq!(srv.version, 32);
+    assert_eq!(srv.version, legacy);
     assert_eq!(caps & CAP_CODECS, CAP_CODECS);
     assert_eq!(peer_codecs, available_codecs(None));
     let expected = {
-        let mut v = 32u32.to_be_bytes().to_vec();
+        let mut v = legacy.to_be_bytes().to_vec();
         v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
         let mut out_frame = Vec::new();
         codecs_frame.encode(&mut out_frame).unwrap();

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,7 +1,7 @@
 // tests/server.rs
 
 use assert_cmd::cargo::cargo_bin;
-use compress::{available_codecs, decode_codecs, encode_codecs};
+use compress::{available_codecs, decode_codecs, encode_codecs, ModernCompress};
 use protocol::{Frame, FrameHeader, Message, Msg, Tag, CAP_CODECS, LATEST_VERSION, MIN_VERSION};
 use std::convert::TryFrom;
 use std::fs;
@@ -41,6 +41,7 @@ fn server_handshake_succeeds() {
     let mut stdin = child.stdin.take().unwrap();
     let mut stdout = child.stdout.take().unwrap();
 
+    stdin.write_all(&[0]).unwrap();
     stdin.write_all(&LATEST_VERSION.to_be_bytes()).unwrap();
 
     let mut ver_buf = [0u8; 4];
@@ -99,9 +100,131 @@ fn server_rejects_unsupported_version() {
     let mut stdin = child.stdin.take().unwrap();
 
     let bad = (MIN_VERSION - 1) as u32;
+    stdin.write_all(&[0]).unwrap();
     stdin.write_all(&bad.to_be_bytes()).unwrap();
     drop(stdin);
 
     let status = child.wait().unwrap();
     assert!(!status.success());
+}
+
+#[test]
+fn server_modern_handshake_succeeds() {
+    let exe = cargo_bin("oc-rsync");
+    let mut child = Command::new(exe)
+        .arg("--server")
+        .env("RSYNC_MODERN", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = child.stdout.take().unwrap();
+
+    stdin.write_all(&[0]).unwrap();
+    stdin.write_all(&LATEST_VERSION.to_be_bytes()).unwrap();
+
+    let mut ver_buf = [0u8; 4];
+    stdout.read_exact(&mut ver_buf).unwrap();
+    assert_eq!(u32::from_be_bytes(ver_buf), LATEST_VERSION);
+
+    stdin.write_all(&CAP_CODECS.to_be_bytes()).unwrap();
+    let mut cap_buf = [0u8; 4];
+    stdout.read_exact(&mut cap_buf).unwrap();
+    assert_eq!(u32::from_be_bytes(cap_buf) & CAP_CODECS, CAP_CODECS);
+
+    let codecs = available_codecs(Some(ModernCompress::Auto));
+    let payload = encode_codecs(&codecs);
+    let frame = Message::Codecs(payload).to_frame(0);
+    let mut buf = Vec::new();
+    frame.encode(&mut buf).unwrap();
+    stdin.write_all(&buf).unwrap();
+
+    let mut hdr = [0u8; 8];
+    stdout.read_exact(&mut hdr).unwrap();
+    let channel = u16::from_be_bytes([hdr[0], hdr[1]]);
+    let tag = Tag::try_from(hdr[2]).unwrap();
+    let msg = Msg::try_from(hdr[3]).unwrap();
+    let len = u32::from_be_bytes([hdr[4], hdr[5], hdr[6], hdr[7]]) as usize;
+    let mut payload = vec![0u8; len];
+    stdout.read_exact(&mut payload).unwrap();
+    let frame = Frame {
+        header: FrameHeader {
+            channel,
+            tag,
+            msg,
+            len: len as u32,
+        },
+        payload: payload.clone(),
+    };
+    let msg = Message::from_frame(frame).unwrap();
+    let server_codecs = match msg {
+        Message::Codecs(data) => decode_codecs(&data).unwrap(),
+        _ => panic!("expected codecs message"),
+    };
+    assert_eq!(server_codecs, codecs);
+
+    let status = child.wait().unwrap();
+    assert!(status.success());
+}
+
+#[test]
+fn server_modern_downgrades_version() {
+    let exe = cargo_bin("oc-rsync");
+    let mut child = Command::new(exe)
+        .arg("--server")
+        .env("RSYNC_MODERN", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let mut stdout = child.stdout.take().unwrap();
+
+    let peer = 40u32;
+    stdin.write_all(&[0]).unwrap();
+    stdin.write_all(&peer.to_be_bytes()).unwrap();
+
+    let mut ver_buf = [0u8; 4];
+    stdout.read_exact(&mut ver_buf).unwrap();
+    assert_eq!(u32::from_be_bytes(ver_buf), peer);
+
+    stdin.write_all(&CAP_CODECS.to_be_bytes()).unwrap();
+    let mut cap_buf = [0u8; 4];
+    stdout.read_exact(&mut cap_buf).unwrap();
+    assert_eq!(u32::from_be_bytes(cap_buf) & CAP_CODECS, CAP_CODECS);
+
+    let codecs = available_codecs(Some(ModernCompress::Auto));
+    let payload = encode_codecs(&codecs);
+    let frame = Message::Codecs(payload).to_frame(0);
+    let mut buf = Vec::new();
+    frame.encode(&mut buf).unwrap();
+    stdin.write_all(&buf).unwrap();
+
+    let mut hdr = [0u8; 8];
+    stdout.read_exact(&mut hdr).unwrap();
+    let channel = u16::from_be_bytes([hdr[0], hdr[1]]);
+    let tag = Tag::try_from(hdr[2]).unwrap();
+    let msg = Msg::try_from(hdr[3]).unwrap();
+    let len = u32::from_be_bytes([hdr[4], hdr[5], hdr[6], hdr[7]]) as usize;
+    let mut payload = vec![0u8; len];
+    stdout.read_exact(&mut payload).unwrap();
+    let frame = Frame {
+        header: FrameHeader {
+            channel,
+            tag,
+            msg,
+            len: len as u32,
+        },
+        payload: payload.clone(),
+    };
+    let msg = Message::from_frame(frame).unwrap();
+    let server_codecs = match msg {
+        Message::Codecs(data) => decode_codecs(&data).unwrap(),
+        _ => panic!("expected codecs message"),
+    };
+    assert_eq!(server_codecs, codecs);
+
+    let status = child.wait().unwrap();
+    assert!(status.success());
 }


### PR DESCRIPTION
## Summary
- Match rsync's `--server` by negotiating the minimum peer version instead of clamping to v32
- Expand protocol tests for legacy versions and add modern handshake edge cases
- Add integration tests for modern server handshake and downgrades

## Testing
- `cargo test -p protocol`
- `cargo test --test server`


------
https://chatgpt.com/codex/tasks/task_e_68b4193894d08323958585baeca0a1ea