### PR TITLE
ci: run tests on macOS and Linux arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,26 +18,35 @@ on:
 jobs:
   test:
     name: Build & Test
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
+            runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: false
           - os: ubuntu-latest
+            runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             use-cross: true
           - os: ubuntu-latest
+            runner: ubuntu-latest
             target: armv7-unknown-linux-gnueabihf
             use-cross: true
           - os: ubuntu-latest
+            runner: ubuntu-latest
             target: x86_64-unknown-freebsd
             use-cross: true
           - os: macos-latest
+            runner: macos-latest
             use-cross: false
           - os: windows-latest
+            runner: windows-latest
+            use-cross: false
+          - os: ubuntu-latest
+            runner: [ubuntu-latest, ARM64]
             use-cross: false
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- run CI job on hosted macOS and Linux arm64 runners

## Testing
- `cargo fmt --all --check`
- `cargo test --workspace --lib --features blake3`


------
https://chatgpt.com/codex/tasks/task_e_68b45a013ab08323ae7a0cf419d182e4