### PR TITLE
Create destination directory in sync_local test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let src_dir = dir.path().join("src");
         let dst_dir = dir.path().join("dst");
+        fs::create_dir_all(&dst_dir).unwrap();
         fs::create_dir_all(&src_dir).unwrap();
         fs::File::create(src_dir.join("file.txt"))
             .unwrap()


### PR DESCRIPTION
## Summary
- ensure sync_local test creates the destination directory before calling synchronize

## Testing
- `cargo test -p oc-rsync sync_local -- --nocapture` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b45c6f92d083239bd360a89b7cb238