### PR TITLE
Add IP socket option parsing and validation

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -790,6 +790,9 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         None
     };
 
+    // Validate socket options early so parsing errors surface before any I/O
+    parse_sockopts(&opts.sockopts).map_err(|e| EngineError::Other(e))?;
+
     if let Some(pf) = &opts.password_file {
         #[cfg(unix)]
         {

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -90,6 +90,8 @@ impl TcpTransport {
                 SockOpt::KeepAlive(v) => sock.set_keepalive(v)?,
                 SockOpt::SendBuf(size) => sock.set_send_buffer_size(size)?,
                 SockOpt::RecvBuf(size) => sock.set_recv_buffer_size(size)?,
+                SockOpt::IpTtl(v) => sock.set_ttl(v)?,
+                SockOpt::IpTos(v) => sock.set_tos(v)?,
             }
         }
         Ok(())

--- a/crates/transport/tests/sockopts.rs
+++ b/crates/transport/tests/sockopts.rs
@@ -1,0 +1,23 @@
+use transport::{parse_sockopts, SockOpt};
+
+#[test]
+fn parse_ip_ttl() {
+    let opts = parse_sockopts(&["ip:ttl=64".into()]).unwrap();
+    assert_eq!(opts, vec![SockOpt::IpTtl(64)]);
+}
+
+#[test]
+fn parse_ip_tos_hex() {
+    let opts = parse_sockopts(&["ip:tos=0x10".into()]).unwrap();
+    assert_eq!(opts, vec![SockOpt::IpTos(0x10)]);
+}
+
+#[test]
+fn parse_ip_unknown() {
+    assert!(parse_sockopts(&["ip:foo=1".into()]).is_err());
+}
+
+#[test]
+fn parse_ip_missing_value() {
+    assert!(parse_sockopts(&["ip:ttl".into()]).is_err());
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -221,7 +221,7 @@ The table below mirrors the full `rsync(1)` flag set. Defaults show the behavior
 |  | `--server` | off | negotiates protocol version and codecs | [matrix](feature_matrix.md#--server) |
 |  | `--size-only` | off |  | [matrix](feature_matrix.md#--size-only) |
 |  | `--skip-compress` | off |  | [matrix](feature_matrix.md#--skip-compress) |
-|  | `--sockopts` | off |  | [matrix](feature_matrix.md#--sockopts) |
+|  | `--sockopts` | off | comma-separated socket options, e.g. `SO_KEEPALIVE` or `ip:ttl=64` | [matrix](feature_matrix.md#--sockopts) |
 | `-S` | `--sparse` | off | creates holes for long zero runs | [matrix](feature_matrix.md#--sparse) |
 |  | `--specials` | off |  | [matrix](feature_matrix.md#--specials) |
 |  | `--stats` | off |  | [matrix](feature_matrix.md#--stats) |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -146,7 +146,7 @@ negotiates version 73.
 | `--server` | — | ✅ | ❌ | [tests/server.rs](../tests/server.rs) | negotiates protocol version and codecs | ≤3.2 |
 | `--size-only` | — | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--skip-compress` | — | ✅ | ✅ | [tests/skip_compress.rs](../tests/skip_compress.rs) | comma-separated list of file suffixes to avoid compressing | ≤3.2 |
-| `--sockopts` | — | ✅ | ❌ | [tests/sockopts.rs](../tests/sockopts.rs) |  | ≤3.2 |
+| `--sockopts` | — | ✅ | ❌ | [tests/sockopts.rs](../tests/sockopts.rs)<br>[crates/transport/tests/sockopts.rs](../crates/transport/tests/sockopts.rs) | supports `SO_*` and `ip:ttl`/`ip:tos` | ≤3.2 |
 | `--sparse` | `-S` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) | creates holes for long zero runs | ≤3.2 |
 | `--specials` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--stats` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |

--- a/tests/sockopts.rs
+++ b/tests/sockopts.rs
@@ -22,3 +22,23 @@ fn accepts_sockopts() {
         .assert()
         .success();
 }
+
+#[test]
+fn rejects_invalid_sockopts() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    let dst = dir.path().join("dst");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--sockopts",
+            "ip:bad=1",
+            "-r",
+            src.to_str().unwrap(),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+}


### PR DESCRIPTION
## Summary
- parse `--sockopts` entries early in the CLI to surface errors
- support `ip:ttl`/`ip:tos` in socket option parser and apply via `setsockopt`
- document new `--sockopts` semantics and test parsing

## Testing
- `cargo +nightly -Znext-lockfile-bump test -p transport --test sockopts`
- `cargo +nightly -Znext-lockfile-bump test --test sockopts`
- `cargo +nightly -Znext-lockfile-bump test` *(fails: 29 passed; 32 failed)*
- `cargo +nightly -Znext-lockfile-bump clippy --all-targets --all-features -- -D warnings` *(fails: clippy lints in crates/filters)*
- `bash scripts/check-comments.sh` *(fails: reports disallowed comments)*
- `make lint` *(fails: Makefile missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b49712375883238c70a67d427bd24d