### PR TITLE
feat: configurable logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "serial_test",
  "shell-words",
  "tempfile",
+ "tracing",
  "transport",
  "users",
  "wait-timeout",
@@ -949,6 +950,7 @@ dependencies = [
  "protocol",
  "shell-words",
  "tempfile",
+ "tracing",
  "transport",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1"
 clap_complete = "4"
 rustc_lexer = "0.1"
 logging = { path = "crates/logging" }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Quick links:
 - [Flags](docs/cli.md#flags)
 - [Configuration precedence](docs/cli.md#configuration-precedence)
 
+### Logging
+
+Enable structured JSON logs on the command line with `--log-format json`. Library
+callers can configure logging by building a [`SyncConfig`] with
+`log_format: LogFormat::Json` and passing it to [`synchronize`].
+
 ## Architecture
 See [docs/architecture.md](docs/architecture.md) for a deeper overview of crate
 boundaries, data flow, and key algorithms.

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -8,11 +8,25 @@ fn main() -> Result<()> {
     let mut verbose = 0u8;
     let mut info = false;
     let mut debug = false;
-    for arg in &args {
+    let mut log_format = LogFormat::Text;
+    let mut iter = args.iter().peekable();
+    while let Some(arg) = iter.next() {
         if arg == "--info" || arg.starts_with("--info=") {
             info = true;
         } else if arg == "--debug" || arg.starts_with("--debug=") {
             debug = true;
+        } else if arg == "--log-format" {
+            if let Some(next) = iter.peek() {
+                if next.as_str() == "json" {
+                    log_format = LogFormat::Json;
+                }
+            }
+        } else if let Some(f) = arg.strip_prefix("--log-format=") {
+            if f == "json" {
+                log_format = LogFormat::Json;
+            }
+        } else if arg == "--verbose" {
+            verbose += 1;
         } else if arg.starts_with('-') && !arg.starts_with("--") {
             for ch in arg.chars().skip(1) {
                 if ch == 'v' {
@@ -21,6 +35,6 @@ fn main() -> Result<()> {
             }
         }
     }
-    logging::init(LogFormat::Text, verbose, info, debug);
+    logging::init(log_format, verbose, info, debug);
     oc_rsync_cli::run()
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ shell-words = "1.1"
 meta = { path = "../meta", default-features = false }
 daemon = { path = "../daemon" }
 logging = { path = "../logging" }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -114,6 +114,8 @@ struct ClientOpts {
     ignore_times: bool,
     #[arg(short, long, action = ArgAction::Count, help_heading = "Output")]
     verbose: u8,
+    #[arg(long = "log-format", help_heading = "Output", value_parser = ["text", "json"])]
+    log_format: Option<String>,
     #[arg(long = "human-readable", help_heading = "Output")]
     human_readable: bool,
     #[arg(short, long, help_heading = "Output")]
@@ -842,7 +844,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         }
     }
     if opts.verbose > 0 && !opts.quiet {
-        println!("verbose level set to {}", opts.verbose);
+        tracing::info!("verbose level set to {}", opts.verbose);
     }
     if opts.recursive && !opts.quiet {
         println!("recursive mode enabled");

--- a/crates/logging/tests/levels.rs
+++ b/crates/logging/tests/levels.rs
@@ -41,3 +41,11 @@ fn info_flag_enables_info() {
         assert!(tracing::enabled!(Level::INFO));
     });
 }
+
+#[test]
+fn json_verbose_enables_info() {
+    let sub = subscriber(LogFormat::Json, 1, false, false);
+    with_default(sub, || {
+        assert!(tracing::enabled!(Level::INFO));
+    });
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,18 +37,22 @@ oc-rsync [OPTIONS] <SRC> <DEST>
   ```sh
   oc-rsync -a --link-dest=../prev --compare-dest=../base ./src/ ./snapshot/
   ```
-- Throttled modern compression:
-  ```sh
-  oc-rsync -az --modern --bwlimit=1m ./src/ host:/archive/
-  ```
-- Tune delta block size:
-  ```sh
-  oc-rsync -B 65536 ./src remote:/dst
-  ```
-- Change ownership during transfer (requires root):
-  ```sh
-  sudo oc-rsync --chown=0:0 ./src/ remote:/dst/
-  ```
+  - Throttled modern compression:
+    ```sh
+    oc-rsync -az --modern --bwlimit=1m ./src/ host:/archive/
+    ```
+  - Tune delta block size:
+    ```sh
+    oc-rsync -B 65536 ./src remote:/dst
+    ```
+  - Emit JSON-formatted logs:
+    ```sh
+    oc-rsync --log-format json -v ./src ./dst
+    ```
+  - Change ownership during transfer (requires root):
+    ```sh
+    sudo oc-rsync --chown=0:0 ./src/ remote:/dst/
+    ```
 - Show version:
   ```sh
   oc-rsync --version

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -131,6 +131,7 @@
 |  | --list-only | list the files instead of copying them | no |  | no |
 |  | --log-file-format=FMT | log updates using the specified FMT | no |  | no |
 |  | --log-file=FILE | log what we're doing to the specified FILE | no |  | no |
+|  | --log-format=FMT | set log output format (text or json) | yes | default text | yes |
 |  | --no-motd | suppress daemon-mode MOTD | no |  | no |
 |  | --out-format=FORMAT | output updates using the specified FORMAT | no |  | no |
 |  | --progress | show progress during transfer | yes |  | no |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,22 +2,59 @@
 use compress::available_codecs;
 use engine::{Result, SyncOptions};
 use filters::Matcher;
+use logging::{subscriber, LogFormat};
 use std::{fs, path::Path};
+use tracing::subscriber::with_default;
 
-pub fn synchronize(src: &Path, dst: &Path) -> Result<()> {
-    if !dst.exists() {
-        fs::create_dir_all(dst)?;
+/// Configuration for [`synchronize`].
+///
+/// `log_format` controls whether logs are human-readable text or JSON.
+/// Adjust the verbosity with `verbose`, `info`, or `debug`.
+///
+/// # Examples
+/// ```no_run
+/// use logging::LogFormat;
+/// use oc_rsync::{synchronize, SyncConfig};
+/// use std::path::Path;
+///
+/// let cfg = SyncConfig { log_format: LogFormat::Json, verbose: 1, ..Default::default() };
+/// synchronize(Path::new("src"), Path::new("dst"), &cfg).unwrap();
+/// ```
+#[derive(Clone)]
+pub struct SyncConfig {
+    pub log_format: LogFormat,
+    pub verbose: u8,
+    pub info: bool,
+    pub debug: bool,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            log_format: LogFormat::Text,
+            verbose: 0,
+            info: false,
+            debug: false,
+        }
     }
-    engine::sync(
-        src,
-        dst,
-        &Matcher::default(),
-        &available_codecs(None),
-        &SyncOptions::default(),
-    )?;
-    // Fall back to a simple copy for any files not handled by the engine
-    copy_recursive(src, dst)?;
-    Ok(())
+}
+pub fn synchronize(src: &Path, dst: &Path, cfg: &SyncConfig) -> Result<()> {
+    let sub = subscriber(cfg.log_format, cfg.verbose, cfg.info, cfg.debug);
+    with_default(sub, || -> Result<()> {
+        if !dst.exists() {
+            fs::create_dir_all(dst)?;
+        }
+        engine::sync(
+            src,
+            dst,
+            &Matcher::default(),
+            &available_codecs(None),
+            &SyncOptions::default(),
+        )?;
+        // Fall back to a simple copy for any files not handled by the engine
+        copy_recursive(src, dst)?;
+        Ok(())
+    })
 }
 
 fn copy_recursive(src: &Path, dst: &Path) -> Result<()> {
@@ -58,8 +95,8 @@ mod tests {
             .unwrap()
             .write_all(b"hello world")
             .unwrap();
-        assert!(dst_dir.exists());
-        synchronize(&src_dir, &dst_dir).unwrap();
+        assert!(!dst_dir.exists());
+        synchronize(&src_dir, &dst_dir, &SyncConfig::default()).unwrap();
         assert!(dst_dir.exists());
         let out = fs::read(dst_dir.join("file.txt")).unwrap();
         assert_eq!(out, b"hello world");
@@ -76,7 +113,7 @@ mod tests {
         // destination should not exist before sync
         assert!(!dst_dir.exists());
 
-        synchronize(&src_dir, &dst_dir).unwrap();
+        synchronize(&src_dir, &dst_dir, &SyncConfig::default()).unwrap();
 
         // destination directory and file should now exist
         assert!(dst_dir.exists());
@@ -95,7 +132,7 @@ mod tests {
         fs::write(src_dir.join("file.txt"), b"hello").unwrap();
         std::os::unix::fs::symlink("file.txt", src_dir.join("link")).unwrap();
 
-        synchronize(&src_dir, &dst_dir).unwrap();
+        synchronize(&src_dir, &dst_dir, &SyncConfig::default()).unwrap();
 
         let meta = fs::symlink_metadata(dst_dir.join("link")).unwrap();
         assert!(meta.file_type().is_symlink());

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -586,6 +586,27 @@ fn verbose_flag_increases_logging() {
 }
 
 #[test]
+fn log_format_json_outputs_structured_logs() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([
+        "--local",
+        "--log-format=json",
+        "--verbose",
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().success().stdout(predicates::str::contains(
+        "\"message\":\"verbose level set to 1\"",
+    ));
+}
+
+#[test]
 fn quiet_flag_suppresses_output() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");


### PR DESCRIPTION
## Summary
- allow configuring log format and verbosity via `SyncConfig`
- add `--log-format` flag to CLI
- document how to enable JSON logging

## Testing
- `cargo test -p logging`
- `cargo test --test cli log_format_json_outputs_structured_logs -- --nocapture`
- `cargo test` *(fails: cdc_skips_renamed_file)*

------
https://chatgpt.com/codex/tasks/task_e_68b46816d15c8323bf4b4b5f4d7c1679