### PR TITLE
docs: document chown support

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -45,6 +45,10 @@ oc-rsync [OPTIONS] <SRC> <DEST>
   ```sh
   oc-rsync -B 65536 ./src remote:/dst
   ```
+- Change ownership during transfer (requires root):
+  ```sh
+  sudo oc-rsync --chown=0:0 ./src/ remote:/dst/
+  ```
 - Show version:
   ```sh
   oc-rsync --version

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -26,7 +26,7 @@ negotiates version 73.
 | `--checksum-choice` | — | ✅ | ✅ | [tests/golden/cli_parity/checksum-choice.sh](../tests/golden/cli_parity/checksum-choice.sh) | choose the strong hash algorithm | ≤3.2 |
 | `--checksum-seed` | — | ✅ | ✅ | [tests/checksum_seed.rs](../tests/checksum_seed.rs)<br>[tests/checksum_seed_cli.rs](../tests/checksum_seed_cli.rs) | set block/file checksum seed | ≤3.2 |
 | `--chmod` | — | ✅ | ✅ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/golden/cli_parity/chmod.sh](../tests/golden/cli_parity/chmod.sh) |  | ≤3.2 |
-| `--chown` | — | ❌ | — | — |  | ≤3.2 |
+| `--chown` | — | ✅ | ❌ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | requires root or CAP_CHOWN | ≤3.2 |
 | `--compare-dest` | — | ✅ | ✅ | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) |  | ≤3.2 |
 | `--compress` | `-z` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/compression_negotiation.sh](../tests/compression_negotiation.sh) | negotiates zstd when supported by both peers | ≤3.2 |
 | `--compress-choice` | — | ✅ | ✅ | [tests/golden/cli_parity/compress-choice.sh](../tests/golden/cli_parity/compress-choice.sh) | supports zstd and zlib only | ≤3.2 |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -19,7 +19,6 @@ This document tracks outstanding gaps in `oc-rsync` compared to the reference `r
 ## Metadata gaps
 - `--acls` — ACL support requires optional feature and lacks parity. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) [feature_matrix](feature_matrix.md#L9)
 - `--atimes` — access time preservation incomplete. [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) [feature_matrix](feature_matrix.md#L14)
- - `--chown` — not implemented. [feature_matrix](feature_matrix.md#L25) ([TODO](#testing-gaps))
  - `--copy-devices` — not implemented. [feature_matrix](feature_matrix.md#L35) ([TODO](#testing-gaps))
  - `--devices` — device file handling lacks parity. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [feature_matrix](feature_matrix.md#L52)
  - `--groupmap` — numeric gid mapping only; group names unsupported and requires root or CAP_CHOWN. [tests/cli.rs](../tests/cli.rs) [feature_matrix](feature_matrix.md#L74)


### PR DESCRIPTION
## Summary
- mark `--chown` as implemented with test link
- drop `--chown` from gap list
- add `--chown` usage example to CLI docs

## Testing
- `cargo test`
- `cargo test --test filter_corpus` *(fails: directory trees differ)*

------
https://chatgpt.com/codex/tasks/task_e_68b44f6494c08323b99700f90899764e