### PR TITLE
feat(cli): support directory entries in --files-from

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1015,6 +1015,33 @@ fn files_from_list_handles_crlf_and_comment_spaces() {
     assert!(!dst.join("skip.txt").exists());
 }
 
+#[test]
+fn files_from_list_includes_directories() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(src.join("dir/sub")).unwrap();
+    std::fs::write(src.join("dir/sub/file.txt"), b"k").unwrap();
+    let list = dir.path().join("files.lst");
+    std::fs::write(&list, "dir\n").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--files-from",
+            list.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(dst.join("dir/sub/file.txt").exists());
+}
+
 #[cfg(unix)]
 #[test]
 fn links_preserve_symlinks() {


### PR DESCRIPTION
## Summary
- ensure `--files-from` entries are treated as root-anchored includes
- automatically include directory trees when listed
- test directory handling in `--files-from` lists

## Testing
- `cargo test --test cli`
- `cargo fmt -- --check crates/cli/src/lib.rs tests/cli.rs`


------
https://chatgpt.com/codex/tasks/task_e_68b432bc065883238ce9a88fff8c329a