### PR TITLE
Fix unclosed match block in filters parser

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -511,18 +511,9 @@ impl Matcher {
                         buf.push_str("!\n");
                         continue;
                     }
-                    let (prefix, pat) = match line.chars().next() {
-                        Some(c @ ('+' | '-' | 'P' | 'p' | 'S' | 'H' | 'R')) => {
-                            (Some(c), line[1..].trim_start())
-                        }
+                    let (prefix, rest) = match line.chars().next() {
+                        Some(c @ ('+' | '-' | 'P' | 'p' | 'S' | 'H' | 'R')) => (Some(c), &line[1..]),
                         _ => (None, line),
-                    let rest = if matches!(
-                        line.chars().next(),
-                        Some('+' | '-' | 'P' | 'p' | 'S' | 'H' | 'R')
-                    ) {
-                        &line[1..]
-                    } else {
-                        line
                     };
                     let (mods, pat) = split_mods(rest);
                     let new_pat = if let Some(rel_str) = &rel_str {


### PR DESCRIPTION
## Summary
- close the missing `match` block when parsing rules
- simplify rule parsing by splitting modifiers from remaining pattern correctly

## Testing
- `cargo test` *(fails: tests::sync_local panicked at src/lib.rs:36:54: No such file or directory)*
- `cargo test -p filters`


------
https://chatgpt.com/codex/tasks/task_e_68b45eb56e588323a762b21367be1d7f