### PR TITLE
Create destination dir in sync_local test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ mod tests {
             .unwrap()
             .write_all(b"hello world")
             .unwrap();
+        fs::create_dir_all(&dst_dir).unwrap();
         assert!(dst_dir.exists());
         synchronize(&src_dir, &dst_dir).unwrap();
         assert!(dst_dir.exists());


### PR DESCRIPTION
## Summary
- ensure sync_local test creates destination directory before syncing

## Testing
- `cargo test -p oc-rsync --lib`
- `cargo test` *(fails: `cdc_skips_renamed_file`)*

------
https://chatgpt.com/codex/tasks/task_e_68b467e7771483238581d50c80e7400e