### PR TITLE
Document matcher behavior and verify include/exclude order

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1604,6 +1604,11 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
+/// Build a [`Matcher`] from the user's CLI filter flags.
+///
+/// This interprets options like `--exclude`, `--include`, `--files-from`,
+/// and their variants, preserving the order in which the flags were
+/// provided so that rule precedence matches rsync's semantics.
 fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
     fn load_patterns(path: &Path, from0: bool) -> io::Result<Vec<String>> {
         if from0 {

--- a/crates/meta/src/parse.rs
+++ b/crates/meta/src/parse.rs
@@ -30,7 +30,7 @@ pub fn parse_chmod_spec(spec: &str) -> StdResult<Chmod, String> {
         });
     }
 
-    let (op_pos, op_char) = match rest.find(|c| c == '+' || c == '-' || c == '=') {
+    let (op_pos, op_char) = match rest.find(|c| ['+', '-', '='].contains(&c)) {
         Some(p) => (p, rest.as_bytes()[p] as char),
         None => {
             if let Some(ch) = rest.chars().find(|c| !matches!(*c, 'u' | 'g' | 'o' | 'a')) {

--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -284,20 +284,18 @@ impl Metadata {
                 } else if opts.times && !skip_mtime {
                     filetime::set_symlink_file_times(path, cur_atime, self.mtime)?;
                 }
-            } else {
-                if opts.atimes {
-                    if let Some(atime) = self.atime {
-                        if skip_mtime {
-                            filetime::set_file_atime(path, atime)?;
-                        } else {
-                            filetime::set_file_times(path, atime, self.mtime)?;
-                        }
-                    } else if opts.times && !skip_mtime {
-                        filetime::set_file_mtime(path, self.mtime)?;
+            } else if opts.atimes {
+                if let Some(atime) = self.atime {
+                    if skip_mtime {
+                        filetime::set_file_atime(path, atime)?;
+                    } else {
+                        filetime::set_file_times(path, atime, self.mtime)?;
                     }
                 } else if opts.times && !skip_mtime {
                     filetime::set_file_mtime(path, self.mtime)?;
                 }
+            } else if opts.times && !skip_mtime {
+                filetime::set_file_mtime(path, self.mtime)?;
             }
         }
 
@@ -373,10 +371,7 @@ fn get_file_crtime(path: &Path) -> io::Result<Option<FileTime>> {
         Ok(None)
     } else {
         let ts = stx.stx_btime;
-        Ok(Some(FileTime::from_unix_time(
-            ts.tv_sec as i64,
-            ts.tv_nsec as u32,
-        )))
+        Ok(Some(FileTime::from_unix_time(ts.tv_sec, ts.tv_nsec)))
     }
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -955,6 +955,35 @@ fn include_pattern_allows_file() {
 }
 
 #[test]
+fn include_after_exclude_does_not_override() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("keep.log"), b"k").unwrap();
+    std::fs::write(src.join("skip.log"), b"s").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--exclude",
+            "*.log",
+            "--include",
+            "keep.log",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(!dst.join("keep.log").exists());
+    assert!(!dst.join("skip.log").exists());
+}
+
+#[test]
 fn include_from_file_allows_patterns() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");


### PR DESCRIPTION
## Summary
- Clarify how `build_matcher` interprets filter flags
- Test precedence when `--include` follows `--exclude`
- Minor clippy-driven cleanups in meta crate

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: needless borrows for generic args, type complexity, etc.)*
- `cargo test` *(fails: 28 passed; 33 failed)*
- `cargo test --test cli include_after_exclude_does_not_override`
- `bash scripts/check-comments.sh` *(reports disallowed comments)*
- `cargo fmt --all --check`


------
https://chatgpt.com/codex/tasks/task_e_68b4762763d08323890262f8cfaf7fdb