### PR TITLE
meta: include uid/gid mapping in needs_metadata

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -19,6 +19,23 @@ pub use stub::*;
 mod parse;
 pub use parse::{parse_chmod, parse_chmod_spec, parse_chown, parse_id_map};
 
+impl Options {
+    pub fn needs_metadata(&self) -> bool {
+        self.xattrs
+            || self.acl
+            || self.chmod.is_some()
+            || self.owner
+            || self.group
+            || self.perms
+            || self.executability
+            || self.times
+            || self.atimes
+            || self.crtimes
+            || self.uid_map.is_some()
+            || self.gid_map.is_some()
+    }
+}
+
 #[cfg(unix)]
 use filetime::set_symlink_file_times;
 use filetime::{set_file_times, FileTime};

--- a/crates/meta/src/stub.rs
+++ b/crates/meta/src/stub.rs
@@ -69,21 +69,6 @@ impl std::fmt::Debug for Options {
     }
 }
 
-impl Options {
-    pub fn needs_metadata(&self) -> bool {
-        self.xattrs
-            || self.acl
-            || self.chmod.is_some()
-            || self.owner
-            || self.group
-            || self.perms
-            || self.executability
-            || self.times
-            || self.atimes
-            || self.crtimes
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Metadata {
     pub uid: u32,

--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -94,21 +94,6 @@ impl std::fmt::Debug for Options {
     }
 }
 
-impl Options {
-    pub fn needs_metadata(&self) -> bool {
-        self.xattrs
-            || self.acl
-            || self.chmod.is_some()
-            || self.owner
-            || self.group
-            || self.perms
-            || self.executability
-            || self.times
-            || self.atimes
-            || self.crtimes
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Metadata {
     pub uid: u32,


### PR DESCRIPTION
## Summary
- Ensure metadata copy triggers when user/group ID maps are provided
- Centralize `Options::needs_metadata` in `lib.rs` and remove per-platform duplicates

## Testing
- `cargo test --test cli --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68b42257d1988323a23967578dc49db9