### PR TITLE
Add group ID mapping table

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -6,10 +6,10 @@ pub use unix::*;
 // Re-export device number helpers so consumers can construct and
 // deconstruct `dev_t` values without depending on `nix` directly.
 #[cfg(target_os = "linux")]
-pub use nix::sys::stat::{makedev, major, minor};
+pub use nix::sys::stat::{major, makedev, minor};
 
 #[cfg(target_os = "macos")]
-pub use libc::{makedev, major, minor};
+pub use libc::{major, makedev, minor};
 
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 mod stub;
@@ -22,6 +22,7 @@ pub use parse::{parse_chmod, parse_chmod_spec, parse_chown, parse_id_map};
 #[cfg(unix)]
 use filetime::set_symlink_file_times;
 use filetime::{set_file_times, FileTime};
+use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -68,6 +69,44 @@ impl AccessTime {
 impl Drop for AccessTime {
     fn drop(&mut self) {
         let _ = self.restore();
+    }
+}
+
+/// Table mapping group IDs to compact indexes.
+///
+/// This helps build the `gid` table used by the file list so that
+/// repeated group IDs are transmitted only once. Calling [`push`]
+/// returns the index for the provided `gid`, inserting it into the
+/// table if it wasn't already present.
+#[derive(Debug, Default, Clone)]
+pub struct GidTable {
+    map: HashMap<u32, usize>,
+    table: Vec<u32>,
+}
+
+impl GidTable {
+    /// Create a new, empty table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert `gid` into the table if it is not present, returning the
+    /// index associated with it.
+    pub fn push(&mut self, gid: u32) -> usize {
+        *self.map.entry(gid).or_insert_with(|| {
+            self.table.push(gid);
+            self.table.len() - 1
+        })
+    }
+
+    /// Returns the group ID stored at `idx`, if any.
+    pub fn gid(&self, idx: usize) -> Option<u32> {
+        self.table.get(idx).copied()
+    }
+
+    /// Exposes the underlying slice of group IDs in insertion order.
+    pub fn as_slice(&self) -> &[u32] {
+        &self.table
     }
 }
 #[cfg(feature = "acl")]

--- a/crates/meta/tests/gid_table.rs
+++ b/crates/meta/tests/gid_table.rs
@@ -1,0 +1,14 @@
+use meta::GidTable;
+
+#[test]
+fn gid_table_deduplicates_and_indexes() {
+    let mut table = GidTable::new();
+    assert_eq!(table.push(100), 0);
+    assert_eq!(table.push(200), 1);
+    // Pushing existing gid returns existing index without duplication
+    assert_eq!(table.push(100), 0);
+    assert_eq!(table.as_slice(), &[100, 200]);
+    assert_eq!(table.gid(0), Some(100));
+    assert_eq!(table.gid(1), Some(200));
+    assert_eq!(table.gid(2), None);
+}


### PR DESCRIPTION
## Summary
- add `GidTable` to track unique group IDs and provide compact indexes
- test group ID table for deduplication and lookup

## Testing
- `cargo test -p meta`
- `cargo test` *(fails: filter_corpus_parity, perdir_sign_parity)*

------
https://chatgpt.com/codex/tasks/task_e_68b42253ae2c8323bc9a8808c0350e66