### PR TITLE
Allow daemon bind address in config

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1761,6 +1761,7 @@ fn run_daemon(opts: DaemonOpts) -> Result<()> {
     let timeout = opts.timeout;
     let bwlimit = opts.bwlimit;
     let mut port = opts.port;
+    let mut address = opts.address;
 
     if let Some(cfg_path) = &opts.config {
         let cfg = parse_config_file(cfg_path).map_err(|e| EngineError::Other(e.to_string()))?;
@@ -1778,6 +1779,9 @@ fn run_daemon(opts: DaemonOpts) -> Result<()> {
         }
         if let Some(s) = cfg.secrets_file {
             secrets = Some(s);
+        }
+        if let Some(a) = cfg.address {
+            address = Some(a);
         }
         if !cfg.hosts_allow.is_empty() {
             hosts_allow = cfg.hosts_allow;
@@ -1798,7 +1802,7 @@ fn run_daemon(opts: DaemonOpts) -> Result<()> {
         None
     };
 
-    let (listener, real_port) = TcpTransport::listen(opts.address, port, addr_family)?;
+    let (listener, real_port) = TcpTransport::listen(address, port, addr_family)?;
 
     if port == 0 {
         println!("{}", real_port);

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -7,6 +7,7 @@ use std::env;
 use std::fs;
 use std::io::{self};
 use std::path::{Path, PathBuf};
+use std::net::IpAddr;
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -60,6 +61,7 @@ pub fn parse_module(s: &str) -> std::result::Result<Module, String> {
 
 #[derive(Debug, Default, Clone)]
 pub struct DaemonConfig {
+    pub address: Option<IpAddr>,
     pub port: Option<u16>,
     pub hosts_allow: Vec<String>,
     pub hosts_deny: Vec<String>,
@@ -101,6 +103,12 @@ pub fn parse_config(contents: &str) -> io::Result<DaemonConfig> {
             .trim()
             .to_string();
         match (current.is_some(), key.as_str()) {
+            (false, "address") => {
+                cfg.address = Some(
+                    val.parse::<IpAddr>()
+                        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+                );
+            }
             (false, "port") => {
                 cfg.port = Some(
                     val.parse::<u16>()


### PR DESCRIPTION
## Summary
- accept an explicit bind address in daemon configuration
- honor configured address when launching the daemon
- test binding to configured address

## Testing
- `cargo test --test daemon daemon_config_binds_to_specified_address -- --test-threads=1`
- `cargo test --test filter_corpus -- --test-threads=1` *(fails: filter_corpus_parity, perdir_sign_parity)*


------
https://chatgpt.com/codex/tasks/task_e_68b43749cdbc83239639a2d7e1e3917d