### PR TITLE
Skip creating new files in update mode

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1419,6 +1419,9 @@ pub fn sync(
                     } else {
                         false
                     };
+                    if opts.update && !dest_path.exists() && !partial_exists {
+                        continue;
+                    }
                     if !dest_path.exists() && !partial_exists {
                         if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
                             if let Ok(chunks) = chunk_file(

--- a/crates/engine/tests/update.rs
+++ b/crates/engine/tests/update.rs
@@ -57,3 +57,24 @@ fn update_replaces_older_dest() {
     .unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"new");
 }
+
+#[test]
+fn update_skips_new_files() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("new.txt"), b"new").unwrap();
+    let mut opts = SyncOptions::default();
+    opts.update = true;
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
+    assert!(!dst.join("new.txt").exists());
+}


### PR DESCRIPTION
## Summary
- avoid creating new files when `--update` is used
- test update mode skipping new files

## Testing
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68b434e404bc83239964048caf451a76