### PR TITLE
Expose ACL helpers and broaden ACL test coverage

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -10,3 +10,6 @@ pub use stub::*;
 
 mod parse;
 pub use parse::*;
+
+#[cfg(feature = "acl")]
+pub use posix_acl::{ACLEntry, PosixACL, Qualifier, ACL_EXECUTE, ACL_READ, ACL_RWX, ACL_WRITE};

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -117,7 +117,7 @@ fn roundtrip_xattrs() -> std::io::Result<()> {
         ..Default::default()
     };
     let meta = Metadata::from_path(&src, opts.clone())?;
-    meta.apply(&dst, opts)?;
+    meta.apply(&dst, opts.clone())?;
     let applied = Metadata::from_path(&dst, opts)?;
     let filter = |xs: &[(std::ffi::OsString, Vec<u8>)]| {
         xs.iter()
@@ -169,7 +169,7 @@ fn roundtrip_acl() -> std::io::Result<()> {
         ..Default::default()
     };
     let meta = Metadata::from_path(&src, opts.clone())?;
-    meta.apply(&dst, opts)?;
+    meta.apply(&dst, opts.clone())?;
     let applied = Metadata::from_path(&dst, opts)?;
 
     assert_eq!(meta.acl, applied.acl);

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use tempfile::tempdir;
 
 #[cfg(all(unix, feature = "acl"))]
-use posix_acl::{PosixACL, Qualifier, ACL_READ};
+use posix_acl::{PosixACL, Qualifier, ACL_READ, ACL_WRITE};
 #[cfg(all(unix, feature = "xattr"))]
 use xattr;
 
@@ -98,7 +98,9 @@ fn daemon_preserves_acls() {
     fs::write(&file, b"hi").unwrap();
 
     let mut acl = PosixACL::read_acl(&file).unwrap();
+    // Add a pair of custom ACL entries to ensure they survive the transfer.
     acl.set(Qualifier::User(12345), ACL_READ);
+    acl.set(Qualifier::User(23456), ACL_WRITE);
     acl.write_acl(&file).unwrap();
 
     let (mut child, port) = spawn_daemon(&srv);


### PR DESCRIPTION
## Summary
- re-export `posix_acl` types from `meta` for easier ACL handling
- cover multiple ACL entries in daemon sync tests
- fix ACL roundtrip test to reuse options without move errors

## Testing
- `cargo test -p meta --features acl`
- `cargo test --features acl --test daemon_sync_attrs -- daemon_preserves_acls --ignored` *(fails: expected `;`, found keyword `return` in crates/cli/src/lib.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b41c374f688323b9670f1d2a96948a