### PR TITLE
feat(engine): clean temporary dirs after sync

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -893,6 +893,17 @@ impl Receiver {
         }
         if needs_rename {
             fs::rename(&tmp_dest, dest)?;
+            if let Some(tmp_parent) = tmp_dest.parent() {
+                if dest.parent().map_or(true, |p| p != tmp_parent) {
+                    if tmp_parent
+                        .read_dir()
+                        .map(|mut i| i.next().is_none())
+                        .unwrap_or(false)
+                    {
+                        let _ = fs::remove_dir(tmp_parent);
+                    }
+                }
+            }
         }
         if self.opts.progress {
             let len = fs::metadata(dest)?.len();

--- a/crates/engine/tests/cleanup.rs
+++ b/crates/engine/tests/cleanup.rs
@@ -1,0 +1,60 @@
+// crates/engine/tests/cleanup.rs
+use std::fs;
+
+use compress::available_codecs;
+use engine::{sync, SyncOptions};
+use filters::Matcher;
+use tempfile::tempdir;
+
+#[test]
+fn removes_partial_dir_after_sync() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file"), b"hi").unwrap();
+
+    let partial = tmp.path().join("partials");
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &SyncOptions {
+            partial: true,
+            partial_dir: Some(partial.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(dst.join("file").exists());
+    assert!(!partial.exists());
+}
+
+#[test]
+fn removes_temp_dir_after_sync() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file"), b"hi").unwrap();
+
+    let tmpdir = tmp.path().join("tmpdir");
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &SyncOptions {
+            temp_dir: Some(tmpdir.clone()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert!(dst.join("file").exists());
+    assert!(!tmpdir.exists());
+}


### PR DESCRIPTION
## Summary
- remove empty temporary/partial directories after file transfer completes
- add regression tests for temp_dir and partial_dir cleanup

## Testing
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68b43571d5b4832392d2836234b2639f