### PR TITLE
Add socket option parsing and application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,6 +1349,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,6 +1514,7 @@ dependencies = [
  "compress",
  "nix 0.28.0",
  "protocol",
+ "socket2",
  "tempfile",
 ]
 

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 protocol = { path = "../protocol" }
 compress = { path = "../compress" }
 nix = { version = "0.28", default-features = false, features = ["poll"] }
+socket2 = "0.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -58,3 +58,42 @@ impl<R: Read, W: Write> Transport for LocalPipeTransport<R, W> {
 pub trait SshTransport: Transport {}
 
 pub trait DaemonTransport: Transport {}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SockOpt {
+    KeepAlive(bool),
+    SendBuf(usize),
+    RecvBuf(usize),
+}
+
+pub fn parse_sockopts(opts: &[String]) -> Result<Vec<SockOpt>, String> {
+    opts.iter().map(|s| parse_sockopt(s)).collect()
+}
+
+fn parse_sockopt(s: &str) -> Result<SockOpt, String> {
+    let (name, value) = match s.split_once('=') {
+        Some((n, v)) => (n.trim(), Some(v.trim())),
+        None => (s.trim(), None),
+    };
+    match name {
+        "SO_KEEPALIVE" => {
+            let enabled = value.map(|v| v != "0").unwrap_or(true);
+            Ok(SockOpt::KeepAlive(enabled))
+        }
+        "SO_SNDBUF" => {
+            let v = value.ok_or_else(|| "SO_SNDBUF requires a value".to_string())?;
+            let size = v
+                .parse::<usize>()
+                .map_err(|_| "invalid SO_SNDBUF value".to_string())?;
+            Ok(SockOpt::SendBuf(size))
+        }
+        "SO_RCVBUF" => {
+            let v = value.ok_or_else(|| "SO_RCVBUF requires a value".to_string())?;
+            let size = v
+                .parse::<usize>()
+                .map_err(|_| "invalid SO_RCVBUF value".to_string())?;
+            Ok(SockOpt::RecvBuf(size))
+        }
+        _ => Err(format!("unknown socket option: {name}")),
+    }
+}

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -3,7 +3,9 @@ use std::io::{self, Read, Write};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::time::Duration;
 
-use crate::{AddressFamily, DaemonTransport, Transport};
+use socket2::SockRef;
+
+use crate::{AddressFamily, DaemonTransport, SockOpt, Transport};
 
 pub struct TcpTransport {
     stream: TcpStream,
@@ -76,6 +78,21 @@ impl TcpTransport {
             self.stream.write_all(tok.as_bytes())?;
         }
         self.stream.write_all(b"\n")
+    }
+
+    pub fn apply_sockopts(&self, opts: &[SockOpt]) -> io::Result<()> {
+        if opts.is_empty() {
+            return Ok(());
+        }
+        let sock = SockRef::from(&self.stream);
+        for opt in opts {
+            match *opt {
+                SockOpt::KeepAlive(v) => sock.set_keepalive(v)?,
+                SockOpt::SendBuf(size) => sock.set_send_buffer_size(size)?,
+                SockOpt::RecvBuf(size) => sock.set_recv_buffer_size(size)?,
+            }
+        }
+        Ok(())
     }
 
     pub fn set_read_timeout(&self, dur: Option<Duration>) -> io::Result<()> {

--- a/tests/remote_option.rs
+++ b/tests/remote_option.rs
@@ -118,6 +118,7 @@ fn daemon_remote_option_forwarded() {
         None,
         None,
         None,
+        &[],
         &[format!("--log-file={}", log.display())],
         protocol::LATEST_VERSION,
         None,


### PR DESCRIPTION
## Summary
- parse `--sockopts` in CLI and forward them to daemon sessions
- add `SockOpt` enum and parsing helpers in transport crate
- apply socket options to `TcpTransport` and depend on `socket2`

## Testing
- `cargo test --all` *(fails: target feature `avx512f` is unstable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4193de5648323a4b197ac6fd4ac4f