### PR TITLE
Limit CI to Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,26 +27,6 @@ jobs:
             runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: false
-          - os: ubuntu-latest
-            runner: [ubuntu-latest, ARM64]
-            target: aarch64-unknown-linux-gnu
-            use-cross: false
-          - os: ubuntu-latest
-            runner: ubuntu-latest
-            target: armv7-unknown-linux-gnueabihf
-            use-cross: true
-          - os: ubuntu-latest
-            runner: ubuntu-latest
-            target: x86_64-unknown-freebsd
-            use-cross: true
-          - os: macos-latest
-            runner: macos-latest
-            target: x86_64-apple-darwin
-            use-cross: false
-          - os: windows-latest
-            runner: windows-latest
-            target: x86_64-pc-windows-msvc
-            use-cross: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -144,21 +124,6 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             use-cross: false
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            use-cross: true
-          - os: ubuntu-latest
-            target: armv7-unknown-linux-gnueabihf
-            use-cross: true
-          - os: ubuntu-latest
-            target: x86_64-unknown-freebsd
-            use-cross: true
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            use-cross: false
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            use-cross: false
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -208,7 +173,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Summary
- restrict CI test and release jobs to Linux x86_64
- run interop tests only on Ubuntu

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` (fails: very complex type, redundant locals, etc.)
- `cargo test --all --features blake3` (fails: unresolved import `assert_cmd`)
- `make verify-comments` (fails: missing separator in Makefile)
- `bash scripts/check-comments.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b49b5376208323bf1ad53553ce70a9