### PR TITLE
Suppress unauthorized daemon messages

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -259,7 +259,6 @@ pub fn authenticate<T: Transport>(
         if let Some(allowed) = parse_auth_token(&token_str, &contents) {
             Ok((Some(token_str), allowed, no_motd))
         } else {
-            let _ = t.send(b"@ERROR: access denied");
             Err(io::Error::new(
                 io::ErrorKind::PermissionDenied,
                 "unauthorized",

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -509,7 +509,7 @@ fn daemon_allows_module_access() {
     t.send(b"data\n").unwrap();
     t.send(b"\n").unwrap();
     let n = t.receive(&mut buf).unwrap_or(0);
-    assert!(n == 0 || !String::from_utf8_lossy(&buf[..n]).starts_with("@ERROR"));
+    assert_eq!(n, 0);
     let _ = child.kill();
     let _ = child.wait();
 }
@@ -556,7 +556,7 @@ fn daemon_rejects_invalid_token() {
 
     t.authenticate(Some("bad"), false).unwrap();
     let n = t.receive(&mut buf).unwrap_or(0);
-    assert!(n == 0 || String::from_utf8_lossy(&buf[..n]).starts_with("@ERR"));
+    assert_eq!(n, 0);
     let _ = child.kill();
     let _ = child.wait();
 }

--- a/tests/daemon_config.rs
+++ b/tests/daemon_config.rs
@@ -80,7 +80,7 @@ fn daemon_config_authentication() {
     t.set_read_timeout(Some(Duration::from_millis(200)))
         .unwrap();
     let n = t.receive(&mut buf).unwrap_or(0);
-    assert!(n == 0 || !String::from_utf8_lossy(&buf[..n]).starts_with("@ERROR"));
+    assert_eq!(n, 0);
     let _ = child.kill();
     let _ = child.wait();
 }
@@ -182,7 +182,7 @@ fn daemon_config_module_secrets_file() {
     t.set_read_timeout(Some(Duration::from_millis(200)))
         .unwrap();
     let n = t.receive(&mut buf).unwrap_or(0);
-    assert!(n == 0 || !String::from_utf8_lossy(&buf[..n]).starts_with("@ERROR"));
+    assert_eq!(n, 0);
     let _ = child.kill();
     let _ = child.wait();
 }


### PR DESCRIPTION
## Summary
- avoid sending an `@ERROR` response when authentication fails in the daemon
- update daemon and config tests to expect silent failure on bad auth tokens

## Testing
- `cargo test --test daemon`
- `cargo test` *(fails: filter_corpus_parity, perdir_sign_parity)*

------
https://chatgpt.com/codex/tasks/task_e_68b43c1a894c8323b6bdae7a5e9faa4e