### PR TITLE
feat: add memory caps and preallocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "fastcdc",
  "filetime",
  "filters",
+ "libc",
  "logging",
  "meta",
  "nix 0.27.1",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -181,6 +181,12 @@ struct ClientOpts {
     max_size: Option<u64>,
     #[arg(long = "min-size", value_name = "SIZE", value_parser = parse_file_size, help_heading = "Misc")]
     min_size: Option<u64>,
+    #[arg(
+        long,
+        help_heading = "Misc",
+        help = "allocate dest files before writing them"
+    )]
+    preallocate: bool,
     #[arg(short = 'b', long, help_heading = "Backup")]
     backup: bool,
     #[arg(long = "backup-dir", value_name = "DIR", help_heading = "Backup")]
@@ -1081,6 +1087,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         max_alloc: opts.max_alloc.unwrap_or(1usize << 30),
         max_size: opts.max_size,
         min_size: opts.min_size,
+        preallocate: opts.preallocate,
         checksum: opts.checksum,
         compress,
         modern_compress,

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -14,6 +14,7 @@ meta = { path = "../meta", default-features = false }
 blake3 = "1"
 fastcdc = "3.2"
 logging = { path = "../logging" }
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
@@ -33,6 +34,10 @@ harness = false
 
 [[bench]]
 name = "compress"
+harness = false
+
+[[bench]]
+name = "preallocate"
 harness = false
 
 [features]

--- a/crates/engine/benches/large_files.rs
+++ b/crates/engine/benches/large_files.rs
@@ -1,7 +1,7 @@
 // crates/engine/benches/large_files.rs
 use checksums::ChecksumConfigBuilder;
 use criterion::{criterion_group, criterion_main, Criterion};
