### PR TITLE
Ensure destination directory exists for sync

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1446,6 +1446,18 @@ pub fn sync(
         return Ok(stats);
     }
 
+    if !dst.exists() {
+        fs::create_dir_all(dst).map_err(|e| {
+            std::io::Error::new(
+                e.kind(),
+                format!(
+                    "failed to create destination directory {}: {e}",
+                    dst.display()
+                ),
+            )
+        })?;
+    }
+
     let codec = select_codec(remote, opts);
     let matcher = matcher.clone().with_root(src_root.clone());
     let mut sender = Sender::new(opts.block_size, matcher.clone(), codec, opts.clone());

--- a/crates/engine/tests/create_dst.rs
+++ b/crates/engine/tests/create_dst.rs
@@ -1,0 +1,27 @@
+// crates/engine/tests/create_dst.rs
+use std::fs;
+
+use compress::available_codecs;
+use engine::{sync, SyncOptions};
+use filters::Matcher;
+use tempfile::tempdir;
+
+#[test]
+fn creates_destination_when_missing() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("file.txt"), b"hi").unwrap();
+    assert!(!dst.exists());
+    sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(None),
+        &SyncOptions::default(),
+    )
+    .unwrap();
+    assert!(dst.exists());
+    assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"hi");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ mod tests {
             .unwrap()
             .write_all(b"hello world")
             .unwrap();
+        assert!(!dst_dir.exists());
         synchronize(&src_dir, &dst_dir).unwrap();
+        assert!(dst_dir.exists());
         let out = fs::read(dst_dir.join("file.txt")).unwrap();
         assert_eq!(out, b"hello world");
     }


### PR DESCRIPTION
## Summary
- Create destination directory in sync when missing, with error context
- Extend sync_local test to verify destination creation
- Add test ensuring engine::sync creates absent destination

## Testing
- `cargo test -p engine` *(fails: this file contains an unclosed delimiter in crates/filters/src/lib.rs)*
- `cargo test -p oc-rsync` *(fails: this file contains an unclosed delimiter in crates/filters/src/lib.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b45def1aec83238af2dc6584e6cac9