### PR TITLE
Derive UID/GID dynamically in CLI usermap test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "shell-words",
  "tempfile",
  "transport",
+ "users",
  "wait-timeout",
  "xattr",
 ]
@@ -1547,6 +1548,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ transport = { path = "crates/transport" }
 filetime = "0.2"
 shell-words = "1.1"
 wait-timeout = "0.2"
+users = "0.11"
 
 [[bin]]
 name = "flag_matrix"


### PR DESCRIPTION
## Summary
- derive current UID and GID via the `users` crate in `user_and_group_ids_are_mapped`
- use these IDs for `--usermap` and `--groupmap` and assert mapped values
- add `users` as a dev dependency for tests

## Testing
- `cargo test --test cli user_and_group_ids_are_mapped`


------
https://chatgpt.com/codex/tasks/task_e_68b42089fcd0832386335731e5deb474