### PR TITLE
refactor: integrate cli command parser

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,40 +1,27 @@
 // bin/oc-rsync/src/main.rs
 use engine::Result;
 use logging::LogFormat;
-use std::env;
+use oc_rsync_cli::cli_command;
 
 fn main() -> Result<()> {
-    let args: Vec<String> = env::args().collect();
-    let mut verbose = 0u8;
-    let mut info = false;
-    let mut debug = false;
-    let mut log_format = LogFormat::Text;
-    let mut iter = args.iter().peekable();
-    while let Some(arg) = iter.next() {
-        if arg == "--info" || arg.starts_with("--info=") {
-            info = true;
-        } else if arg == "--debug" || arg.starts_with("--debug=") {
-            debug = true;
-        } else if arg == "--log-format" {
-            if let Some(next) = iter.peek() {
-                if next.as_str() == "json" {
-                    log_format = LogFormat::Json;
-                }
-            }
-        } else if let Some(f) = arg.strip_prefix("--log-format=") {
-            if f == "json" {
-                log_format = LogFormat::Json;
-            }
-        } else if arg == "--verbose" {
-            verbose += 1;
-        } else if arg.starts_with('-') && !arg.starts_with("--") {
-            for ch in arg.chars().skip(1) {
-                if ch == 'v' {
-                    verbose += 1;
-                }
-            }
-        }
+    if std::env::args().any(|a| a == "--version" || a == "-V") {
+        println!("oc-rsync {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
     }
+    let matches = cli_command().get_matches();
+    let verbose = matches.get_count("verbose") as u8;
+    let info = false;
+    let debug = false;
+    let log_format = matches
+        .get_one::<String>("log_format")
+        .map(|f| {
+            if f == "json" {
+                LogFormat::Json
+            } else {
+                LogFormat::Text
+            }
+        })
+        .unwrap_or(LogFormat::Text);
     logging::init(log_format, verbose, info, debug);
-    oc_rsync_cli::run()
+    oc_rsync_cli::run(&matches)
 }

--- a/crates/cli/tests/logging_flags.rs
+++ b/crates/cli/tests/logging_flags.rs
@@ -1,0 +1,45 @@
+use assert_cmd::Command;
+use oc_rsync_cli::cli_command;
+use tempfile::tempdir;
+
+#[test]
+fn verbose_and_log_format_json_parity() {
+    let src = tempdir().unwrap();
+    let dst = tempdir().unwrap();
+    let src_path = src.path();
+    let dst_path = dst.path();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--verbose",
+            "--log-format=json",
+            "--dry-run",
+            src_path.to_str().unwrap(),
+            dst_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let matches = cli_command()
+        .try_get_matches_from([
+            "oc-rsync",
+            "--verbose",
+            "--log-format=json",
+            "--dry-run",
+            src_path.to_str().unwrap(),
+            dst_path.to_str().unwrap(),
+        ])
+        .unwrap();
+    let verbose = matches.get_count("verbose") as u8;
+    let info = false;
+    let debug = false;
+    let log_format = if matches.get_one::<String>("log_format").map(String::as_str) == Some("json")
+    {
+        logging::LogFormat::Json
+    } else {
+        logging::LogFormat::Text
+    };
+    logging::init(log_format, verbose, info, debug);
+    oc_rsync_cli::run(&matches).unwrap();
+}


### PR DESCRIPTION
## Summary
- parse arguments with `oc_rsync_cli::cli_command` in the top-level binary and forward matches to the CLI library
- accept parsed matches in `oc_rsync_cli::run`
- add a parity test for `--verbose` and `--log-format=json`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: needless borrows, type complexity, etc.)*
- `cargo test` *(fails: prints_version and many CLI tests)*
- `make verify-comments` *(fails: missing separator in Makefile)*
- `make lint` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68b47f57e4ec8323b767a0ef1423787d