### PR TITLE
feat(filters): support from0 list parsing and merge tests

### DIFF
--- a/crates/filters/tests/from0_merges.rs
+++ b/crates/filters/tests/from0_merges.rs
@@ -1,0 +1,55 @@
+// crates/filters/tests/from0_merges.rs
+use filters::{parse, parse_list, Matcher};
+use proptest::prelude::*;
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(16))]
+    #[test]
+    fn list_parsing_from0_eq_newline(entries in prop::collection::vec("[^\0#\r\n]*", 0..4)) {
+        let mut bytes = Vec::new();
+        for e in &entries {
+            if !e.is_empty() {
+                bytes.extend(e.as_bytes());
+            }
+            bytes.push(0);
+        }
+        let parsed0 = parse_list(&bytes, true);
+        let joined = entries.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("\n");
+        let parsed_nl = parse_list(joined.as_bytes(), false);
+        prop_assert_eq!(parsed0, parsed_nl);
+    }
+}
+
+proptest! {
+    #[test]
+    fn recursive_merge_excludes_file(_dummy in any::<bool>()) {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        fs::write(root.join(".rsync-filter"), ": filter\n- .rsync-filter\n").unwrap();
+        fs::write(root.join("filter"), "- foo\n").unwrap();
+
+        let mut v = HashSet::new();
+        let rules = parse(": /.rsync-filter\n- .rsync-filter\n", &mut v, 0).unwrap();
+        let matcher = Matcher::new(rules).with_root(root);
+        prop_assert!(!matcher.is_included("foo").unwrap());
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(16))]
+    #[test]
+    fn parse_list_ignores_empty(entries in prop::collection::vec("[a-z]{0,3}", 0..4)) {
+        let mut bytes = Vec::new();
+        for e in &entries {
+            bytes.extend(e.as_bytes());
+            bytes.push(0);
+        }
+        bytes.extend(&[0,0]);
+        let parsed = parse_list(&bytes, true);
+        let expected: Vec<String> = entries.into_iter().filter(|s| !s.is_empty()).collect();
+        prop_assert_eq!(parsed, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- fix sign handling when applying dir-merge rule modifiers
- add helpers to parse null-separated lists and external filter files
- cover from0 parsing and recursive merges with property tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy lint errors in other crates)*
- `cargo clippy -p filters --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: numerous CLI tests fail)
- `cargo test -p filters`
- `make verify-comments` *(fails: disallowed comments in other crates)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4b270c3c883239daafe36e250813e