### PR TITLE
Add user/group ID remapping support

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -9,4 +9,4 @@ mod stub;
 pub use stub::*;
 
 mod parse;
-pub use parse::*;
+pub use parse::{parse_chmod, parse_chmod_spec, parse_chown, parse_id_map};

--- a/crates/meta/src/parse.rs
+++ b/crates/meta/src/parse.rs
@@ -1,5 +1,6 @@
 use crate::{Chmod, ChmodOp, ChmodTarget};
 use std::result::Result as StdResult;
+use std::sync::Arc;
 
 pub fn parse_chmod_spec(spec: &str) -> StdResult<Chmod, String> {
     let (target, rest) = if let Some(r) = spec.strip_prefix('D') {
@@ -168,4 +169,59 @@ fn parse_group(s: &str) -> StdResult<u32, String> {
 #[cfg(not(unix))]
 fn parse_group(s: &str) -> StdResult<u32, String> {
     s.parse().map_err(|_| format!("invalid gid '{s}'"))
+}
+
+pub fn parse_id_map(spec: &str) -> StdResult<Arc<dyn Fn(u32) -> u32 + Send + Sync>, String> {
+    #[derive(Clone)]
+    enum From {
+        Any,
+        Range(u32, u32),
+        Id(u32),
+    }
+    let mut rules: Vec<(From, u32)> = Vec::new();
+    for part in spec.split(',') {
+        if part.is_empty() {
+            continue;
+        }
+        let (from_s, to_s) = part
+            .split_once(':')
+            .ok_or_else(|| format!("invalid mapping '{part}'"))?;
+        let to: u32 = to_s
+            .parse()
+            .map_err(|_| format!("invalid id '{to_s}'"))?;
+        let from = if from_s == "*" {
+            From::Any
+        } else if let Some((lo_s, hi_s)) = from_s.split_once('-') {
+            let lo: u32 = lo_s
+                .parse()
+                .map_err(|_| format!("invalid id '{lo_s}'"))?;
+            let hi: u32 = hi_s
+                .parse()
+                .map_err(|_| format!("invalid id '{hi_s}'"))?;
+            if lo > hi {
+                return Err(format!("invalid range '{from_s}'"));
+            }
+            From::Range(lo, hi)
+        } else {
+            let id: u32 = from_s
+                .parse()
+                .map_err(|_| format!("invalid id '{from_s}'"))?;
+            From::Id(id)
+        };
+        rules.push((from, to));
+    }
+    if rules.is_empty() {
+        return Err("empty id map".into());
+    }
+    Ok(Arc::new(move |id: u32| -> u32 {
+        for (from, to) in &rules {
+            match from {
+                From::Any => return *to,
+                From::Range(lo, hi) if id >= *lo && id <= *hi => return *to,
+                From::Id(x) if id == *x => return *to,
+                _ => {}
+            }
+        }
+        id
+    }))
 }


### PR DESCRIPTION
## Summary
- add parser for UID/GID remapping and expose in meta crate
- plumb user/group ID maps through engine and CLI
- test CLI `--usermap`/`--groupmap` behavior

## Testing
- `cargo test --test cli user_and_group_ids_are_mapped -q`

------
https://chatgpt.com/codex/tasks/task_e_68b41c3a57f483239d9bf3c4be8d62ec