### PR TITLE
Consolidate std imports in lib tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,8 +175,6 @@ fn copy_recursive(src: &Path, dst: &Path) -> Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use std::path::Path;
     use tempfile::{tempdir, TempDir};
 
     fn setup_dirs() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {


### PR DESCRIPTION
## Summary
- streamline standard library imports in lib tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: collapsible else if, unnecessary casts, manual pattern char comparison, needless borrows)*
- `cargo test` *(fails: 27 passed; 33 failed)*
- `make verify-comments` *(fails: missing separator)*
- `make lint` *(fails: missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b47402c4488323a9dc08c810f20b4a