### PR TITLE
Handle EngineError in delete_extraneous

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1306,7 +1306,10 @@ fn delete_extraneous(
 ) -> Result<()> {
     let mut walker = walk(dst, 1024);
     let mut state = String::new();
-    let mut first_err: Option<std::io::Error> = None;
+    // Track the first I/O error encountered while deleting extraneous files.
+    // Errors are stored as `EngineError` so we can preserve contextual
+    // information added by `io_context` above.
+    let mut first_err: Option<EngineError> = None;
     while let Some(batch) = walker.next() {
         let batch = batch.map_err(|e| EngineError::Other(e.to_string()))?;
         for entry in batch {
@@ -1365,7 +1368,7 @@ fn delete_extraneous(
         }
     }
     if let Some(e) = first_err {
-        Err(e.into())
+        Err(e)
     } else {
         Ok(())
     }


### PR DESCRIPTION
## Summary
- track first delete error as `EngineError`
- return stored `EngineError` directly

## Testing
- `cargo test` *(fails: tests::sync_local panicked)*

------
https://chatgpt.com/codex/tasks/task_e_68b46185a62083238bbcb1d50aa65b95