### PR TITLE
Handle comments and from0 in files-from list

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1569,7 +1569,7 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
                     if s.is_empty() {
                         return None;
                     }
-                    let p = String::from_utf8_lossy(s).trim().to_string();
+                    let p = String::from_utf8_lossy(s).to_string();
                     if p.is_empty() {
                         None
                     } else {
@@ -1581,8 +1581,9 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
             let content = fs::read_to_string(path)?;
             Ok(content
                 .lines()
-                .map(|l| l.trim().to_string())
-                .filter(|s| !s.is_empty())
+                .map(|l| l.trim())
+                .filter(|s| !s.is_empty() && !s.starts_with('#'))
+                .map(|s| s.to_string())
                 .collect())
         }
     }


### PR DESCRIPTION
## Summary
- Ignore comment and blank lines in include/exclude/files-from lists
- Preserve whitespace when reading `--from0` list files
- Test list file handling including comments and NUL-separated entries

## Testing
- `cargo test --test cli files_from_zero_separated_list -- --test-threads=1`
- `cargo test --test cli files_from_list_file -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_68b42989bc5c8323956285f7610e4f31