### PR TITLE
Use indexed manifest store and add manifest parser fuzz target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "filters",
  "libc",
  "logging",
+ "memmap2",
  "meta",
  "nix 0.27.1",
  "posix-acl",
@@ -829,6 +830,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "meta"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -15,6 +15,7 @@ blake3 = "1"
 fastcdc = "3.2"
 logging = { path = "../logging" }
 libc = "0.2"
+memmap2 = "0.9"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/engine/src/cdc.rs
+++ b/crates/engine/src/cdc.rs
@@ -1,11 +1,12 @@
 // crates/engine/src/cdc.rs
-use std::collections::HashMap;
-use std::fs;
-use std::io::{self, Read};
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, OpenOptions};
+use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
 
 use blake3::Hash;
 use fastcdc::v2020::StreamCDC;
+use memmap2::MmapOptions;
 
 const RSYNC_BLOCK_SIZE: usize = 700;
 const RSYNC_MAX_BLOCK_SIZE: usize = 1 << 17;
@@ -83,10 +84,10 @@ where
 }
 
 fn chunk_reader<R: Read>(reader: R, min: usize, avg: usize, max: usize) -> io::Result<Vec<Chunk>> {
-    let mut chunker = StreamCDC::new(reader, min as u32, avg as u32, max as u32);
+    let chunker = StreamCDC::new(reader, min as u32, avg as u32, max as u32);
     let mut chunks = Vec::new();
-    while let Some(result) = chunker.next() {
-        let data = result.map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    for result in chunker {
+        let data = result.map_err(io::Error::other)?;
         chunks.push(Chunk {
             hash: blake3::hash(&data.data),
         });
@@ -96,46 +97,97 @@ fn chunk_reader<R: Read>(reader: R, min: usize, avg: usize, max: usize) -> io::R
 
 #[derive(Default)]
 pub struct Manifest {
-    entries: HashMap<String, PathBuf>,
+    entries: HashMap<Hash, HashSet<PathBuf>>,
     path: PathBuf,
+    file: Option<fs::File>,
 }
 
 impl Manifest {
+    pub fn parse(data: &[u8]) -> Vec<(Hash, PathBuf)> {
+        let mut out = Vec::new();
+        let mut i = 0;
+        while i + 36 <= data.len() {
+            let mut hash_bytes = [0u8; 32];
+            hash_bytes.copy_from_slice(&data[i..i + 32]);
+            i += 32;
+            let mut len_bytes = [0u8; 4];
+            len_bytes.copy_from_slice(&data[i..i + 4]);
+            i += 4;
+            let path_len = u32::from_le_bytes(len_bytes) as usize;
+            if i + path_len > data.len() {
+                break;
+            }
+            if let Ok(s) = std::str::from_utf8(&data[i..i + path_len]) {
+                out.push((Hash::from_bytes(hash_bytes), PathBuf::from(s)));
+            }
+            i += path_len;
+        }
+        out
+    }
+
     pub fn load() -> Self {
         let home = std::env::var("HOME").unwrap_or_else(|_| String::from("."));
         let path = Path::new(&home).join(".oc-rsync/manifest");
-        let mut entries = HashMap::new();
-        if let Ok(contents) = fs::read_to_string(&path) {
-            for line in contents.lines() {
-                let mut parts = line.splitn(2, ' ');
-                if let (Some(hash), Some(p)) = (parts.next(), parts.next()) {
-                    entries.insert(hash.to_string(), PathBuf::from(p));
+        let mut entries: HashMap<Hash, HashSet<PathBuf>> = HashMap::new();
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(&path);
+        let mut file_opt = None;
+        if let Ok(f) = file {
+            if let Ok(meta) = f.metadata() {
+                if meta.len() > 0 {
+                    if let Ok(mmap) = unsafe { MmapOptions::new().map(&f) } {
+                        for (h, p) in Self::parse(&mmap) {
+                            entries.entry(h).or_default().insert(p);
+                        }
+                    }
                 }
             }
+            file_opt = Some(f);
         }
-        Manifest { entries, path }
+        Manifest {
+            entries,
+            path,
+            file: file_opt,
+        }
     }
 
-    pub fn save(&self) -> io::Result<()> {
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent)?;
+    pub fn save(&mut self) -> io::Result<()> {
+        if let Some(f) = self.file.as_mut() {
+            f.sync_all()?;
         }
-        let mut out = String::new();
-        for (hash, path) in &self.entries {
-            out.push_str(hash);
-            out.push(' ');
-            out.push_str(&path.to_string_lossy());
-            out.push('\n');
-        }
-        fs::write(&self.path, out)
+        Ok(())
     }
 
-    pub fn lookup(&self, hash: &Hash) -> Option<PathBuf> {
-        self.entries.get(&hash.to_hex().to_string()).cloned()
+    pub fn lookup(&self, hash: &Hash, path: &Path) -> Option<PathBuf> {
+        self.entries.get(hash).and_then(|set| {
+            if set.contains(path) {
+                Some(path.to_path_buf())
+            } else {
+                set.iter().next().cloned()
+            }
+        })
     }
 
     pub fn insert(&mut self, hash: &Hash, path: &Path) {
-        self.entries
-            .insert(hash.to_hex().to_string(), path.to_path_buf());
+        let set = self.entries.entry(*hash).or_default();
+        if set.insert(path.to_path_buf()) {
+            if let Some(f) = self.file.as_mut() {
+                if let Some(parent) = self.path.parent() {
+                    let _ = fs::create_dir_all(parent);
+                }
+                let p = path.to_string_lossy();
+                let mut buf = Vec::with_capacity(32 + 4 + p.len());
+                buf.extend_from_slice(hash.as_bytes());
+                buf.extend_from_slice(&(p.len() as u32).to_le_bytes());
+                buf.extend_from_slice(p.as_bytes());
+                let _ = f.write_all(&buf);
+            }
+        }
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1706,10 +1706,12 @@ pub fn sync(
                                 opts.modern_cdc_max,
                             ) {
                                 if !chunks.is_empty() {
-                                    if let Some(existing) = manifest.lookup(&chunks[0].hash) {
-                                        let all = chunks
-                                            .iter()
-                                            .all(|c| manifest.lookup(&c.hash).is_some());
+                                    if let Some(existing) =
+                                        manifest.lookup(&chunks[0].hash, &dest_path)
+                                    {
+                                        let all = chunks.iter().all(|c| {
+                                            manifest.lookup(&c.hash, &dest_path).is_some()
+                                        });
                                         if all {
                                             if let Some(parent) = dest_path.parent() {
                                                 fs::create_dir_all(parent)

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ filters = { path = "../crates/filters" }
 walk = { path = "../crates/walk" }
 oc-rsync-cli = { path = "../crates/cli" }
 tempfile = "3"
+engine = { path = "../crates/engine" }
 
 [[bin]]
 name = "protocol_frame_decode_fuzz"
@@ -63,5 +64,11 @@ doc = false
 [[bin]]
 name = "daemon_auth_token_parser"
 path = "fuzz_targets/daemon_auth_token_parser.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "manifest_parser"
+path = "fuzz_targets/manifest_parser.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/manifest_parser.rs
+++ b/fuzz/fuzz_targets/manifest_parser.rs
@@ -1,0 +1,8 @@
+// fuzz/fuzz_targets/manifest_parser.rs
+#![no_main]
+use engine::cdc::Manifest;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let _ = Manifest::parse(data);
+});


### PR DESCRIPTION
## Summary
- replace text-based manifest with append-only mmap-backed index
- deduplicate chunks by hash and path
- fuzz manifest parser for robustness

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: too many arguments and other lints)*
- `cargo test` *(fails: many CLI tests and others)*
- `make verify-comments` *(fails: disallowed comments in tests/daemon.rs)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4b33ffabc8323b44f26bb2f3aeae1