### PR TITLE
Handle CRLF in null-delimited pattern files

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1577,7 +1577,14 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
                     if s.is_empty() {
                         return None;
                     }
-                    let p = String::from_utf8_lossy(s).to_string();
+                    let mut end = s.len();
+                    while end > 0 && (s[end - 1] == b'\n' || s[end - 1] == b'\r') {
+                        end -= 1;
+                    }
+                    if end == 0 {
+                        return None;
+                    }
+                    let p = String::from_utf8_lossy(&s[..end]).to_string();
                     if p.is_empty() {
                         None
                     } else {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -856,6 +856,66 @@ fn files_from_zero_separated_list() {
 }
 
 #[test]
+fn files_from_zero_separated_list_with_crlf() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("keep me.txt"), b"k").unwrap();
+    std::fs::write(src.join("skip.txt"), b"s").unwrap();
+    let list = dir.path().join("files.lst");
+    std::fs::write(&list, b"keep me.txt\r\n\0").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--from0",
+            "--files-from",
+            list.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(dst.join("keep me.txt").exists());
+    assert!(!dst.join("skip.txt").exists());
+}
+
+#[test]
+fn exclude_from_zero_separated_list_with_crlf() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("keep.txt"), b"k").unwrap();
+    std::fs::write(src.join("skip.log"), b"s").unwrap();
+    let list = dir.path().join("exclude.lst");
+    std::fs::write(&list, b"*.log\r\n\0").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--from0",
+            "--exclude-from",
+            list.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(dst.join("keep.txt").exists());
+    assert!(!dst.join("skip.log").exists());
+}
+
+#[test]
 fn files_from_list_file() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");


### PR DESCRIPTION
## Summary
- Trim trailing `\r` and `\n` when parsing `--from0` pattern files
- Add tests for CRLF-terminated `--files-from` and `--exclude-from` lists

## Testing
- `cargo test --test cli zero_separated_list`

------
https://chatgpt.com/codex/tasks/task_e_68b42f33d8688323b54e9026f98e3dc5