### PR TITLE
Restore source access times during sync

### DIFF
--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -205,7 +205,8 @@ fn atimes_roundtrip() {
     let dst_meta = fs::metadata(dst.join("file")).unwrap();
     let src_atime = FileTime::from_last_access_time(&src_meta);
     let dst_atime = FileTime::from_last_access_time(&dst_meta);
-    assert_eq!(dst_atime, src_atime);
+    assert_eq!(src_atime, atime);
+    assert_eq!(dst_atime, atime);
 }
 
 #[test]

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -10,3 +10,55 @@ pub use stub::*;
 
 mod parse;
 pub use parse::*;
+
+#[cfg(unix)]
+use filetime::set_symlink_file_times;
+use filetime::{set_file_times, FileTime};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Tracks a file's access time and restores it when dropped.
+#[derive(Debug)]
+pub struct AccessTime {
+    path: PathBuf,
+    atime: FileTime,
+    mtime: FileTime,
+    is_symlink: bool,
+}
+
+impl AccessTime {
+    /// Capture the current access time of `path`.
+    pub fn new(path: &Path) -> io::Result<Self> {
+        let meta = fs::symlink_metadata(path)?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            atime: FileTime::from_last_access_time(&meta),
+            mtime: FileTime::from_last_modification_time(&meta),
+            is_symlink: meta.file_type().is_symlink(),
+        })
+    }
+
+    /// Restore the previously captured access time.
+    pub fn restore(&self) -> io::Result<()> {
+        if self.is_symlink {
+            #[cfg(unix)]
+            {
+                set_symlink_file_times(&self.path, self.atime, self.mtime)?;
+            }
+            #[cfg(not(unix))]
+            {
+                set_file_times(&self.path, self.atime, self.mtime)?;
+            }
+        } else {
+            set_file_times(&self.path, self.atime, self.mtime)?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for AccessTime {
+    fn drop(&mut self) {
+        let _ = self.restore();
+    }
+}


### PR DESCRIPTION
## Summary
- add `AccessTime` guard to capture and restore atime values
- ensure sender drops atime guard before copying metadata
- verify atime round-trip for source and destination

## Testing
- `cargo test -p meta`
- `cargo test -p engine`
- `cargo fmt` *(fails: expected `;`, found keyword `return` in crates/cli/src/lib.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b41c3b40048323905fecbdeec3d86c