### PR TITLE
Add tests for unreadable paths in copy_recursive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
 serial_test = "2"
-nix = { version = "0.27", features = ["user", "fs"] }
+nix = { version = "0.27", features = ["user", "fs", "process"] }
 xattr = "1.3"
 posix-acl = "1.2"
 transport = { path = "crates/transport" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 // src/lib.rs
 use compress::available_codecs;
-use engine::{Result, SyncOptions};
+use engine::{EngineError, Result, SyncOptions};
 use filters::Matcher;
-use std::{fs, path::Path};
+use std::{fs, io, path::Path};
 
 pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
     if !dst.exists() {
@@ -20,21 +20,30 @@ pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
+fn io_context(path: &Path, err: io::Error) -> EngineError {
+    EngineError::Io(io::Error::new(
+        err.kind(),
+        format!("{}: {}", path.display(), err),
+    ))
+}
+
 fn copy_recursive(src: &Path, dst: &Path) -> Result<()> {
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let file_type = entry.file_type()?;
+    for entry in fs::read_dir(src).map_err(|e| io_context(src, e))? {
+        let entry = entry.map_err(|e| io_context(src, e))?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|e| io_context(&path, e))?;
         let dst_path = dst.join(entry.file_name());
         if file_type.is_dir() {
-            fs::create_dir_all(&dst_path)?;
-            copy_recursive(&entry.path(), &dst_path)?;
+            fs::create_dir_all(&dst_path).map_err(|e| io_context(&dst_path, e))?;
+            copy_recursive(&path, &dst_path)?;
         } else if file_type.is_file() {
-            fs::copy(entry.path(), dst_path)?;
+            fs::copy(&path, &dst_path).map_err(|e| io_context(&path, e))?;
         } else if file_type.is_symlink() {
             #[cfg(unix)]
             {
-                let target = fs::read_link(entry.path())?;
-                std::os::unix::fs::symlink(&target, &dst_path)?;
+                let target = fs::read_link(&path).map_err(|e| io_context(&path, e))?;
+                std::os::unix::fs::symlink(&target, &dst_path)
+                    .map_err(|e| io_context(&dst_path, e))?;
             }
         }
     }
@@ -54,6 +63,7 @@ mod tests {
         let src_dir = dir.path().join("src");
         let dst_dir = dir.path().join("dst");
         fs::create_dir_all(&src_dir).unwrap();
+        fs::create_dir_all(&dst_dir).unwrap();
         fs::File::create(src_dir.join("file.txt"))
             .unwrap()
             .write_all(b"hello world")
@@ -102,5 +112,83 @@ mod tests {
         let target = fs::read_link(dst_dir.join("link")).unwrap();
         assert_eq!(target, Path::new("file.txt"));
         assert_eq!(fs::read(dst_dir.join("file.txt")).unwrap(), b"hello");
+    }
+
+    #[cfg(unix)]
+    fn run_copy_unprivileged(src: &Path, dst: &Path) -> (i32, String) {
+        use nix::sys::wait::{waitpid, WaitStatus};
+        use nix::unistd::{fork, setuid, ForkResult, Uid};
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixStream;
+
+        let (mut parent_sock, mut child_sock) = UnixStream::pair().unwrap();
+        match unsafe { fork() }.expect("fork failed") {
+            ForkResult::Child => {
+                drop(parent_sock);
+                setuid(Uid::from_raw(1)).unwrap();
+                let res = copy_recursive(src, dst);
+                let msg = match &res {
+                    Ok(_) => "ok".to_string(),
+                    Err(e) => e.to_string(),
+                };
+                child_sock.write_all(msg.as_bytes()).unwrap();
+                std::process::exit(if res.is_err() { 0 } else { 1 });
+            }
+            ForkResult::Parent { child } => {
+                drop(child_sock);
+                let mut msg = String::new();
+                parent_sock.read_to_string(&mut msg).unwrap();
+                let status = waitpid(child, None).unwrap();
+                let code = match status {
+                    WaitStatus::Exited(_, c) => c,
+                    _ => -1,
+                };
+                (code, msg)
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_recursive_unreadable_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+        let src_dir = dir.path().join("src");
+        let dst_dir = dir.path().join("dst");
+        fs::create_dir_all(&src_dir).unwrap();
+        fs::create_dir_all(&dst_dir).unwrap();
+        fs::set_permissions(&dst_dir, fs::Permissions::from_mode(0o777)).unwrap();
+
+        let file_path = src_dir.join("file.txt");
+        fs::write(&file_path, b"data").unwrap();
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let (code, msg) = run_copy_unprivileged(&src_dir, &dst_dir);
+        assert_eq!(code, 0);
+        assert!(msg.contains("Permission denied"));
+        assert!(msg.contains("file.txt"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copy_recursive_unreadable_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().unwrap();
+        fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o755)).unwrap();
+        let src_dir = dir.path().join("src");
+        let dst_dir = dir.path().join("dst");
+        let subdir = src_dir.join("sub");
+        fs::create_dir_all(&subdir).unwrap();
+        fs::create_dir_all(&dst_dir).unwrap();
+        fs::set_permissions(&dst_dir, fs::Permissions::from_mode(0o777)).unwrap();
+        fs::set_permissions(&subdir, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let (code, msg) = run_copy_unprivileged(&src_dir, &dst_dir);
+        assert_eq!(code, 0);
+        assert!(msg.contains("Permission denied"));
+        assert!(msg.contains("sub"));
     }
 }


### PR DESCRIPTION
## Summary
- improve copy_recursive error context
- test permission errors for unreadable files and directories

## Testing
- `cargo test --lib copy_recursive_unreadable -- --nocapture`
- `cargo test --lib --tests --quiet` *(fails: cdc_skips_renamed_file)*
- `cargo test --all --quiet` *(fails: tests::sync_dir)*

------
https://chatgpt.com/codex/tasks/task_e_68b4681e030c8323a63f276bc4d027f5