### PR TITLE
Handle writing to device nodes via --write-devices

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -418,7 +418,11 @@ struct ClientOpts {
     write_batch: Option<PathBuf>,
     #[arg(long = "copy-devices", help_heading = "Misc")]
     copy_devices: bool,
-    #[arg(long = "write-devices", help_heading = "Misc")]
+    #[arg(
+        long = "write-devices",
+        help = "write to devices as files (implies --inplace)",
+        help_heading = "Misc"
+    )]
     write_devices: bool,
     #[arg(long, hide = true)]
     server: bool,

--- a/crates/cli/tests/cli_parity.rs
+++ b/crates/cli/tests/cli_parity.rs
@@ -14,7 +14,9 @@ fn archive_flag_matches_upstream() {
 
     // upstream short flag
     let status = Command::new("rsync")
-        .args(["-a", "-n"]).arg(src_path).arg(dst_path)
+        .args(["-a", "-n"])
+        .arg(src_path)
+        .arg(dst_path)
         .status()
         .expect("rsync not installed");
     assert!(status.success());
@@ -22,7 +24,9 @@ fn archive_flag_matches_upstream() {
     // our parser short flag
     let matches = cli_command()
         .try_get_matches_from([
-            "oc-rsync", "-a", "-n",
+            "oc-rsync",
+            "-a",
+            "-n",
             src_path.to_str().unwrap(),
             dst_path.to_str().unwrap(),
         ])
@@ -31,7 +35,9 @@ fn archive_flag_matches_upstream() {
 
     // upstream long flag
     let status = Command::new("rsync")
-        .args(["--archive", "-n"]).arg(src_path).arg(dst_path)
+        .args(["--archive", "-n"])
+        .arg(src_path)
+        .arg(dst_path)
         .status()
         .expect("rsync not installed");
     assert!(status.success());
@@ -39,7 +45,9 @@ fn archive_flag_matches_upstream() {
     // our parser long flag
     let matches = cli_command()
         .try_get_matches_from([
-            "oc-rsync", "--archive", "-n",
+            "oc-rsync",
+            "--archive",
+            "-n",
             src_path.to_str().unwrap(),
             dst_path.to_str().unwrap(),
         ])
@@ -56,7 +64,9 @@ fn combined_flags_match_upstream() {
 
     // upstream combined flags
     let status = Command::new("rsync")
-        .args(["-avz", "-n"]).arg(src_path).arg(dst_path)
+        .args(["-avz", "-n"])
+        .arg(src_path)
+        .arg(dst_path)
         .status()
         .expect("rsync not installed");
     assert!(status.success());
@@ -64,7 +74,9 @@ fn combined_flags_match_upstream() {
     // our parser combined flags
     let matches = cli_command()
         .try_get_matches_from([
-            "oc-rsync", "-avz", "-n",
+            "oc-rsync",
+            "-avz",
+            "-n",
             src_path.to_str().unwrap(),
             dst_path.to_str().unwrap(),
         ])
@@ -75,7 +87,9 @@ fn combined_flags_match_upstream() {
 
     // upstream separate flags
     let status = Command::new("rsync")
-        .args(["-a", "-v", "-z", "-n"]).arg(src_path).arg(dst_path)
+        .args(["-a", "-v", "-z", "-n"])
+        .arg(src_path)
+        .arg(dst_path)
         .status()
         .expect("rsync not installed");
     assert!(status.success());
@@ -83,7 +97,11 @@ fn combined_flags_match_upstream() {
     // our parser separate flags
     let matches = cli_command()
         .try_get_matches_from([
-            "oc-rsync", "-a", "-v", "-z", "-n",
+            "oc-rsync",
+            "-a",
+            "-v",
+            "-z",
+            "-n",
             src_path.to_str().unwrap(),
             dst_path.to_str().unwrap(),
         ])
@@ -102,7 +120,9 @@ fn partial_progress_alias_matches_upstream() {
 
     // upstream short alias -P
     let status = Command::new("rsync")
-        .args(["-P", "-n"]).arg(src_path).arg(dst_path)
+        .args(["-P", "-n"])
+        .arg(src_path)
+        .arg(dst_path)
         .status()
         .expect("rsync not installed");
     assert!(status.success());
@@ -110,7 +130,9 @@ fn partial_progress_alias_matches_upstream() {
     // our parser for -P
     let matches = cli_command()
         .try_get_matches_from([
-            "oc-rsync", "-P", "-n",
+            "oc-rsync",
+            "-P",
+            "-n",
             src_path.to_str().unwrap(),
             dst_path.to_str().unwrap(),
         ])
@@ -119,7 +141,9 @@ fn partial_progress_alias_matches_upstream() {
 
     // upstream long form --partial --progress
     let status = Command::new("rsync")
-        .args(["--partial", "--progress", "-n"]).arg(src_path).arg(dst_path)
+        .args(["--partial", "--progress", "-n"])
+        .arg(src_path)
+        .arg(dst_path)
         .status()
         .expect("rsync not installed");
     assert!(status.success());
@@ -127,7 +151,10 @@ fn partial_progress_alias_matches_upstream() {
     // our parser long form
     let matches = cli_command()
         .try_get_matches_from([
-            "oc-rsync", "--partial", "--progress", "-n",
+            "oc-rsync",
+            "--partial",
+            "--progress",
+            "-n",
             src_path.to_str().unwrap(),
             dst_path.to_str().unwrap(),
         ])

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -829,7 +829,7 @@ impl Receiver {
         if resume > src_len {
             resume = src_len;
         }
-        let mut basis: Box<dyn ReadSeek> = if self.opts.copy_devices {
+        let mut basis: Box<dyn ReadSeek> = if self.opts.copy_devices || self.opts.write_devices {
             if let Ok(meta) = fs::symlink_metadata(&basis_path) {
                 let ft = meta.file_type();
                 if ft.is_block_device() || ft.is_char_device() {

--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -108,7 +108,6 @@ impl Iterator for Walk {
                         continue;
                     }
 
-
                     if let Some(max) = self.max_file_size {
                         if meta.is_file() && meta.len() > max {
                             continue;

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -25,7 +25,7 @@
 |  | --super | receiver attempts super-user activities | no |  | no |
 |  | --times | preserve modification times | yes |  | no |
 |  | --usermap=STRING | custom username mapping | no |  | no |
-|  | --write-devices | write to devices as files (implies --inplace) | no |  | no |
+|  | --write-devices | write to devices as files (implies --inplace) | yes |  | no |
 | -X | --xattrs | preserve extended attributes | yes | requires `xattr` feature | no |
 
 ## Compression

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -165,5 +165,5 @@ negotiates version 73.
 | `--version` | `-V` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--whole-file` | `-W` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--write-batch` | — | ✅ | ✅ | [tests/write_batch.rs](../tests/write_batch.rs) |  | ≤3.2 |
-| `--write-devices` | — | ✅ | ✅ | [tests/write_devices.rs](../tests/write_devices.rs) |  | ≤3.2 |
+| `--write-devices` | — | ✅ | ✅ | [tests/write_devices.rs](../tests/write_devices.rs) | writes to existing devices | ≤3.2 |
 | `--xattrs` | `-X` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | requires `xattr` feature | ≤3.2 |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -13,7 +13,6 @@ This document tracks outstanding gaps in `oc-rsync` compared to the reference `r
  - `--server` — handshake lacks full parity. [tests/server.rs](../tests/server.rs) [feature_matrix](feature_matrix.md#L134)
 - `--sockopts` — not implemented. [feature_matrix](feature_matrix.md#L137) ([TODO](#testing-gaps))
 - `--timeout` — timeout semantics differ. [tests/timeout.rs](../tests/timeout.rs) [feature_matrix](feature_matrix.md#L147)
-- `--write-devices` — not implemented. [feature_matrix](feature_matrix.md#L156) ([TODO](#testing-gaps))
 
 ## Metadata gaps
 - `--acls` — ACL support requires optional feature and lacks parity. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) [feature_matrix](feature_matrix.md#L9)

--- a/tests/filter_corpus.rs
+++ b/tests/filter_corpus.rs
@@ -249,21 +249,21 @@ fn perdir_sign_parity() {
         ours_output = ours_output.replace("recursive mode enabled\n", "");
         assert_eq!(rsync_output, ours_output);
 
-    let diff = StdCommand::new("diff")
-        .arg("-r")
-        .arg(&rsync_dst)
-        .arg(&ours_dst)
-        .output()
-        .unwrap();
-    assert!(diff.status.success(), "directory trees differ");
+        let diff = StdCommand::new("diff")
+            .arg("-r")
+            .arg(&rsync_dst)
+            .arg(&ours_dst)
+            .output()
+            .unwrap();
+        assert!(diff.status.success(), "directory trees differ");
 
-    assert!(ours_dst.join("sub/keep.tmp").exists());
-    assert!(!ours_dst.join("sub/other.tmp").exists());
-    assert!(ours_dst.join("sub/nested/keep.tmp").exists());
-    assert!(!ours_dst.join("sub/nested/other.tmp").exists());
-    assert!(!ours_dst.join(".rsync-filter").exists());
-    assert!(!ours_dst.join("sub/.rsync-filter").exists());
-    assert!(!ours_dst.join("sub/nested/.rsync-filter").exists());
+        assert!(ours_dst.join("sub/keep.tmp").exists());
+        assert!(!ours_dst.join("sub/other.tmp").exists());
+        assert!(ours_dst.join("sub/nested/keep.tmp").exists());
+        assert!(!ours_dst.join("sub/nested/other.tmp").exists());
+        assert!(!ours_dst.join(".rsync-filter").exists());
+        assert!(!ours_dst.join("sub/.rsync-filter").exists());
+        assert!(!ours_dst.join("sub/nested/.rsync-filter").exists());
         let diff = StdCommand::new("diff")
             .arg("-r")
             .arg(&rsync_dst)

--- a/tests/secluded_args.rs
+++ b/tests/secluded_args.rs
@@ -66,7 +66,12 @@ fn rsync_protect_args_env_enables_secluded() {
     )
     .unwrap();
     fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755)).unwrap();
-    let rsync_path = format!("{} {} {}", wrapper.display(), log.display(), remote_bin.display());
+    let rsync_path = format!(
+        "{} {} {}",
+        wrapper.display(),
+        log.display(),
+        remote_bin.display()
+    );
 
     let rsh = dir.path().join("fake_rsh.sh");
     fs::write(&rsh, b"#!/bin/sh\nshift\nexec \"$@\"\n").unwrap();

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -7,11 +7,7 @@ use std::time::Duration;
 
 use protocol::Demux;
 use transport::{
-    ssh::SshStdioTransport,
-    LocalPipeTransport,
-    TcpTransport,
-    TimeoutTransport,
-    Transport,
+    ssh::SshStdioTransport, LocalPipeTransport, TcpTransport, TimeoutTransport, Transport,
 };
 
 #[test]
@@ -36,7 +32,8 @@ fn tcp_read_timeout() {
         thread::sleep(Duration::from_secs(5));
     });
     let mut t = TcpTransport::connect(&addr.ip().to_string(), addr.port(), None, None).unwrap();
-    t.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
+    t.set_read_timeout(Some(Duration::from_millis(100)))
+        .unwrap();
     let mut buf = [0u8; 1];
     let err = t.receive(&mut buf).err().expect("error");
     assert!(err.kind() == io::ErrorKind::WouldBlock || err.kind() == io::ErrorKind::TimedOut);
@@ -45,7 +42,8 @@ fn tcp_read_timeout() {
 #[test]
 fn ssh_read_timeout() {
     let mut t = SshStdioTransport::spawn("sh", ["-c", "sleep 5"]).unwrap();
-    t.set_read_timeout(Some(Duration::from_millis(100))).unwrap();
+    t.set_read_timeout(Some(Duration::from_millis(100)))
+        .unwrap();
     let mut buf = [0u8; 1];
     let err = t.receive(&mut buf).err().expect("error");
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);

--- a/tests/write_devices.rs
+++ b/tests/write_devices.rs
@@ -1,4 +1,8 @@
 use assert_cmd::Command;
+use std::fs;
+use std::os::unix::fs::FileTypeExt;
+use std::process::Command as StdCommand;
+use tempfile::tempdir;
 
 #[test]
 fn write_devices_flag_parses() {
@@ -7,4 +11,59 @@ fn write_devices_flag_parses() {
         .args(["--write-devices", "--help"])
         .assert()
         .success();
+}
+
+#[test]
+fn write_devices_requires_flag() {
+    let tmp = tempdir().unwrap();
+    let file = tmp.path().join("file");
+    fs::write(&file, b"hi").unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--local", file.to_str().unwrap(), "/dev/null"])
+        .assert()
+        .failure();
+
+    let meta = fs::metadata("/dev/null").unwrap();
+    assert!(meta.file_type().is_char_device());
+}
+
+#[test]
+fn write_devices_parity() {
+    let tmp = tempdir().unwrap();
+    let file = tmp.path().join("file");
+    fs::write(&file, b"hi").unwrap();
+
+    let rsync_out = StdCommand::new("rsync")
+        .args([
+            "--quiet",
+            "--write-devices",
+            file.to_str().unwrap(),
+            "/dev/null",
+        ])
+        .output()
+        .unwrap();
+    assert!(rsync_out.status.success());
+    let rsync_output = String::from_utf8_lossy(&rsync_out.stdout).to_string()
+        + &String::from_utf8_lossy(&rsync_out.stderr);
+
+    let ours_out = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--write-devices",
+            file.to_str().unwrap(),
+            "/dev/null",
+        ])
+        .output()
+        .unwrap();
+    assert!(ours_out.status.success());
+    let ours_output = String::from_utf8_lossy(&ours_out.stdout).to_string()
+        + &String::from_utf8_lossy(&ours_out.stderr);
+
+    assert_eq!(rsync_output, ours_output);
+
+    let meta = fs::metadata("/dev/null").unwrap();
+    assert!(meta.file_type().is_char_device());
 }

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -701,7 +701,7 @@
   },
   {
     "flag": "--write-devices",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -140,7 +140,7 @@
 | --version | Error |  |
 | --whole-file | Supported |  |
 | --write-batch | Error |  |
-| --write-devices | Error |  |
+| --write-devices | Supported |  |
 | --xattrs | Error |  |
 | -0 | Error | alias for --from0 |
 | -4 | Alias | alias for --ipv4 |


### PR DESCRIPTION
## Summary
- detect device file types and allow in-place writes when `--write-devices` is set
- surface `--write-devices` flag in CLI and propagate into `SyncOptions`
- test writing to devices against upstream rsync and document support

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: type complexity and other lints in `crates/filters`)*
- `cargo test` *(fails: numerous cli tests such as `archive_implies_recursive`)*
- `make verify-comments` *(fails: Makefile missing separator)*
- `make lint` *(fails: Makefile missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b499be35088323bffaaf7f0441978c