### PR TITLE
docs: update user/group mapping support

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -71,7 +71,7 @@ negotiates version 73.
 | `--fsync` | — | ❌ | — | — |  | ≤3.2 |
 | `--fuzzy` | `-y` | ❌ | — | — |  | ≤3.2 |
 | `--group` | `-g` | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
-| `--groupmap` | — | ❌ | — | — |  | ≤3.2 |
+| `--groupmap` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) | numeric gid mapping only; requires root or CAP_CHOWN | ≤3.2 |
 | `--hard-links` | `-H` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | ≤3.2 |
 | `--help` | `-h (*)` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--human-readable` |  | ✅ | ✅ | [tests/golden/cli_parity/human-readable.sh](../tests/golden/cli_parity/human-readable.sh) |  | ≤3.2 |
@@ -160,7 +160,7 @@ negotiates version 73.
 | `--times` | `-t` | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--trust-sender` | — | ❌ | — | — |  | ≤3.2 |
 | `--update` | `-u` | ✅ | ❌ | [crates/engine/tests/update.rs](../crates/engine/tests/update.rs) |  | ≤3.2 |
-| `--usermap` | — | ❌ | — | — |  | ≤3.2 |
+| `--usermap` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) | numeric uid mapping only; requires root or CAP_CHOWN | ≤3.2 |
 | `--verbose` | `-v` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--version` | `-V` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--whole-file` | `-W` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -22,13 +22,13 @@ This document tracks outstanding gaps in `oc-rsync` compared to the reference `r
  - `--chown` — not implemented. [feature_matrix](feature_matrix.md#L25) ([TODO](#testing-gaps))
  - `--copy-devices` — not implemented. [feature_matrix](feature_matrix.md#L35) ([TODO](#testing-gaps))
  - `--devices` — device file handling lacks parity. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [feature_matrix](feature_matrix.md#L52)
- - `--groupmap` — not implemented. [feature_matrix](feature_matrix.md#L68) ([TODO](#testing-gaps))
+ - `--groupmap` — numeric gid mapping only; group names unsupported and requires root or CAP_CHOWN. [tests/cli.rs](../tests/cli.rs) [feature_matrix](feature_matrix.md#L74)
  - `--hard-links` — hard link tracking incomplete. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [feature_matrix](feature_matrix.md#L69)
  - `--keep-dirlinks` — not implemented. [feature_matrix](feature_matrix.md#L84) ([TODO](#testing-gaps))
  - `--links` — symlink handling lacks parity. [tests/cli.rs](../tests/cli.rs) [feature_matrix](feature_matrix.md#L86)
  - `--owner` — ownership restoration lacks parity. [tests/cli.rs](../tests/cli.rs) [feature_matrix](feature_matrix.md#L113)
  - `--perms` — permission preservation incomplete. [tests/cli.rs](../tests/cli.rs) [feature_matrix](feature_matrix.md#L117)
- - `--usermap` — not implemented. [feature_matrix](feature_matrix.md#L151) ([TODO](#testing-gaps))
+ - `--usermap` — numeric uid mapping only; user names unsupported and requires root or CAP_CHOWN. [tests/cli.rs](../tests/cli.rs) [feature_matrix](feature_matrix.md#L163)
  - `--xattrs` — extended attribute support requires optional feature and lacks parity. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) [feature_matrix](feature_matrix.md#L157)
 
 ## Filter gaps


### PR DESCRIPTION
## Summary
- document `--usermap` and `--groupmap` as supported
- note required privileges for user/group mapping flags
- update gap notes for mapping flags

## Testing
- `cargo test` *(fails: directory trees differ in filter corpus tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b4208c43d88323af998e6c3bc3fe9c