### PR TITLE
Add resume and progress interop scenarios

### DIFF
--- a/tests/interop/run_matrix.sh
+++ b/tests/interop/run_matrix.sh
@@ -28,6 +28,7 @@ SCENARIOS=(
   "remote_remote"
   "append --append"
   "append_verify --append-verify"
+  "resume --partial"
   "progress --progress"
 )
 
@@ -223,6 +224,10 @@ for c in "${CLIENT_VERSIONS[@]}"; do
             if [[ "$name" == drop_connection ]]; then
               dd if=/dev/zero of="$src/big.bin" bs=1M count=20 >/dev/null 2>&1
               timeout 1 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" -e "$ssh" "$src/" "root@localhost:$tmpdir" >/dev/null || true
+            elif [[ "$name" == resume ]]; then
+              dd if=/dev/zero of="$src/big.bin" bs=1M count=20 >/dev/null 2>&1
+              timeout 1 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" -e "$ssh" "$src/" "root@localhost:$tmpdir" >/dev/null || true
+              "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" -e "$ssh" "$src/" "root@localhost:$tmpdir" >/dev/null
             elif [[ "$name" == vanished ]]; then
               (sleep 0.1 && rm -f "$src/file.txt") &
               "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" -e "$ssh" "$src/" "root@localhost:$tmpdir" >/dev/null || true
@@ -265,6 +270,10 @@ for c in "${CLIENT_VERSIONS[@]}"; do
               if [[ "$name" == drop_connection ]]; then
                 dd if=/dev/zero of="$src/big.bin" bs=1M count=20 >/dev/null 2>&1
                 timeout 1 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" "$src/" "rsync://localhost:$port/mod" >/dev/null || true
+              elif [[ "$name" == resume ]]; then
+                dd if=/dev/zero of="$src/big.bin" bs=1M count=20 >/dev/null 2>&1
+                timeout 1 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" "$src/" "rsync://localhost:$port/mod" >/dev/null || true
+                "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" "$src/" "rsync://localhost:$port/mod" >/dev/null
               elif [[ "$name" == vanished ]]; then
                 (sleep 0.1 && rm -f "$src/file.txt") &
                 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" "$src/" "rsync://localhost:$port/mod" >/dev/null || true


### PR DESCRIPTION
## Summary
- exercise resume with `--partial` and re-run to completion in interop test matrix
- include progress flag in scenario matrix

## Testing
- `bash -n tests/interop/run_matrix.sh`
- `bash /tmp/run_matrix_min.sh` *(fails: mismatched types in crates/engine/src/lib.rs:1359: expected Error, found EngineError)*
- `cargo test` *(fails: mismatched types in crates/engine/src/lib.rs:1359: expected Error, found EngineError)*

------
https://chatgpt.com/codex/tasks/task_e_68b460aa97088323bcc25d47b70a60df