### PR TITLE
Defer directory metadata until children processed

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1358,6 +1358,7 @@ pub fn sync(
     } else {
         Manifest::default()
     };
+    let mut dir_meta: Vec<(PathBuf, PathBuf)> = Vec::new();
     if matches!(opts.delete, Some(DeleteMode::Before)) {
         delete_extraneous(&src_root, dst, &matcher, opts, &mut stats)?;
     }
@@ -1516,7 +1517,7 @@ pub fn sync(
                     if created && opts.itemize_changes {
                         println!("cd+++++++++ {}/", rel.display());
                     }
-                    receiver.copy_metadata(&path, &dest_path)?;
+                    dir_meta.push((path.clone(), dest_path.clone()));
                 } else if file_type.is_symlink() {
                     let created = fs::symlink_metadata(&dest_path).is_err();
                     let target = fs::read_link(&path)?;
@@ -1636,6 +1637,9 @@ pub fn sync(
         Some(DeleteMode::After) | Some(DeleteMode::During)
     ) {
         delete_extraneous(src, dst, &matcher, opts, &mut stats)?;
+    }
+    for (src_dir, dest_dir) in dir_meta.into_iter().rev() {
+        receiver.copy_metadata(&src_dir, &dest_dir)?;
     }
     if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
         manifest.save()?;


### PR DESCRIPTION
## Summary
- Collect directories needing metadata updates while walking the tree
- Apply saved directory metadata after file transfers complete

## Testing
- `cargo test --test cli`


------
https://chatgpt.com/codex/tasks/task_e_68b44b3788e483238233edbe7211a69d