### PR TITLE
Normalize numeric chmod modes and add test

### DIFF
--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -256,7 +256,8 @@ impl Metadata {
                     }
                 }
             }
-            mode_val = normalize_mode(mode_val);
+            let mode_val = normalize_mode(mode_val);
+            debug_assert_eq!(mode_val & !0o7777, 0);
             let mode_t: libc::mode_t = mode_val as libc::mode_t;
             let mode = Mode::from_bits_truncate(mode_t);
             if let Err(err) = stat::fchmodat(None, path, mode, FchmodatFlags::NoFollowSymlink) {

--- a/crates/meta/tests/chmod.rs
+++ b/crates/meta/tests/chmod.rs
@@ -1,0 +1,31 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+use meta::{normalize_mode, parse_chmod, Metadata, Options};
+use nix::sys::stat::{fchmodat, FchmodatFlags, Mode};
+use tempfile::tempdir;
+
+#[test]
+fn chmod_numeric_mode_normalized() -> std::io::Result<()> {
+    let dir = tempdir()?;
+    let path = dir.path().join("file");
+    fs::write(&path, b"test")?;
+
+    fchmodat(
+        None,
+        &path,
+        Mode::from_bits_truncate(0o600),
+        FchmodatFlags::NoFollowSymlink,
+    )?;
+
+    let meta = Metadata::from_path(&path, Options::default())?;
+    let opts = Options {
+        chmod: Some(parse_chmod("100644").unwrap()),
+        ..Default::default()
+    };
+    meta.apply(&path, opts)?;
+
+    let mode = fs::symlink_metadata(&path)?.permissions().mode();
+    assert_eq!(normalize_mode(mode), 0o644);
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- normalize octal `--chmod` values before storing in `Chmod::bits`
- assert sanitized modes before calling `fchmodat`
- cover `--chmod=100644` with a regression test

## Testing
- `cargo test` *(fails: filter_corpus_parity, perdir_sign_parity)*

------
https://chatgpt.com/codex/tasks/task_e_68b44797b67883239f890d41c456f41c