### PR TITLE
Add SIMD-backed compression paths and feature-gated benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ version = "0.1.0"
 dependencies = [
  "cpufeatures",
  "flate2",
+ "lz4",
  "lz4_flex",
  "zstd",
 ]
@@ -785,6 +786,25 @@ version = "0.1.0"
 dependencies = [
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 flate2 = "1"
 zstd = "0.13"
 lz4_flex = { version = "0.11", optional = true }
+lz4 = { version = "1", optional = true }
 cpufeatures = "0.2"
 
 [features]
 default = []
-lz4 = ["lz4_flex"]
+lz4 = ["dep:lz4_flex", "dep:lz4"]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -41,8 +41,9 @@ name = "preallocate"
 harness = false
 
 [features]
-default = []
+default = ["zstd"]
 lz4 = ["compress/lz4"]
+zstd = []
 xattr = ["meta/xattr"]
 acl = ["meta/acl"]
 blake3 = ["checksums/blake3"]

--- a/crates/engine/benches/compress.rs
+++ b/crates/engine/benches/compress.rs
@@ -1,17 +1,22 @@
 // crates/engine/benches/compress.rs
+use compress::Compressor;
 #[cfg(feature = "lz4")]
 use compress::Lz4;
-use compress::{Compressor, Zstd};
+#[cfg(feature = "zstd")]
+use compress::Zstd;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn bench_compress(c: &mut Criterion) {
     let data = vec![0u8; 1024 * 1024];
-    let zstd = Zstd::default();
-    c.bench_function("zstd_compress_1mb", |b| {
-        b.iter(|| {
-            zstd.compress(&data).unwrap();
+    #[cfg(feature = "zstd")]
+    {
+        let zstd = Zstd::default();
+        c.bench_function("zstd_compress_1mb", |b| {
+            b.iter(|| {
+                zstd.compress(&data).unwrap();
+            });
         });
-    });
+    }
     #[cfg(feature = "lz4")]
     {
         let lz4 = Lz4;


### PR DESCRIPTION
## Summary
- add `lz4` crate and route SIMD functions through `lz4::block`
- use `zstd::bulk` for SIMD compression paths
- gate benchmark code by `lz4` and `zstd` features

## Testing
- `cargo clippy -p compress --all-targets --all-features -- -D warnings`
- `cargo test --all-features` *(fails: test result: FAILED. 31 passed; 32 failed)*
- `make verify-comments` *(fails: tests/daemon.rs: contains disallowed comments)*
- `make lint`
- `cargo bench -p engine --bench compress --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68b4b0a42c0883238189eef69775a5cf