### PR TITLE
track deletion cap in sync

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1321,10 +1321,15 @@ pub fn sync(
         .as_ref()
         .and_then(|p| OpenOptions::new().create(true).append(true).open(p).ok());
     let src_root = fs::canonicalize(src).unwrap_or_else(|_| src.to_path_buf());
-    let mut stats = Stats::default();
+        let mut stats = Stats::default();
     if !src_root.exists() {
         if opts.delete_missing_args {
             if dst.exists() {
+                if let Some(max) = opts.max_delete {
+                    if stats.files_deleted >= max {
+                        return Err(EngineError::Other("max-delete limit exceeded".into()));
+                    }
+                }
                 let meta = fs::symlink_metadata(dst)?;
                 if opts.backup {
                     let backup_path = if let Some(ref dir) = opts.backup_dir {

--- a/crates/engine/tests/max_delete.rs
+++ b/crates/engine/tests/max_delete.rs
@@ -1,0 +1,89 @@
+// crates/engine/tests/max_delete.rs
+use std::fs;
+
+use compress::available_codecs;
+use engine::{sync, DeleteMode, SyncOptions};
+use filters::Matcher;
+use tempfile::tempdir;
+
+#[test]
+fn caps_extraneous_deletions() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(dst.join("extra.txt"), b"data").unwrap();
+
+    let opts = SyncOptions {
+        delete: Some(DeleteMode::Before),
+        max_delete: Some(0),
+        ..Default::default()
+    };
+    let err = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap_err();
+    assert!(format!("{}", err).contains("max-delete"));
+    assert!(dst.join("extra.txt").exists());
+
+    let opts = SyncOptions {
+        delete: Some(DeleteMode::Before),
+        max_delete: Some(1),
+        ..Default::default()
+    };
+    let stats = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
+    assert_eq!(stats.files_deleted, 1);
+    assert!(!dst.join("extra.txt").exists());
+}
+
+#[test]
+fn caps_missing_arg_deletions() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("missing.txt");
+    let dst = tmp.path().join("dst.txt");
+    fs::write(&dst, b"data").unwrap();
+
+    let opts = SyncOptions {
+        delete_missing_args: true,
+        max_delete: Some(0),
+        ..Default::default()
+    };
+    let err = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap_err();
+    assert!(format!("{}", err).contains("max-delete"));
+    assert!(dst.exists());
+
+    let opts = SyncOptions {
+        delete_missing_args: true,
+        max_delete: Some(1),
+        ..Default::default()
+    };
+    let stats = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &opts,
+    )
+    .unwrap();
+    assert_eq!(stats.files_deleted, 1);
+    assert!(!dst.exists());
+}


### PR DESCRIPTION
## Summary
- ensure sync respects `max_delete` when deleting missing args
- cover max-delete cap with tests for extraneous and missing sources

## Testing
- `cargo test -p engine`


------
https://chatgpt.com/codex/tasks/task_e_68b44c8f349c8323802fe6d0ca0e9cb9