### PR TITLE
Preserve timestamps after permission changes in apply_metadata

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,9 +101,10 @@ fn io_context(path: &Path, err: io::Error) -> EngineError {
 fn apply_metadata(dst: &Path, meta: &fs::Metadata) -> Result<()> {
     let atime = FileTime::from_last_access_time(meta);
     let mtime = FileTime::from_last_modification_time(meta);
-    // Provide the destination path in any I/O error.
-    set_file_times(dst, atime, mtime).map_err(|e| io_context(dst, e))?;
+    // Some platforms modify file times when permissions change; set permissions
+    // first and then restore atime/mtime.
     fs::set_permissions(dst, meta.permissions()).map_err(|e| io_context(dst, e))?;
+    set_file_times(dst, atime, mtime).map_err(|e| io_context(dst, e))?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- set permissions before restoring file times in `apply_metadata`
- document that some platforms update timestamps when permissions change

## Testing
- `cargo fmt --all`
- `make verify-comments` *(fails: missing separator)*
- `bash scripts/check-comments.sh` *(reports doc/disallowed comments)*
- `make lint` *(fails: missing separator)*
- `cargo fmt --all --check` *(fails: diff in crates/cli/tests/cli_parity.rs, etc.)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: multiple lint errors)*
- `cargo test` *(sync_preserves_metadata passed, several other tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ad5eaf08323b3ba6d121e038430