### PR TITLE
Use libc on macOS for device number helpers

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -5,8 +5,11 @@ pub use unix::*;
 
 // Re-export device number helpers so consumers can construct and
 // deconstruct `dev_t` values without depending on `nix` directly.
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(target_os = "linux")]
 pub use nix::sys::stat::{makedev, major, minor};
+
+#[cfg(target_os = "macos")]
+pub use libc::{makedev, major, minor};
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 mod stub;


### PR DESCRIPTION
## Summary
- Use libc's `makedev`, `major`, and `minor` on macOS instead of nix

## Testing
- `cargo test -p meta` *(fails: lock file version 4 requires -Znext-lockfile-bump)*
- `cargo test -p meta --target x86_64-apple-darwin` *(fails: lock file version 4 requires -Znext-lockfile-bump)*


------
https://chatgpt.com/codex/tasks/task_e_68b41fe7d8fc8323be628a027059439d