### PR TITLE
Expose device helpers and verify major/minor preservation

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -3,6 +3,11 @@ mod unix;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 pub use unix::*;
 
+// Re-export device number helpers so consumers can construct and
+// deconstruct `dev_t` values without depending on `nix` directly.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub use nix::sys::stat::{makedev, major, minor};
+
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 mod stub;
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]

--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -249,7 +249,7 @@ fn sync_preserves_crtimes() {
 #[cfg(target_os = "linux")]
 #[test]
 fn sync_preserves_device_nodes() {
-    use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+    use nix::sys::stat::{makedev, major, minor, mknod, Mode, SFlag};
 
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
@@ -276,7 +276,10 @@ fn sync_preserves_device_nodes() {
 
     let meta = fs::symlink_metadata(dst.join("null")).unwrap();
     assert!(meta.file_type().is_char_device());
-    assert_eq!(meta.rdev(), makedev(1, 3));
+    let rdev = meta.rdev();
+    assert_eq!(rdev, makedev(1, 3));
+    assert_eq!(major(rdev), 1);
+    assert_eq!(minor(rdev), 3);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- re-export `major`, `minor`, and `makedev` helpers from the meta crate
- extend local sync test to assert major/minor numbers for device nodes

## Testing
- `cargo test -p meta --quiet`
- `cargo test sync_preserves_device_nodes --quiet` *(fails: expected `;`, found keyword `return` in `crates/cli/src/lib.rs`)*

------
https://chatgpt.com/codex/tasks/task_e_68b41c3c5ae08323bc5452df8f1c42df