### PR TITLE
Add cargo helper targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,22 @@
-.PHONY: verify-comments lint coverage interop test-golden
+.PHONY: verify-comments lint coverage interop test-golden fmt clippy doc test
 
 verify-comments:
 	bash scripts/check-comments.sh
 
 lint:
-	cargo fmt --all --check
+        cargo fmt --all --check
+
+fmt:
+	cargo fmt --all
+
+clippy:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+doc:
+	cargo doc --no-deps --all-features
+
+test:
+	cargo test --all-features
 
 coverage:
        cargo llvm-cov --workspace --features blake3 --doctests \

--- a/README.md
+++ b/README.md
@@ -103,7 +103,18 @@ cargo run -p oc-rsync-bin -- <args>
 Run the full test suite with:
 
 ```
-cargo test
+make test
+```
+
+## Development
+
+The Makefile offers shortcuts for common tasks:
+
+```
+make fmt    # Format the code
+make clippy # Run Clippy lints
+make doc    # Build documentation
+make test   # Run the test suite
 ```
 
 ## Fuzzing


### PR DESCRIPTION
## Summary
- add fmt, clippy, doc, and test targets to Makefile
- document new Makefile shortcuts in README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: collapsible-else-if, unnecessary-cast, manual-pattern-char-comparison, needless-borrows-for-generic-args)*
- `cargo doc --no-deps --all-features`
- `cargo test --all-features` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68b4684d717883239d8403ef4818a42d