### PR TITLE
Print progress after file completion

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -750,6 +750,7 @@ impl Sender {
         recv.apply(path, dest, rel, ops)?;
         drop(atime_guard);
         recv.copy_metadata(path, dest)?;
+        recv.progress(dest)?;
         Ok(true)
     }
 }
@@ -946,6 +947,11 @@ impl Receiver {
                 }
             }
         }
+        self.state = ReceiverState::Finished;
+        Ok(())
+    }
+
+    fn progress(&self, dest: &Path) -> Result<()> {
         if self.opts.progress {
             let len = fs::metadata(dest).map_err(|e| io_context(dest, e))?.len();
             if self.opts.human_readable {
@@ -954,7 +960,6 @@ impl Receiver {
                 eprintln!("{}: {} bytes", dest.display(), len);
             }
         }
-        self.state = ReceiverState::Finished;
         Ok(())
     }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -270,8 +270,8 @@ fn progress_flag_shows_output() {
     let src_dir = dir.path().join("src");
     let dst_dir = dir.path().join("dst");
     std::fs::create_dir_all(&src_dir).unwrap();
-    std::fs::write(src_dir.join("a.txt"), b"hello").unwrap();
-    let expected = format!("{}: 5 bytes\n", dst_dir.join("a.txt").display());
+    std::fs::write(src_dir.join("a.txt"), vec![0u8; 2048]).unwrap();
+    let expected = format!("{}: 2048 bytes\n", dst_dir.join("a.txt").display());
 
     let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
     let src_arg = format!("{}/", src_dir.display());


### PR DESCRIPTION
## Summary
- ensure progress output is emitted after each file is fully written
- add dedicated `Receiver::progress` helper and call it from `Sender::process_file`
- verify CLI `--progress` flag prints the exact expected line

## Testing
- `cargo test progress_flag_shows_output --test cli -q`
- `cargo test progress_flag_human_readable --test cli -q`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: function has too many arguments, get-first, etc.)*
- `cargo test` *(fails: 29 passed; 32 failed)*
- `bash scripts/check-comments.sh` *(fails: contains disallowed comments)*
- `make lint` *(fails: Makefile missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b4791e6064832386312c9ede5afc6c