-use engine::compute_delta;
+use engine::{compute_delta, SyncOptions};
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
 fn bench_large_delta(c: &mut Criterion) {
@@ -13,7 +13,16 @@ fn bench_large_delta(c: &mut Criterion) {
         b.iter(|| {
             let mut basis = Cursor::new(data.clone());
             let mut target = Cursor::new(data.clone());
-            for op in compute_delta(&cfg, &mut basis, &mut target, block_size, window).unwrap() {
+            for op in compute_delta(
+                &cfg,
+                &mut basis,
+                &mut target,
+                block_size,
+                window,
+                &SyncOptions::default(),
+            )
+            .unwrap()
+            {
                 op.unwrap();
             }
         });
@@ -67,7 +76,16 @@ fn bench_streaming_delta(c: &mut Criterion) {
         b.iter(|| {
             let mut basis = ZeroReader::new(len);
             let mut target = ZeroReader::new(len);
-            for op in compute_delta(&cfg, &mut basis, &mut target, block_size, window).unwrap() {
+            for op in compute_delta(
+                &cfg,
+                &mut basis,
+                &mut target,
+                block_size,
+                window,
+                &SyncOptions::default(),
+            )
+            .unwrap()
+            {
                 op.unwrap();
             }
         });

--- a/crates/engine/benches/preallocate.rs
+++ b/crates/engine/benches/preallocate.rs
@@ -1,0 +1,26 @@
+// crates/engine/benches/preallocate.rs
+use criterion::{criterion_group, criterion_main, Criterion};
+use engine::{sync, SyncOptions};
+use std::fs;
+use tempfile::tempdir;
+
+fn bench_preallocate(c: &mut Criterion) {
+    c.bench_function("preallocate_10mb", |b| {
+        b.iter(|| {
+            let dir = tempdir().unwrap();
+            let src = dir.path().join("src");
+            let dst = dir.path().join("dst");
+            fs::create_dir_all(&src).unwrap();
+            fs::create_dir_all(&dst).unwrap();
+            fs::write(src.join("file.bin"), vec![0u8; 10 * 1024 * 1024]).unwrap();
+            let opts = SyncOptions {
+                preallocate: true,
+                ..SyncOptions::default()
+            };
+            sync(&src, &dst, &opts).unwrap();
+        });
+    });
+}
+
+criterion_group!(benches, bench_preallocate);
+criterion_main!(benches);

--- a/crates/engine/tests/resume.rs
+++ b/crates/engine/tests/resume.rs
@@ -65,10 +65,17 @@ fn resume_large_file_minimal_network_io() {
     let cfg = ChecksumConfigBuilder::new().build();
     let mut basis = File::open(dst.join("big.bin.partial")).unwrap();
     let mut target = File::open(src.join("big.bin")).unwrap();
-    let delta: Vec<Op> = compute_delta(&cfg, &mut basis, &mut target, block_size, usize::MAX)
-        .unwrap()
-        .collect::<engine::Result<_>>()
-        .unwrap();
+    let delta: Vec<Op> = compute_delta(
+        &cfg,
+        &mut basis,
+        &mut target,
+        block_size,
+        usize::MAX,
+        &SyncOptions::default(),
+    )
+    .unwrap()
+    .collect::<engine::Result<_>>()
+    .unwrap();
     let mut sent = 0usize;
     for op in &delta {
         if let Op::Data(d) = op {

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -183,7 +183,7 @@
 | -x | --one-file-system | don't cross filesystem boundaries | no |  | no |
 |  | --partial | keep partially transferred files | yes |  | no |
 |  | --partial-dir=DIR | put a partially transferred file into DIR | yes |  | no |
-|  | --preallocate | allocate dest files before writing them | no |  | no |
+|  | --preallocate | allocate dest files before writing them | yes |  | no |
 | -m | --prune-empty-dirs | prune empty directory chains from file-list | yes |  | no |
 | -r | --recursive | recurse into directories | yes |  | no |
 | -R | --relative | use relative path names | yes |  | no |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -128,7 +128,7 @@ negotiates version 73.
 | `--password-file` | — | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) |  | ≤3.2 |
 | `--perms` | `-p` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--port` | — | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) | overrides default port | ≤3.2 |
-| `--preallocate` | — | ❌ | — | — |  | ≤3.2 |
+| `--preallocate` | — | ✅ | ✅ | [tests/perf_limits.rs](../tests/perf_limits.rs) |  | ≤3.2 |
 | `--progress` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--protocol` | — | ✅ | ❌ | [tests/cli_flags.rs](../tests/cli_flags.rs) |  | ≤3.2 |
 | `--prune-empty-dirs` | `-m` | ✅ | ✅ | [tests/filter_corpus.rs](../tests/filter_corpus.rs) |  | ≤3.2 |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -59,7 +59,6 @@ This document tracks outstanding gaps in `oc-rsync` compared to the reference `r
 
 ## Performance knob gaps
 - `--max-alloc` — not implemented. [feature_matrix](feature_matrix.md#L90) ([TODO](#testing-gaps))
-- `--preallocate` — not implemented. [feature_matrix](feature_matrix.md#L122) ([TODO](#testing-gaps))
 - `--temp-dir` — cross-filesystem behavior differs. [tests/cli.rs](../tests/cli.rs) [feature_matrix](feature_matrix.md#L149)
 
 ## CI gaps

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -5,6 +5,15 @@ compression and rolling checksums. When AVX2/AVX-512/SSE4.2 are available the
 engine selects optimized code paths while maintaining scalar fallbacks for other
 architectures.
 
+Two new options improve resource usage during transfers:
+
+* `--max-alloc` limits in-memory buffer sizes. The engine now enforces this cap
+  before allocating buffers in core routines, preventing pathological memory
+  spikes during large transfers.
+* `--preallocate` uses platform-specific `fallocate`/`posix_fallocate` to
+  allocate destination files up front, reducing fragmentation and surfacing
+  out-of-space errors early.
+
 Benchmarks are available under `crates/engine/benches`. Running on the default
 CI environment produced the following sample results:
 

--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -2,7 +2,7 @@
 
 use assert_cmd::Command;
 use checksums::ChecksumConfigBuilder;
-use engine::{cdc, compute_delta, Op};
+use engine::{cdc, compute_delta, Op, SyncOptions};
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::tempdir;
@@ -62,10 +62,17 @@ fn delta_block_size_matches_rsync() {
         let cfg = ChecksumConfigBuilder::new().build();
         let mut basis_f = fs::File::open(&dst_file).unwrap();
         let mut target_f = fs::File::open(&src_file).unwrap();
-        let ops: Vec<Op> = compute_delta(&cfg, &mut basis_f, &mut target_f, block_size, usize::MAX)
-            .unwrap()
-            .map(Result::unwrap)
-            .collect();
+        let ops: Vec<Op> = compute_delta(
+            &cfg,
+            &mut basis_f,
+            &mut target_f,
+            block_size,
+            usize::MAX,
+            &SyncOptions::default(),
+        )
+        .unwrap()
+        .map(Result::unwrap)
+        .collect();
         let literal: usize = ops
             .iter()
             .map(|op| match op {
@@ -133,10 +140,17 @@ fn delta_block_size_large_file() {
     let cfg = ChecksumConfigBuilder::new().build();
     let mut basis_f = fs::File::open(&dst_file).unwrap();
     let mut target_f = fs::File::open(&src_file).unwrap();
-    let ops: Vec<Op> = compute_delta(&cfg, &mut basis_f, &mut target_f, block_size, usize::MAX)
-        .unwrap()
-        .map(Result::unwrap)
-        .collect();
+    let ops: Vec<Op> = compute_delta(
+        &cfg,
+        &mut basis_f,
+        &mut target_f,
+        block_size,
+        usize::MAX,
+        &SyncOptions::default(),
+    )
+    .unwrap()
+    .map(Result::unwrap)
+    .collect();
     let literal: usize = ops
         .iter()
         .map(|op| match op {
@@ -187,10 +201,17 @@ fn delta_block_size_unaligned_edit() {
     let cfg = ChecksumConfigBuilder::new().build();
     let mut basis_f = fs::File::open(&dst_file).unwrap();
     let mut target_f = fs::File::open(&src_file).unwrap();
-    let ops: Vec<Op> = compute_delta(&cfg, &mut basis_f, &mut target_f, block_size, usize::MAX)
-        .unwrap()
-        .map(Result::unwrap)
-        .collect();
+    let ops: Vec<Op> = compute_delta(
+        &cfg,
+        &mut basis_f,
+        &mut target_f,
+        block_size,
+        usize::MAX,
+        &SyncOptions::default(),
+    )
+    .unwrap()
+    .map(Result::unwrap)
+    .collect();
     let literal: usize = ops
         .iter()
         .map(|op| match op {
@@ -241,10 +262,17 @@ fn delta_block_size_non_power_two() {
     let cfg = ChecksumConfigBuilder::new().build();
     let mut basis_f = fs::File::open(&dst_file).unwrap();
     let mut target_f = fs::File::open(&src_file).unwrap();
-    let ops: Vec<Op> = compute_delta(&cfg, &mut basis_f, &mut target_f, block_size, usize::MAX)
-        .unwrap()
-        .map(Result::unwrap)
-        .collect();
+    let ops: Vec<Op> = compute_delta(
+        &cfg,
+        &mut basis_f,
+        &mut target_f,
+        block_size,
+        usize::MAX,
+        &SyncOptions::default(),
+    )
+    .unwrap()
+    .map(Result::unwrap)
+    .collect();
     let literal: usize = ops
         .iter()
         .map(|op| match op {
@@ -293,10 +321,17 @@ fn delta_block_size_smaller_file() {
     let cfg = ChecksumConfigBuilder::new().build();
     let mut basis_f = fs::File::open(&dst_file).unwrap();
     let mut target_f = fs::File::open(&src_file).unwrap();
-    let ops: Vec<Op> = compute_delta(&cfg, &mut basis_f, &mut target_f, block_size, usize::MAX)
-        .unwrap()
-        .map(Result::unwrap)
-        .collect();
+    let ops: Vec<Op> = compute_delta(
+        &cfg,
+        &mut basis_f,
+        &mut target_f,
+        block_size,
+        usize::MAX,
+        &SyncOptions::default(),
+    )
+    .unwrap()
+    .map(Result::unwrap)
+    .collect();
     let literal: usize = ops
         .iter()
         .map(|op| match op {

--- a/tests/perf_limits.rs
+++ b/tests/perf_limits.rs
@@ -51,6 +51,31 @@ fn max_alloc_zero_is_unlimited() {
 }
 
 #[test]
+fn preallocate_option_creates_files() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file.bin"), vec![0u8; 1024]).unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--preallocate",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert_eq!(fs::metadata(dst.join("file.bin")).unwrap().len(), 1024);
+}
+
+#[test]
 fn max_size_skips_large_files() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -526,7 +526,7 @@
   },
   {
     "flag": "--preallocate",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -105,7 +105,7 @@
 | --password-file | Supported |  |
 | --perms | Supported |  |
 | --port | Supported |  |
-| --preallocate | Error |  |
+| --preallocate | Supported |  |
 | --progress | Supported |  |
 | --protocol | Supported |  |
 | --prune-empty-dirs | Supported |  |


### PR DESCRIPTION
## Summary
- add `--max-alloc` and `--preallocate` options in CLI and sync engine
- enforce allocation limits before buffer creation and support file preallocation
- document memory tuning options and add benchmark & tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: too many arguments and other lints)*
- `cargo test --all-features` *(fails: missing `-lacl` dependency)*
- `cargo test` *(fails: 32 tests failed)*
- `bash scripts/check-comments.sh` *(reports disallowed comments)*
- `make lint` *(fails: Makefile missing separator)*


------
https://chatgpt.com/codex/tasks/task_e_68b4a5d31c9083238634ee44f2cb712d