### PR TITLE
Add BLAKE2 and xxHash checksum support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,12 +218,14 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 name = "checksums"
 version = "0.1.0"
 dependencies = [
+ "blake2",
  "blake3",
  "cpufeatures",
  "hex",
  "md-5",
  "md4",
  "sha1",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -420,6 +431,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1372,6 +1384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1808,6 +1826,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "zerocopy"

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -9,6 +9,8 @@ sha1 = "0.10"
 md4 = "0.10"
 blake3 = { version = "1", optional = true }
 cpufeatures = "0.2"
+blake2 = "0.10"
+xxhash-rust = { version = "0.8", features = ["xxh3", "xxh64"] }
 
 [features]
 default = []

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -1,10 +1,13 @@
 // crates/checksums/src/lib.rs
+use blake2::{Blake2b512, Blake2s256};
 #[cfg(feature = "blake3")]
 use blake3::Hasher as Blake3;
 use md4::Md4;
 use md5::Digest;
 use md5::Md5;
 use sha1::Sha1;
+use xxhash_rust::xxh3::xxh3_128;
+use xxhash_rust::xxh64::xxh64;
 
 cpufeatures::new!(sse42, "sse4.2");
 cpufeatures::new!(avx2, "avx2");
@@ -21,6 +24,10 @@ pub enum StrongHash {
     Md5,
     Sha1,
     Md4,
+    Blake2b,
+    Blake2s,
+    Xxh64,
+    Xxh128,
     #[cfg(feature = "blake3")]
     Blake3,
 }
@@ -104,6 +111,30 @@ pub fn strong_digest(data: &[u8], alg: StrongHash, seed: u32) -> Vec<u8> {
             hasher.update(&seed.to_le_bytes());
             hasher.update(data);
             hasher.finalize().to_vec()
+        }
+        StrongHash::Blake2b => {
+            let mut hasher = Blake2b512::new();
+            hasher.update(&seed.to_le_bytes());
+            hasher.update(data);
+            hasher.finalize().to_vec()
+        }
+        StrongHash::Blake2s => {
+            let mut hasher = Blake2s256::new();
+            hasher.update(&seed.to_le_bytes());
+            hasher.update(data);
+            hasher.finalize().to_vec()
+        }
+        StrongHash::Xxh64 => {
+            let mut buf = Vec::with_capacity(4 + data.len());
+            buf.extend_from_slice(&seed.to_le_bytes());
+            buf.extend_from_slice(data);
+            xxh64(&buf, 0).to_le_bytes().to_vec()
+        }
+        StrongHash::Xxh128 => {
+            let mut buf = Vec::with_capacity(4 + data.len());
+            buf.extend_from_slice(&seed.to_le_bytes());
+            buf.extend_from_slice(data);
+            xxh3_128(&buf).to_le_bytes().to_vec()
         }
         #[cfg(feature = "blake3")]
         StrongHash::Blake3 => {
@@ -234,6 +265,27 @@ mod tests {
 
         let digest_md4 = strong_digest(b"hello world", StrongHash::Md4, 0);
         assert_eq!(hex::encode(digest_md4), "ea91f391e02b5e19f432b43bd87a531d",);
+
+        let digest_blake2b = strong_digest(b"hello world", StrongHash::Blake2b, 0);
+        assert_eq!(
+            hex::encode(digest_blake2b),
+            "d32b7e7c9028b6e0b1ddd7e83799a8b857a0afcaa370985dfaa42dfa59e275097eb75b99e05bb7ef3ac5cf74c957c3b7cad1dfcbb5e3380d56b63780394af8bd",
+        );
+
+        let digest_blake2s = strong_digest(b"hello world", StrongHash::Blake2s, 0);
+        assert_eq!(
+            hex::encode(digest_blake2s),
+            "a2dc531d6048af9ab7cf85108ebcf147632fce6290fbdfcd5ea789a0b31784d0",
+        );
+
+        let digest_xxh64 = strong_digest(b"hello world", StrongHash::Xxh64, 0);
+        assert_eq!(hex::encode(digest_xxh64), "648e94e9d09503e7");
+
+        let digest_xxh128 = strong_digest(b"hello world", StrongHash::Xxh128, 0);
+        assert_eq!(
+            hex::encode(digest_xxh128),
+            "052acb3009ceb7609305f939f85080da",
+        );
 
         #[cfg(feature = "blake3")]
         {

--- a/crates/checksums/tests/golden.rs
+++ b/crates/checksums/tests/golden.rs
@@ -37,6 +37,18 @@ fn builder_strong_digests() {
         .strong(StrongHash::Sha1)
         .build();
     let cfg_md4 = ChecksumConfigBuilder::new().strong(StrongHash::Md4).build();
+    let cfg_blake2b = ChecksumConfigBuilder::new()
+        .strong(StrongHash::Blake2b)
+        .build();
+    let cfg_blake2s = ChecksumConfigBuilder::new()
+        .strong(StrongHash::Blake2s)
+        .build();
+    let cfg_xxh64 = ChecksumConfigBuilder::new()
+        .strong(StrongHash::Xxh64)
+        .build();
+    let cfg_xxh128 = ChecksumConfigBuilder::new()
+        .strong(StrongHash::Xxh128)
+        .build();
     let data = b"hello world";
 
     let cs_md5 = cfg_md5.checksum(data);
@@ -50,7 +62,7 @@ fn builder_strong_digests() {
     assert_eq!(cs_sha1.weak, rolling_checksum(data));
     assert_eq!(
         hex::encode(cs_sha1.strong),
-        "1fb6475c524899f98b088f7608bdab8f1591e078"
+        "1fb6475c524899f98b088f7608bdab8f1591e078",
     );
 
     let cs_md4 = cfg_md4.checksum(data);
@@ -58,6 +70,31 @@ fn builder_strong_digests() {
     assert_eq!(
         hex::encode(cs_md4.strong),
         "ea91f391e02b5e19f432b43bd87a531d"
+    );
+
+    let cs_blake2b = cfg_blake2b.checksum(data);
+    assert_eq!(cs_blake2b.weak, rolling_checksum(data));
+    assert_eq!(
+        hex::encode(cs_blake2b.strong),
+        "d32b7e7c9028b6e0b1ddd7e83799a8b857a0afcaa370985dfaa42dfa59e275097eb75b99e05bb7ef3ac5cf74c957c3b7cad1dfcbb5e3380d56b63780394af8bd",
+    );
+
+    let cs_blake2s = cfg_blake2s.checksum(data);
+    assert_eq!(cs_blake2s.weak, rolling_checksum(data));
+    assert_eq!(
+        hex::encode(cs_blake2s.strong),
+        "a2dc531d6048af9ab7cf85108ebcf147632fce6290fbdfcd5ea789a0b31784d0",
+    );
+
+    let cs_xxh64 = cfg_xxh64.checksum(data);
+    assert_eq!(cs_xxh64.weak, rolling_checksum(data));
+    assert_eq!(hex::encode(cs_xxh64.strong), "648e94e9d09503e7");
+
+    let cs_xxh128 = cfg_xxh128.checksum(data);
+    assert_eq!(cs_xxh128.weak, rolling_checksum(data));
+    assert_eq!(
+        hex::encode(cs_xxh128.strong),
+        "052acb3009ceb7609305f939f85080da",
     );
 
     #[cfg(feature = "blake3")]
@@ -69,7 +106,7 @@ fn builder_strong_digests() {
         assert_eq!(cs_blake3.weak, rolling_checksum(data));
         assert_eq!(
             hex::encode(cs_blake3.strong),
-            "861487254e43e2e567ef5177d0c85452f1982ec89c494e8d4a957ff01dd9b421"
+            "861487254e43e2e567ef5177d0c85452f1982ec89c494e8d4a957ff01dd9b421",
         );
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -940,6 +940,9 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
             "md5" => StrongHash::Md5,
             "sha1" => StrongHash::Sha1,
             "md4" => StrongHash::Md4,
+            "blake2" => StrongHash::Blake2b,
+            "xxh64" => StrongHash::Xxh64,
+            "xxh128" => StrongHash::Xxh128,
             #[cfg(feature = "blake3")]
             "blake3" => StrongHash::Blake3,
             other => {
@@ -970,6 +973,18 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                 }
                 "md4" => {
                     chosen = StrongHash::Md4;
+                    break;
+                }
+                "blake2" => {
+                    chosen = StrongHash::Blake2b;
+                    break;
+                }
+                "xxh64" => {
+                    chosen = StrongHash::Xxh64;
+                    break;
+                }
+                "xxh128" => {
+                    chosen = StrongHash::Xxh128;
                     break;
                 }
                 _ => {}
@@ -2172,6 +2187,12 @@ mod tests {
         assert_eq!(opts.checksum_choice.as_deref(), Some("sha1"));
         let opts = ClientOpts::parse_from(["prog", "--checksum-choice", "md4", "src", "dst"]);
         assert_eq!(opts.checksum_choice.as_deref(), Some("md4"));
+        let opts = ClientOpts::parse_from(["prog", "--checksum-choice", "blake2", "src", "dst"]);
+        assert_eq!(opts.checksum_choice.as_deref(), Some("blake2"));
+        let opts = ClientOpts::parse_from(["prog", "--checksum-choice", "xxh64", "src", "dst"]);
+        assert_eq!(opts.checksum_choice.as_deref(), Some("xxh64"));
+        let opts = ClientOpts::parse_from(["prog", "--checksum-choice", "xxh128", "src", "dst"]);
+        assert_eq!(opts.checksum_choice.as_deref(), Some("xxh128"));
         let opts = ClientOpts::parse_from(["prog", "--cc", "md5", "src", "dst"]);
         assert_eq!(opts.checksum_choice.as_deref(), Some("md5"));
     }


### PR DESCRIPTION
## Summary
- implement BLAKE2b/BLAKE2s and xxh64/xxh128 checksum algorithms
- expose new options in CLI and configuration
- add golden tests for all checksum variants

## Testing
- `make verify-comments` *(fails: crates/daemon/src/lib.rs: contains doc comments; tests/daemon.rs: contains disallowed comments)*
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: transport crate warnings)*
- `cargo test` *(fails: integration tests in `cli`)*
- `cargo test -p checksums`


------
https://chatgpt.com/codex/tasks/task_e_68b4b09efebc8323a0a2abefda80f64c