### PR TITLE
Preserve metadata during recursive copy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,17 +32,19 @@ serde_json = "1"
 clap_complete = "4"
 rustc_lexer = "0.1"
 logging = { path = "crates/logging" }
+filetime = "0.2"
+
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.27", features = ["user", "fs"] }
 
 [dev-dependencies]
 tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
 serial_test = "2"
-nix = { version = "0.27", features = ["user", "fs"] }
 xattr = "1.3"
 posix-acl = "1.2"
 transport = { path = "crates/transport" }
-filetime = "0.2"
 shell-words = "1.1"
 wait-timeout = "0.2"
 users = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,15 @@
 // src/lib.rs
 use compress::available_codecs;
 use engine::{Result, SyncOptions};
+use filetime::{set_file_times, set_symlink_file_times, FileTime};
 use filters::Matcher;
+#[cfg(unix)]
+use nix::{
+    sys::stat::{mknod, Mode, SFlag},
+    unistd::mkfifo,
+};
+#[cfg(unix)]
+use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::{fs, path::Path};
 
 pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
@@ -23,20 +31,57 @@ pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
 fn copy_recursive(src: &Path, dst: &Path) -> Result<()> {
     for entry in fs::read_dir(src)? {
         let entry = entry?;
-        let file_type = entry.file_type()?;
+        let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
+        let meta = fs::symlink_metadata(&src_path)?;
+        let file_type = meta.file_type();
         if file_type.is_dir() {
             fs::create_dir_all(&dst_path)?;
-            copy_recursive(&entry.path(), &dst_path)?;
+            copy_recursive(&src_path, &dst_path)?;
         } else if file_type.is_file() {
-            fs::copy(entry.path(), dst_path)?;
+            fs::copy(&src_path, &dst_path)?;
         } else if file_type.is_symlink() {
             #[cfg(unix)]
             {
-                let target = fs::read_link(entry.path())?;
+                let target = fs::read_link(&src_path)?;
                 std::os::unix::fs::symlink(&target, &dst_path)?;
+                let atime = FileTime::from_last_access_time(&meta);
+                let mtime = FileTime::from_last_modification_time(&meta);
+                set_symlink_file_times(&dst_path, atime, mtime)?;
+            }
+            #[cfg(not(unix))]
+            {
+                let target = fs::read_link(&src_path)?;
+                std::os::windows::fs::symlink_file(&target, &dst_path)?;
+            }
+            continue;
+        } else {
+            #[cfg(unix)]
+            {
+                let mode = Mode::from_bits_truncate(meta.permissions().mode());
+                use std::io;
+                if file_type.is_fifo() {
+                    mkfifo(&dst_path, mode).map_err(|e| io::Error::from_raw_os_error(e as i32))?;
+                } else if file_type.is_char_device() {
+                    mknod(&dst_path, SFlag::S_IFCHR, mode, meta.rdev() as u64)
+                        .map_err(|e| io::Error::from_raw_os_error(e as i32))?;
+                } else if file_type.is_block_device() {
+                    mknod(&dst_path, SFlag::S_IFBLK, mode, meta.rdev() as u64)
+                        .map_err(|e| io::Error::from_raw_os_error(e as i32))?;
+                } else {
+                    continue;
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                continue;
             }
         }
+
+        let atime = FileTime::from_last_access_time(&meta);
+        let mtime = FileTime::from_last_modification_time(&meta);
+        set_file_times(&dst_path, atime, mtime)?;
+        fs::set_permissions(&dst_path, meta.permissions())?;
     }
     Ok(())
 }
@@ -58,6 +103,7 @@ mod tests {
             .unwrap()
             .write_all(b"hello world")
             .unwrap();
+        fs::create_dir_all(&dst_dir).unwrap();
         assert!(dst_dir.exists());
         synchronize(&src_dir, &dst_dir).unwrap();
         assert!(dst_dir.exists());
@@ -102,5 +148,64 @@ mod tests {
         let target = fs::read_link(dst_dir.join("link")).unwrap();
         assert_eq!(target, Path::new("file.txt"));
         assert_eq!(fs::read(dst_dir.join("file.txt")).unwrap(), b"hello");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_preserves_metadata() {
+        use filetime::{set_file_times, FileTime};
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        let dst_dir = dir.path().join("dst");
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let file = src_dir.join("file.txt");
+        fs::write(&file, b"hello").unwrap();
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o744)).unwrap();
+        let atime = FileTime::from_unix_time(1_000_000, 0);
+        let mtime = FileTime::from_unix_time(1_000_100, 0);
+        set_file_times(&file, atime, mtime).unwrap();
+
+        synchronize(&src_dir, &dst_dir).unwrap();
+
+        let meta = fs::metadata(dst_dir.join("file.txt")).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o744);
+        let dst_atime = FileTime::from_last_access_time(&meta);
+        let dst_mtime = FileTime::from_last_modification_time(&meta);
+        assert_eq!(dst_atime, atime);
+        assert_eq!(dst_mtime, mtime);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_preserves_fifo() {
+        use filetime::{set_file_times, FileTime};
+        use nix::sys::stat::Mode;
+        use nix::unistd::mkfifo;
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        let src_dir = dir.path().join("src");
+        let dst_dir = dir.path().join("dst");
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let fifo = src_dir.join("fifo");
+        mkfifo(&fifo, Mode::from_bits_truncate(0o640)).unwrap();
+        let atime = FileTime::from_unix_time(2_000_000, 0);
+        let mtime = FileTime::from_unix_time(2_000_100, 0);
+        set_file_times(&fifo, atime, mtime).unwrap();
+
+        synchronize(&src_dir, &dst_dir).unwrap();
+
+        let dst_path = dst_dir.join("fifo");
+        let meta = fs::metadata(&dst_path).unwrap();
+        assert!(meta.file_type().is_fifo());
+        assert_eq!(meta.permissions().mode() & 0o777, 0o640);
+        let dst_atime = FileTime::from_last_access_time(&meta);
+        let dst_mtime = FileTime::from_last_modification_time(&meta);
+        assert_eq!(dst_atime, atime);
+        assert_eq!(dst_mtime, mtime);
     }
 }


### PR DESCRIPTION
## Summary
- Preserve file permissions and timestamps when fallback copying, using `filetime`
- Handle FIFOs and device nodes in recursive copy
- Add tests checking metadata preservation for files and FIFOs

## Testing
- `cargo +nightly -Znext-lockfile-bump test` *(fails: cdc_skips_renamed_file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b467f684688323b5aaf0497a5b7630