### PR TITLE
Handle xattr removal and test daemon xattr cleanup

### DIFF
--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -39,7 +39,9 @@ impl Options {
 #[cfg(unix)]
 use filetime::set_symlink_file_times;
 use filetime::{set_file_times, FileTime};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+#[cfg(all(unix, feature = "xattr"))]
+use std::ffi::OsString;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -125,6 +127,26 @@ impl GidTable {
     pub fn as_slice(&self) -> &[u32] {
         &self.table
     }
+}
+
+/// Apply the provided extended attributes to `path`, removing any
+/// existing attributes that are not present in `xattrs`.
+#[cfg(all(unix, feature = "xattr"))]
+pub fn apply_xattrs(path: &Path, xattrs: &[(OsString, Vec<u8>)]) -> io::Result<()> {
+    let mut existing: HashSet<OsString> = xattr::list(path)?.collect();
+    for (name, value) in xattrs {
+        existing.remove(name);
+        xattr::set(path, name, value)?;
+    }
+    for name in existing {
+        if let Some(s) = name.to_str() {
+            if s == "system.posix_acl_access" || s == "system.posix_acl_default" {
+                continue;
+            }
+        }
+        let _ = xattr::remove(path, &name);
+    }
+    Ok(())
 }
 #[cfg(feature = "acl")]
 pub use posix_acl::{ACLEntry, PosixACL, Qualifier, ACL_EXECUTE, ACL_READ, ACL_RWX, ACL_WRITE};

--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -306,9 +306,7 @@ impl Metadata {
 
         #[cfg(feature = "xattr")]
         if opts.xattrs {
-            for (name, value) in &self.xattrs {
-                xattr::set(path, name, value)?;
-            }
+            crate::apply_xattrs(path, &self.xattrs)?;
         }
 
         #[cfg(feature = "acl")]


### PR DESCRIPTION
## Summary
- remove stray xattrs when applying metadata
- exercise daemon xattr transfer, including cleanup of pre-existing attrs

## Testing
- `cargo fmt -- crates/meta/src/lib.rs crates/meta/src/unix.rs tests/daemon_sync_attrs.rs`
- `cargo test -p meta --features xattr`
- `cargo test --test daemon_sync_attrs --features xattr -- --ignored` *(fails: connection error: Connection reset by peer)*

------
https://chatgpt.com/codex/tasks/task_e_68b426228f6883238ad3f7c0ca5f4a86