### PR TITLE
Handle deletion of missing source args

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1084,6 +1084,8 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     let sync_opts = SyncOptions {
         delete: delete_mode,
         delete_excluded: opts.delete_excluded,
+        ignore_missing_args: false,
+        delete_missing_args: false,
         max_delete: opts.max_delete,
         max_alloc: opts.max_alloc.unwrap_or(1usize << 30),
         checksum: opts.checksum,

--- a/crates/engine/tests/missing_args.rs
+++ b/crates/engine/tests/missing_args.rs
@@ -1,0 +1,28 @@
+// crates/engine/tests/missing_args.rs
+use std::fs;
+
+use compress::available_codecs;
+use engine::{sync, SyncOptions};
+use filters::Matcher;
+use tempfile::tempdir;
+
+#[test]
+fn deletes_missing_arg() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("missing.txt");
+    let dst = tmp.path().join("dst.txt");
+    fs::write(&dst, b"data").unwrap();
+    let opts = SyncOptions {
+        delete_missing_args: true,
+        ..Default::default()
+    };
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
+    assert!(!dst.exists());
+}


### PR DESCRIPTION
## Summary
- support ignoring or deleting missing source arguments
- delete destination path when `delete_missing_args` is set
- test missing-arg deletion in engine

## Testing
- `cargo test -p engine`
- `cargo test` *(fails: filter_corpus_parity: directory trees differ)*

------
https://chatgpt.com/codex/tasks/task_e_68b449448fe083238b5833083451051f