### PR TITLE
Silence unused variables in filters and engine

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -5,11 +5,10 @@ use std::any::Any;
 use std::collections::{HashMap, VecDeque};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
+#[cfg(all(unix, any(target_os = "linux", target_os = "android")))]
+use std::os::fd::AsRawFd;
 #[cfg(unix)]
-use std::os::unix::{
-    fs::{FileTypeExt, MetadataExt},
-    io::AsRawFd,
-};
+use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -511,8 +511,10 @@ impl Matcher {
                         buf.push_str("!\n");
                         continue;
                     }
-                    let (prefix, rest) = match line.chars().next() {
-                        Some(c @ ('+' | '-' | 'P' | 'p' | 'S' | 'H' | 'R')) => (Some(c), &line[1..]),
+                    let (prefix, _rest) = match line.chars().next() {
+                        Some(c @ ('+' | '-' | 'P' | 'p' | 'S' | 'H' | 'R')) => {
+                            (Some(c), &line[1..])
+                        }
                         _ => (None, line),
                     };
                     let rest = if matches!(


### PR DESCRIPTION
## Summary
- rename unused `rest` binding in filters matcher to `_rest`
- gate `AsRawFd` import for linux/android to avoid unused import warnings

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_68b463f7233083238580f246a1e2f58e