### PR TITLE
Respect explicit prefixes in per-dir sign rules

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -493,13 +493,11 @@ impl Matcher {
                         buf.push_str("!\n");
                         continue;
                     }
-                    let pat = if matches!(
-                        line.chars().next(),
-                        Some('+' | '-' | 'P' | 'p' | 'S' | 'H' | 'R')
-                    ) {
-                        line[1..].trim_start()
-                    } else {
-                        line
+                    let (prefix, pat) = match line.chars().next() {
+                        Some(c @ ('+' | '-' | 'P' | 'p' | 'S' | 'H' | 'R')) => {
+                            (Some(c), line[1..].trim_start())
+                        }
+                        _ => (None, line),
                     };
                     let new_pat = if let Some(rel_str) = &rel_str {
                         if pat.starts_with('/') {
@@ -510,7 +508,7 @@ impl Matcher {
                     } else {
                         pat.to_string()
                     };
-                    buf.push(ch);
+                    buf.push(prefix.unwrap_or(ch));
                     buf.push(' ');
                     buf.push_str(&new_pat);
                     buf.push('\n');

--- a/tests/filter_corpus.rs
+++ b/tests/filter_corpus.rs
@@ -211,4 +211,12 @@ fn perdir_sign_parity() {
         .output()
         .unwrap();
     assert!(diff.status.success(), "directory trees differ");
+
+    assert!(ours_dst.join("sub/keep.tmp").exists());
+    assert!(!ours_dst.join("sub/other.tmp").exists());
+    assert!(ours_dst.join("sub/nested/keep.tmp").exists());
+    assert!(!ours_dst.join("sub/nested/other.tmp").exists());
+    assert!(!ours_dst.join(".rsync-filter").exists());
+    assert!(!ours_dst.join("sub/.rsync-filter").exists());
+    assert!(!ours_dst.join("sub/nested/.rsync-filter").exists());
 }


### PR DESCRIPTION
## Summary
- Adjust per-directory merge logic to preserve explicit rule prefixes when a default sign is provided
- Strengthen perdir sign corpus test with file-presence assertions

## Testing
- `cargo test --test filter_corpus` *(fails: directory trees differ)*

------
https://chatgpt.com/codex/tasks/task_e_68b4531c5efc8323bc6c0d67f8d4ec16