### PR TITLE
Restore directory permissions in chmod test

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -605,6 +605,7 @@ fn perms_flag_preserves_permissions() {
 #[test]
 fn chmod_masks_file_type_bits() {
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
     let dst_dir = dir.path().join("dst");
@@ -621,6 +622,7 @@ fn chmod_masks_file_type_bits() {
         dst_dir.to_str().unwrap(),
     ]);
     cmd.assert().success();
+    fs::set_permissions(&dst_dir, fs::Permissions::from_mode(0o755)).unwrap();
 
     let mode = fs::metadata(dst_dir.join("a.txt"))
         .unwrap()


### PR DESCRIPTION
## Summary
- restore execute permissions on dst_dir after running `--chmod` integration test

## Testing
- `cargo test --test cli chmod_masks_file_type_bits`


------
https://chatgpt.com/codex/tasks/task_e_68b44de4e5dc8323858c698a678ad6c0