### PR TITLE
Handle IO errors during deletions

### DIFF
--- a/crates/engine/tests/delete_errors.rs
+++ b/crates/engine/tests/delete_errors.rs
@@ -1,0 +1,60 @@
+// crates/engine/tests/delete_errors.rs
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process::Command;
+
+use compress::available_codecs;
+use engine::{sync, DeleteMode, SyncOptions};
+use filters::Matcher;
+use nix::unistd::{chown, Gid, Uid};
+use tempfile::tempdir;
+
+#[test]
+fn continues_deleting_after_io_errors() {
+    if env::var("ENGINE_DELETE_CHILD").is_ok() {
+        let src = PathBuf::from(env::var("SRC").unwrap());
+        let dst = PathBuf::from(env::var("DST").unwrap());
+        let res = sync(
+            &src,
+            &dst,
+            &Matcher::default(),
+            &available_codecs(None),
+            &SyncOptions {
+                delete: Some(DeleteMode::During),
+                ..Default::default()
+            },
+        );
+        std::process::exit(if res.is_err() { 1 } else { 0 });
+    }
+
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::set_permissions(&dst, fs::Permissions::from_mode(0o1777)).unwrap();
+    fs::create_dir_all(dst.join("a")).unwrap();
+    fs::create_dir_all(dst.join("b")).unwrap();
+    chown(
+        dst.join("b").as_path(),
+        Some(Uid::from_raw(65534)),
+        Some(Gid::from_raw(65534)),
+    )
+    .unwrap();
+
+    let status = Command::new(env::current_exe().unwrap())
+        .env("ENGINE_DELETE_CHILD", "1")
+        .env("SRC", &src)
+        .env("DST", &dst)
+        .uid(65534)
+        .gid(65534)
+        .status()
+        .unwrap();
+
+    assert!(!status.success());
+    assert!(dst.join("a").exists());
+    assert!(!dst.join("b").exists());
+}


### PR DESCRIPTION
## Summary
- Continue deleting files even when an IO error occurs and surface the first error afterward
- Add regression test covering partial deletion failures

## Testing
- `cargo test -p engine`
- `cargo test -p engine --test delete_errors -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b44bd8370883239a1c0f39f34295e4