### PR TITLE
docs: mark copy-devices implemented and prune obsolete gaps

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -37,7 +37,7 @@ negotiates version 73.
 | `--contimeout` | — | ✅ | ❌ | [tests/timeout.rs](../tests/timeout.rs) |  | ≤3.2 |
 | `--copy-as` | — | ❌ | — | — |  | ≤3.2 |
 | `--copy-dest` | — | ✅ | ✅ | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) |  | ≤3.2 |
-| `--copy-devices` | — | ❌ | — | — |  | ≤3.2 |
+| `--copy-devices` | — | ✅ | ✅ | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) |  | ≤3.2 |
 | `--copy-dirlinks` | `-k` | ✅ | ✅ | [tests/golden/cli_parity/copy-dirlinks.sh](../tests/golden/cli_parity/copy-dirlinks.sh) |  | ≤3.2 |
 | `--copy-links` | `-L` | ✅ | ❌ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) |  | ≤3.2 |
 | `--copy-unsafe-links` | — | ✅ | ❌ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) |  | ≤3.2 |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -9,15 +9,12 @@ This document tracks outstanding gaps in `oc-rsync` compared to the reference `r
 - `--block-size` — behavior differs from upstream. [tests/block_size.rs](../tests/block_size.rs) [feature_matrix](feature_matrix.md#L17)
 - `--bwlimit` — rate limiting semantics differ. [crates/transport/tests/bwlimit.rs](../crates/transport/tests/bwlimit.rs) [feature_matrix](feature_matrix.md#L19)
  - `--contimeout` — connection timeout handling incomplete. [tests/timeout.rs](../tests/timeout.rs) [feature_matrix](feature_matrix.md#L32)
- - `--secluded-args` — not implemented. [feature_matrix](feature_matrix.md#L132) ([TODO](#testing-gaps))
  - `--server` — handshake lacks full parity. [tests/server.rs](../tests/server.rs) [feature_matrix](feature_matrix.md#L134)
-- `--sockopts` — not implemented. [feature_matrix](feature_matrix.md#L137) ([TODO](#testing-gaps))
 - `--timeout` — timeout semantics differ. [tests/timeout.rs](../tests/timeout.rs) [feature_matrix](feature_matrix.md#L147)
 
 ## Metadata gaps
 - `--acls` — ACL support requires optional feature and lacks parity. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) [feature_matrix](feature_matrix.md#L9)
 - `--atimes` — access time preservation incomplete. [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) [feature_matrix](feature_matrix.md#L14)
- - `--copy-devices` — not implemented. [feature_matrix](feature_matrix.md#L35) ([TODO](#testing-gaps))
  - `--devices` — device file handling lacks parity. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [feature_matrix](feature_matrix.md#L52)
  - `--groupmap` — numeric gid mapping only; group names unsupported and requires root or CAP_CHOWN. [tests/cli.rs](../tests/cli.rs) [feature_matrix](feature_matrix.md#L74)
  - `--hard-links` — hard link tracking incomplete. [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) [feature_matrix](feature_matrix.md#L69)

--- a/man/oc-rsync-modern.7
+++ b/man/oc-rsync-modern.7
@@ -18,9 +18,10 @@
 .hy
 .SH Modern Mode
 .PP
-Protocol 73 extends the classic rsync protocol with optional features
-that are negotiated when both peers invoke \f[V]oc-rsync\f[R] with the
-\f[V]--modern\f[R] flag or one of its sub-flags.
+oc-rsync implements the upstream rsync protocol version 31 and adds a
+private protocol 73 extension for optional features.
+Protocol 73 is negotiated when both peers invoke \f[V]oc-rsync\f[R] with
+the \f[V]--modern\f[R] flag or one of its sub-flags.
 .SS Stronger checksums
 .PP
 \f[V]--modern\f[R] or \f[V]--modern-hash\f[R] upgrades the strong file
@@ -31,6 +32,11 @@ fast.
 .PP
 Modern mode prefers zstd compression and also supports lz4 through the
 \f[V]--modern-compress\f[R] option.
+\f[V]--modern-compress=auto\f[R] inspects the CPU at runtime: zstd is
+chosen only when AVX2 or AVX-512 are available on x86, or when NEON or
+SVE are present on aarch64.
+Without those SIMD features the code falls back to lz4 if enabled,
+otherwise compression is disabled.
 When both peers support the algorithm the most efficient codec is
 selected automatically.
 .SS Content-defined chunking

--- a/man/oc-rsync.1
+++ b/man/oc-rsync.1
@@ -91,6 +91,46 @@ Incremental backup using hard links:
 oc-rsync -a --link-dest=\[dq]../prev\[dq] --compare-dest=\[dq]../base\[dq] \[dq]./src/\[dq] \[dq]./snapshot/\[dq]
 \f[R]
 .fi
+.IP \[bu] 2
+Throttled modern compression:
+.RS 2
+.IP
+.nf
+\f[C]
+oc-rsync -az --modern --bwlimit=1m ./src/ host:/archive/
+\f[R]
+.fi
+.RE
+.IP \[bu] 2
+Tune delta block size:
+.RS 2
+.IP
+.nf
+\f[C]
+oc-rsync -B 65536 ./src remote:/dst
+\f[R]
+.fi
+.RE
+.IP \[bu] 2
+Emit JSON-formatted logs:
+.RS 2
+.IP
+.nf
+\f[C]
+oc-rsync --log-format json -v ./src ./dst
+\f[R]
+.fi
+.RE
+.IP \[bu] 2
+Change ownership during transfer (requires root):
+.RS 2
+.IP
+.nf
+\f[C]
+sudo oc-rsync --chown=0:0 ./src/ remote:/dst/
+\f[R]
+.fi
+.RE
 .RE
 .IP \[bu] 2
 Throttled modern compression:
@@ -113,6 +153,16 @@ oc-rsync -B 65536 \[dq]./src\[dq] \[dq]remote:/dst\[dq]
 .fi
 .RE
 .IP \[bu] 2
+Change ownership during transfer (requires root):
+.RS 2
+.IP
+.nf
+\f[C]
+sudo oc-rsync --chown=0:0 \[dq]./src/\[dq] \[dq]remote:/dst/\[dq]
+\f[R]
+.fi
+.RE
+.IP \[bu] 2
 Show version:
 .RS 2
 .IP
@@ -127,14 +177,14 @@ oc-rsync --version
 Just like \f[V]rsync\f[R], adding a trailing slash to the source path
 changes what is copied:
 .IP \[bu] 2
-\f[V]oc-rsync \[dq]src/\[dq] \[dq]dest/\[dq]\f[R] copies the \f[I]contents\f[R] of
-\f[V]src\f[R] into \f[V]dest\f[R].
+\f[V]oc-rsync \[dq]src/\[dq] \[dq]dest/\[dq]\f[R] copies the
+\f[I]contents\f[R] of \f[V]src\f[R] into \f[V]dest\f[R].
 .IP \[bu] 2
-\f[V]oc-rsync \[dq]src\[dq] \[dq]dest/\[dq]\f[R] creates a \f[V]dest/src\f[R] directory
-containing the original files.
+\f[V]oc-rsync \[dq]src\[dq] \[dq]dest/\[dq]\f[R] creates a
+\f[V]dest/src\f[R] directory containing the original files.
 .IP \[bu] 2
-\f[V]oc-rsync \[dq]remote:/src/\[dq] \[dq]local/\[dq]\f[R] pulls the contents of
-\f[V]/src\f[R] from the remote host into \f[V]local\f[R].
+\f[V]oc-rsync \[dq]remote:/src/\[dq] \[dq]local/\[dq]\f[R] pulls the
+contents of \f[V]/src\f[R] from the remote host into \f[V]local\f[R].
 .SS Options
 .PP
 The table below mirrors the full \f[V]rsync(1)\f[R] flag set.
@@ -1341,6 +1391,7 @@ T}@T{
 T}@T{
 off
 T}@T{
+forward option to remote side only; repeat for multiple
 T}@T{
 matrix
 T}
@@ -1437,6 +1488,8 @@ T}@T{
 T}@T{
 off
 T}@T{
+comma-separated socket options, e.g.\ \f[V]SO_KEEPALIVE\f[R] or
+\f[V]ip:ttl=64\f[R]
 T}@T{
 matrix
 T}

--- a/man/oc-rsync.bash
+++ b/man/oc-rsync.bash
@@ -23,12 +23,32 @@ _oc-rsync() {
 
     case "${cmd}" in
         oc__rsync)
-            opts="-a -r -d -R -n -S -u -I -v -q -8 -i -b -c -E -U -N -O -J -L -k -m -z -T -P -4 -6 -B -W -e -f -F -C -h --local --archive --recursive --dirs --relative --dry-run --list-only --sparse --update --existing --ignore-existing --size-only --ignore-times --verbose --human-readable --quiet --no-motd --8-bit-output --itemize-changes --delete --delete-before --delete-during --delete-after --delete-delay --delete-excluded --backup --backup-dir --checksum --cc --checksum-choice --checksum-seed --perms --executability --chmod --chown --times --atimes --crtimes --omit-dir-times --omit-link-times --owner --group --links --copy-links --copy-dirlinks --copy-unsafe-links --safe-links --hard-links --devices --specials --compress --zc --compress-choice --zl --compress-level --skip-compress --modern --modern-compress --modern-hash --modern-cdc --modern-cdc-min --modern-cdc-max --partial --partial-dir --temp-dir --prune-empty-dirs --progress --blocking-io --append --append-verify --inplace --bwlimit --timeout --contimeout --protocol --port --ipv4 --ipv6 --block-size --whole-file --no-whole-file --link-dest --copy-dest --compare-dest --numeric-ids --stats --config --known-hosts --no-host-key-checking --password-file --early-input --rsh --server --sender --rsync-path --filter --filter-file --cvs-exclude --include --exclude --include-from --exclude-from --files-from --from0 --help <SRC> <DST>"
+            opts="-a -r -d -R -n -S -u -m -I -v -q -8 -i -b -c -E -U -N -O -J -L -k -z -T -P -4 -6 -B -W -e -M -s -f -F -C -h --local --archive --recursive --dirs --relative --dry-run --list-only --sparse --update --existing --ignore-existing --prune-empty-dirs --size-only --ignore-times --verbose --log-format --human-readable --quiet --no-motd --8-bit-output --itemize-changes --delete --delete-before --delete-during --delete-after --delete-delay --delete-excluded --delete-missing-args --remove-source-files --ignore-errors --max-delete --max-alloc --max-size --min-size --preallocate --backup --backup-dir --checksum --cc --checksum-choice --checksum-seed --perms --executability --chmod --chown --usermap --groupmap --times --atimes --crtimes --omit-dir-times --omit-link-times --owner --group --links --copy-links --copy-dirlinks --copy-unsafe-links --safe-links --hard-links --devices --specials --compress --zc --compress-choice --zl --compress-level --skip-compress --modern --modern-compress --modern-hash --modern-cdc --modern-cdc-min --modern-cdc-max --partial --partial-dir --temp-dir --progress --blocking-io --append --append-verify --inplace --bwlimit --timeout --contimeout --protocol --port --ipv4 --ipv6 --block-size --whole-file --no-whole-file --link-dest --copy-dest --compare-dest --numeric-ids --stats --config --known-hosts --no-host-key-checking --password-file --early-input --rsh --remote-option --secluded-args --sockopts --write-batch --copy-devices --write-devices --server --sender --rsync-path --filter --filter-file --cvs-exclude --include --exclude --include-from --exclude-from --files-from --from0 --help <SRC> <DST>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --log-format)
+                    COMPREPLY=($(compgen -W "text json" -- "${cur}"))
+                    return 0
+                    ;;
+                --max-delete)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-alloc)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --max-size)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --min-size)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
                 --backup-dir)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
@@ -50,6 +70,14 @@ _oc-rsync() {
                     return 0
                     ;;
                 --chown)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --usermap)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --groupmap)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -85,7 +113,11 @@ _oc-rsync() {
                     COMPREPLY=($(compgen -W "fastcdc off" -- "${cur}"))
                     return 0
                     ;;
-                --modern-cdc-min|--modern-cdc-max)
+                --modern-cdc-min)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --modern-cdc-max)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;
@@ -162,6 +194,22 @@ _oc-rsync() {
                     return 0
                     ;;
                 -e)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --remote-option)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                -M)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --sockopts)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --write-batch)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/man/oc-rsync.fish
+++ b/man/oc-rsync.fish
@@ -1,8 +1,16 @@
+complete -c oc-rsync -l log-format -r -f -a "text\t''
+json\t''"
+complete -c oc-rsync -l max-delete -r
+complete -c oc-rsync -l max-alloc -r
+complete -c oc-rsync -l max-size -r
+complete -c oc-rsync -l min-size -r
 complete -c oc-rsync -l backup-dir -r -F
 complete -c oc-rsync -l checksum-choice -l cc -r
 complete -c oc-rsync -l checksum-seed -d 'set block/file checksum seed (advanced)' -r
 complete -c oc-rsync -l chmod -r
 complete -c oc-rsync -l chown -r
+complete -c oc-rsync -l usermap -r
+complete -c oc-rsync -l groupmap -r
 complete -c oc-rsync -l compress-choice -l zc -r
 complete -c oc-rsync -l compress-level -l zl -r
 complete -c oc-rsync -l skip-compress -r
@@ -12,8 +20,8 @@ lz4\t''"
 complete -c oc-rsync -l modern-hash -r -f -a ""
 complete -c oc-rsync -l modern-cdc -r -f -a "fastcdc\t''
 off\t''"
-complete -c oc-rsync -l modern-cdc-min -r -f
-complete -c oc-rsync -l modern-cdc-max -r -f
+complete -c oc-rsync -l modern-cdc-min -r
+complete -c oc-rsync -l modern-cdc-max -r
 complete -c oc-rsync -l partial-dir -r -F
 complete -c oc-rsync -s T -l temp-dir -r -F
 complete -c oc-rsync -l bwlimit -r
@@ -30,6 +38,9 @@ complete -c oc-rsync -l known-hosts -r -F
 complete -c oc-rsync -l password-file -r -F
 complete -c oc-rsync -l early-input -r -F
 complete -c oc-rsync -s e -l rsh -r
+complete -c oc-rsync -s M -l remote-option -d 'send OPTION to the remote side only' -r
+complete -c oc-rsync -l sockopts -r
+complete -c oc-rsync -l write-batch -r -F
 complete -c oc-rsync -l rsync-path -r
 complete -c oc-rsync -s f -l filter -r
 complete -c oc-rsync -l filter-file -r -F
@@ -47,8 +58,9 @@ complete -c oc-rsync -s n -l dry-run
 complete -c oc-rsync -l list-only
 complete -c oc-rsync -s S -l sparse
 complete -c oc-rsync -s u -l update
-complete -c oc-rsync -l ignore-existing
 complete -c oc-rsync -l existing
+complete -c oc-rsync -l ignore-existing
+complete -c oc-rsync -s m -l prune-empty-dirs
 complete -c oc-rsync -l size-only
 complete -c oc-rsync -s I -l ignore-times
 complete -c oc-rsync -s v -l verbose
@@ -63,6 +75,10 @@ complete -c oc-rsync -l delete-during
 complete -c oc-rsync -l delete-after
 complete -c oc-rsync -l delete-delay
 complete -c oc-rsync -l delete-excluded
+complete -c oc-rsync -l delete-missing-args
+complete -c oc-rsync -l remove-source-files
+complete -c oc-rsync -l ignore-errors
+complete -c oc-rsync -l preallocate -d 'allocate dest files before writing them'
 complete -c oc-rsync -s b -l backup
 complete -c oc-rsync -s c -l checksum
 complete -c oc-rsync -l perms
@@ -85,7 +101,6 @@ complete -c oc-rsync -l specials
 complete -c oc-rsync -s z -l compress
 complete -c oc-rsync -l modern -d 'Enable modern compression (zstd or lz4) and BLAKE3 checksums (requires `blake3` feature)'
 complete -c oc-rsync -l partial
-complete -c oc-rsync -s m -l prune-empty-dirs
 complete -c oc-rsync -l progress
 complete -c oc-rsync -l blocking-io
 complete -c oc-rsync -s P
@@ -99,6 +114,9 @@ complete -c oc-rsync -l no-whole-file
 complete -c oc-rsync -l numeric-ids
 complete -c oc-rsync -l stats
 complete -c oc-rsync -l no-host-key-checking
+complete -c oc-rsync -s s -l secluded-args -d 'use the protocol to safely send the args'
+complete -c oc-rsync -l copy-devices
+complete -c oc-rsync -l write-devices -d 'write to devices as files (implies --inplace)'
 complete -c oc-rsync -l server
 complete -c oc-rsync -l sender
 complete -c oc-rsync -s F

--- a/man/oc-rsync.zsh
+++ b/man/oc-rsync.zsh
@@ -15,12 +15,19 @@ _oc-rsync() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" : \
+'--log-format=[]:LOG_FORMAT:(text json)' \
+'--max-delete=[]:NUM:_default' \
+'--max-alloc=[]:SIZE:_default' \
+'--max-size=[]:SIZE:_default' \
+'--min-size=[]:SIZE:_default' \
 '--backup-dir=[]:DIR:_files' \
 '--checksum-choice=[]:STR:_default' \
 '--cc=[]:STR:_default' \
 '--checksum-seed=[set block/file checksum seed (advanced)]:NUM:_default' \
 '*--chmod=[]:CHMOD:_default' \
 '--chown=[]:USER:GROUP:_default' \
+'*--usermap=[]:FROM:TO:_default' \
+'*--groupmap=[]:FROM:TO:_default' \
 '--compress-choice=[]:STR:_default' \
 '--zc=[]:STR:_default' \
 '--compress-level=[]:NUM:_default' \
@@ -29,8 +36,8 @@ _oc-rsync() {
 '--modern-compress=[]:MODERN_COMPRESS:(auto zstd lz4)' \
 '--modern-hash=[]:MODERN_HASH:()' \
 '--modern-cdc=[]:MODERN_CDC:(fastcdc off)' \
-'--modern-cdc-min=[]:SIZE:_default' \
-'--modern-cdc-max=[]:SIZE:_default' \
+'--modern-cdc-min=[]:BYTES:_default' \
+'--modern-cdc-max=[]:BYTES:_default' \
 '--partial-dir=[]:DIR:_files' \
 '-T+[]:DIR:_files' \
 '--temp-dir=[]:DIR:_files' \
@@ -50,6 +57,10 @@ _oc-rsync() {
 '--early-input=[]:FILE:_files' \
 '-e+[]:COMMAND:_default' \
 '--rsh=[]:COMMAND:_default' \
+'*-M+[send OPTION to the remote side only]:OPT:_default' \
+'*--remote-option=[send OPTION to the remote side only]:OPT:_default' \
+'*--sockopts=[]:OPTIONS:_default' \
+'--write-batch=[]:FILE:_files' \
 '--rsync-path=[]:PATH:_default' \
 '*-f+[]:RULE:_default' \
 '*--filter=[]:RULE:_default' \
@@ -75,9 +86,11 @@ _oc-rsync() {
 '--sparse[]' \
 '-u[]' \
 '--update[]' \
-    '--ignore-existing[]' \
-    '--existing[]' \
-    '--size-only[]' \
+'--existing[]' \
+'--ignore-existing[]' \
+'-m[]' \
+'--prune-empty-dirs[]' \
+'--size-only[]' \
 '-I[]' \
 '--ignore-times[]' \
 '*-v[]' \
@@ -96,6 +109,10 @@ _oc-rsync() {
 '--delete-after[]' \
 '--delete-delay[]' \
 '--delete-excluded[]' \
+'--delete-missing-args[]' \
+'--remove-source-files[]' \
+'--ignore-errors[]' \
+'--preallocate[allocate dest files before writing them]' \
 '-b[]' \
 '--backup[]' \
 '-c[]' \
@@ -127,10 +144,8 @@ _oc-rsync() {
 '-z[]' \
 '--compress[]' \
 '--modern[Enable modern compression (zstd or lz4) and BLAKE3 checksums (requires \`blake3\` feature)]' \
-    '--partial[]' \
-    '-m[]' \
-    '--prune-empty-dirs[]' \
-    '--progress[]' \
+'--partial[]' \
+'--progress[]' \
 '--blocking-io[]' \
 '-P[]' \
 '--append[]' \
@@ -146,6 +161,10 @@ _oc-rsync() {
 '--numeric-ids[]' \
 '--stats[]' \
 '--no-host-key-checking[]' \
+'-s[use the protocol to safely send the args]' \
+'--secluded-args[use the protocol to safely send the args]' \
+'--copy-devices[]' \
+'--write-devices[write to devices as files (implies --inplace)]' \
 '--server[]' \
 '--sender[]' \
 '*-F[]' \

--- a/man/oc-rsyncd.conf.5
+++ b/man/oc-rsyncd.conf.5
@@ -74,6 +74,15 @@ This flag applies equally in daemon mode and when invoking a client:
 oc-rsync --daemon --numeric-ids --module \[aq]data=/srv/export\[aq]
 \f[R]
 .fi
+.SS Ownership and permissions
+.PP
+Setting file ownership or groups requires elevated privileges.
+The daemon must run as \f[V]root\f[R] or possess the \f[V]CAP_CHOWN\f[R]
+capability in order to honor the \f[V]--owner\f[R], \f[V]--group\f[R],
+or \f[V]--chown\f[R] flags from clients.
+Without these capabilities the daemon will silently retain its current
+UID and GID when creating files, and ownership requests from clients
+will be ignored.
 .SS Chroot and privilege drop
 .PP
 Before serving files the daemon confines itself to the module root.
@@ -123,6 +132,6 @@ Clients can suppress this output with the \f[V]--no-motd\f[R] flag:
 .IP
 .nf
 \f[C]
-oc-rsync --no-motd \[dq]rsync://host/module\[dq] \[dq]dest/\[dq]
+oc-rsync --no-motd \[aq]rsync://host/module\[aq] \[aq]dest/\[aq]
 \f[R]
 .fi


### PR DESCRIPTION
## Summary
- remove stale gap entries for `--secluded-args`, `--sockopts`, and `--copy-devices`
- mark `--copy-devices` as supported with tests in the feature matrix
- regenerate manpages

## Testing
- `cargo fmt --all`
- `scripts/generate-manpages.sh`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: too many arguments, get-first, needless-lifetimes, redundant-closure, unnecessary-map-or)*
- `cargo test` *(fails: numerous CLI parity tests)*
- `make verify-comments` *(fails: missing separator in Makefile)*
- `bash scripts/check-comments.sh` *(fails: disallowed comments reported)*
- `make lint` *(fails: missing separator in Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a9a57fd48323b1929e552c5184b8