### PR TITLE
feat(cli): support ignore-missing-args flag

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -159,7 +159,7 @@ struct ClientOpts {
     delete: bool,
     #[arg(long = "delete-before", help_heading = "Delete")]
     delete_before: bool,
-    #[arg(long = "delete-during", help_heading = "Delete", alias = "del")]
+    #[arg(long = "delete-during", help_heading = "Delete", visible_alias = "del")]
     delete_during: bool,
     #[arg(long = "delete-after", help_heading = "Delete")]
     delete_after: bool,
@@ -169,6 +169,8 @@ struct ClientOpts {
     delete_excluded: bool,
     #[arg(long = "delete-missing-args", help_heading = "Delete")]
     delete_missing_args: bool,
+    #[arg(long = "ignore-missing-args", help_heading = "Delete")]
+    ignore_missing_args: bool,
     #[arg(long = "remove-source-files", help_heading = "Delete")]
     remove_source_files: bool,
     #[arg(long = "ignore-errors", help_heading = "Delete")]
@@ -1124,7 +1126,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     let sync_opts = SyncOptions {
         delete: delete_mode,
         delete_excluded: opts.delete_excluded,
-        ignore_missing_args: false,
+        ignore_missing_args: opts.ignore_missing_args,
         delete_missing_args: opts.delete_missing_args,
         remove_source_files: opts.remove_source_files,
         ignore_errors: opts.ignore_errors,

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -78,8 +78,8 @@ negotiates version 73.
 | `--iconv` | — | ❌ | — | — |  | ≤3.2 |
 | `--ignore-errors` | — | ✅ | ❌ | [tests/delete_policy.rs](../tests/delete_policy.rs) |  | ≤3.2 |
 | `--ignore-existing` | — | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
-| `--ignore-missing-args` | — | ❌ | — | — |  | ≤3.2 |
-| `--ignore-times` | `-I` | ❌ | — | — |  | ≤3.2 |
+| `--ignore-missing-args` | — | ✅ | ❌ | [tests/ignore_missing_args.rs](../tests/ignore_missing_args.rs) |  | ≤3.2 |
+| `--ignore-times` | `-I` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--include` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--include-from` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--info` | — | ❌ | — | — |  | ≤3.2 |

--- a/tests/ignore_missing_args.rs
+++ b/tests/ignore_missing_args.rs
@@ -1,0 +1,25 @@
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+#[test]
+fn ignore_missing_args_allows_missing_sources() {
+    let dst = tempdir().unwrap();
+    // Without the flag, syncing a missing path should fail
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--local", "missing-src", dst.path().to_str().unwrap()])
+        .assert()
+        .failure();
+
+    // With --ignore-missing-args, the command should succeed
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--ignore-missing-args",
+            "missing-src",
+            dst.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -1,17 +1,17 @@
 [
   {
     "flag": "--8-bit-output",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--acls",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--address",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -51,7 +51,7 @@
   },
   {
     "flag": "--blocking-io",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -111,7 +111,7 @@
   },
   {
     "flag": "--copy-as",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -121,7 +121,7 @@
   },
   {
     "flag": "--copy-devices",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -151,17 +151,12 @@
   },
   {
     "flag": "--debug",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
-    "flag": "--del",
-    "status": "Error",
-    "notes": "an alias for --delete-during"
-  },
-  {
     "flag": "--delay-updates",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -187,7 +182,7 @@
   {
     "flag": "--delete-during",
     "status": "Supported",
-    "notes": ""
+    "notes": "an alias for --delete-during"
   },
   {
     "flag": "--delete-excluded",
@@ -196,7 +191,7 @@
   },
   {
     "flag": "--delete-missing-args",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -216,7 +211,7 @@
   },
   {
     "flag": "--early-input",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -241,7 +236,7 @@
   },
   {
     "flag": "--fake-super",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -256,7 +251,7 @@
   },
   {
     "flag": "--force",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -266,12 +261,12 @@
   },
   {
     "flag": "--fsync",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--fuzzy",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -281,7 +276,7 @@
   },
   {
     "flag": "--groupmap",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -301,12 +296,12 @@
   },
   {
     "flag": "--iconv",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--ignore-errors",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -316,7 +311,7 @@
   },
   {
     "flag": "--ignore-missing-args",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -336,7 +331,7 @@
   },
   {
     "flag": "--info",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -361,7 +356,7 @@
   },
   {
     "flag": "--keep-dirlinks",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -381,57 +376,57 @@
   },
   {
     "flag": "--log-file",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--log-file-format",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--max-alloc",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--max-delete",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--max-size",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--min-size",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--mkpath",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--modify-window",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--munge-links",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--no-OPTION",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--no-implied-dirs",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -446,17 +441,12 @@
   },
   {
     "flag": "--old-args",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
-    "flag": "--old-d",
-    "status": "Error",
-    "notes": "alias for --old-dirs"
-  },
-  {
     "flag": "--old-dirs",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -471,27 +461,27 @@
   },
   {
     "flag": "--one-file-system",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--only-write-batch",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--open-noatime",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--out-format",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--outbuf",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -551,7 +541,7 @@
   },
   {
     "flag": "--read-batch",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -566,12 +556,12 @@
   },
   {
     "flag": "--remote-option",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--remove-source-files",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -591,7 +581,7 @@
   },
   {
     "flag": "--secluded-args",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -606,7 +596,7 @@
   },
   {
     "flag": "--sockopts",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -626,27 +616,27 @@
   },
   {
     "flag": "--stderr",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--stop-after",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--stop-at",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--suffix",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
     "flag": "--super",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -666,7 +656,7 @@
   },
   {
     "flag": "--trust-sender",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
   },
   {
@@ -676,17 +666,17 @@
   },
   {
     "flag": "--usermap",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--verbose",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--version",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -696,7 +686,7 @@
   },
   {
     "flag": "--write-batch",
-    "status": "Error",
+    "status": "Supported",
     "notes": ""
   },
   {
@@ -706,262 +696,7 @@
   },
   {
     "flag": "--xattrs",
-    "status": "Error",
+    "status": "Ignored",
     "notes": ""
-  },
-  {
-    "flag": "-0",
-    "status": "Error",
-    "notes": "alias for --from0"
-  },
-  {
-    "flag": "-4",
-    "status": "Alias",
-    "notes": "alias for --ipv4"
-  },
-  {
-    "flag": "-6",
-    "status": "Alias",
-    "notes": "alias for --ipv6"
-  },
-  {
-    "flag": "-8",
-    "status": "Error",
-    "notes": "alias for --8-bit-output"
-  },
-  {
-    "flag": "-@",
-    "status": "Error",
-    "notes": "alias for --modify-window"
-  },
-  {
-    "flag": "-A",
-    "status": "Error",
-    "notes": "alias for --acls"
-  },
-  {
-    "flag": "-B",
-    "status": "Alias",
-    "notes": "alias for --block-size"
-  },
-  {
-    "flag": "-C",
-    "status": "Alias",
-    "notes": "alias for --cvs-exclude"
-  },
-  {
-    "flag": "-D",
-    "status": "Error",
-    "notes": "same as --devices --specials"
-  },
-  {
-    "flag": "-E",
-    "status": "Alias",
-    "notes": "alias for --executability"
-  },
-  {
-    "flag": "-F",
-    "status": "Error",
-    "notes": "same as --filter='dir-merge /.rsync-filter'"
-  },
-  {
-    "flag": "-H",
-    "status": "Error",
-    "notes": "alias for --hard-links"
-  },
-  {
-    "flag": "-I",
-    "status": "Alias",
-    "notes": "alias for --ignore-times"
-  },
-  {
-    "flag": "-J",
-    "status": "Alias",
-    "notes": "alias for --omit-link-times"
-  },
-  {
-    "flag": "-K",
-    "status": "Error",
-    "notes": "alias for --keep-dirlinks"
-  },
-  {
-    "flag": "-L",
-    "status": "Alias",
-    "notes": "alias for --copy-links"
-  },
-  {
-    "flag": "-M",
-    "status": "Error",
-    "notes": "alias for --remote-option"
-  },
-  {
-    "flag": "-N",
-    "status": "Alias",
-    "notes": "alias for --crtimes"
-  },
-  {
-    "flag": "-O",
-    "status": "Alias",
-    "notes": "alias for --omit-dir-times"
-  },
-  {
-    "flag": "-P",
-    "status": "Supported",
-    "notes": "same as --partial --progress"
-  },
-  {
-    "flag": "-R",
-    "status": "Alias",
-    "notes": "alias for --relative"
-  },
-  {
-    "flag": "-S",
-    "status": "Alias",
-    "notes": "alias for --sparse"
-  },
-  {
-    "flag": "-T",
-    "status": "Alias",
-    "notes": "alias for --temp-dir"
-  },
-  {
-    "flag": "-U",
-    "status": "Alias",
-    "notes": "alias for --atimes"
-  },
-  {
-    "flag": "-V",
-    "status": "Error",
-    "notes": "alias for --version"
-  },
-  {
-    "flag": "-W",
-    "status": "Alias",
-    "notes": "alias for --whole-file"
-  },
-  {
-    "flag": "-X",
-    "status": "Error",
-    "notes": "alias for --xattrs"
-  },
-  {
-    "flag": "-a",
-    "status": "Alias",
-    "notes": "alias for --archive"
-  },
-  {
-    "flag": "-b",
-    "status": "Alias",
-    "notes": "alias for --backup"
-  },
-  {
-    "flag": "-c",
-    "status": "Alias",
-    "notes": "alias for --checksum"
-  },
-  {
-    "flag": "-d",
-    "status": "Alias",
-    "notes": "alias for --dirs"
-  },
-  {
-    "flag": "-e",
-    "status": "Alias",
-    "notes": "alias for --rsh"
-  },
-  {
-    "flag": "-f",
-    "status": "Alias",
-    "notes": "alias for --filter"
-  },
-  {
-    "flag": "-g",
-    "status": "Error",
-    "notes": "alias for --group"
-  },
-  {
-    "flag": "-h",
-    "status": "Alias",
-    "notes": "alias for --help"
-  },
-  {
-    "flag": "-i",
-    "status": "Alias",
-    "notes": "alias for --itemize-changes"
-  },
-  {
-    "flag": "-k",
-    "status": "Alias",
-    "notes": "alias for --copy-dirlinks"
-  },
-  {
-    "flag": "-l",
-    "status": "Error",
-    "notes": "alias for --links"
-  },
-  {
-    "flag": "-m",
-    "status": "Alias",
-    "notes": "alias for --prune-empty-dirs"
-  },
-  {
-    "flag": "-n",
-    "status": "Alias",
-    "notes": "alias for --dry-run"
-  },
-  {
-    "flag": "-o",
-    "status": "Error",
-    "notes": "alias for --owner"
-  },
-  {
-    "flag": "-p",
-    "status": "Error",
-    "notes": "alias for --perms"
-  },
-  {
-    "flag": "-q",
-    "status": "Alias",
-    "notes": "alias for --quiet"
-  },
-  {
-    "flag": "-r",
-    "status": "Alias",
-    "notes": "alias for --recursive"
-  },
-  {
-    "flag": "-s",
-    "status": "Error",
-    "notes": "alias for --secluded-args"
-  },
-  {
-    "flag": "-t",
-    "status": "Error",
-    "notes": "alias for --times"
-  },
-  {
-    "flag": "-u",
-    "status": "Alias",
-    "notes": "alias for --update"
-  },
-  {
-    "flag": "-v",
-    "status": "Alias",
-    "notes": "alias for --verbose"
-  },
-  {
-    "flag": "-x",
-    "status": "Error",
-    "notes": "alias for --one-file-system"
-  },
-  {
-    "flag": "-y",
-    "status": "Error",
-    "notes": "alias for --fuzzy"
-  },
-  {
-    "flag": "-z",
-    "status": "Alias",
-    "notes": "alias for --compress"
   }
 ]

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -1,8 +1,8 @@
 | flag | status | notes |
 | --- | --- | --- |
-| --8-bit-output | Error |  |
-| --acls | Error |  |
-| --address | Error |  |
+| --8-bit-output | Supported |  |
+| --acls | Ignored |  |
+| --address | Supported |  |
 | --append | Supported |  |
 | --append-verify | Supported |  |
 | --archive | Supported |  |
@@ -10,7 +10,7 @@
 | --backup | Supported |  |
 | --backup-dir | Supported |  |
 | --block-size | Supported |  |
-| --blocking-io | Error |  |
+| --blocking-io | Supported |  |
 | --bwlimit | Supported |  |
 | --checksum | Supported |  |
 | --checksum-choice | Supported |  |
@@ -22,83 +22,81 @@
 | --compress-choice | Supported |  |
 | --compress-level | Supported |  |
 | --contimeout | Supported |  |
-| --copy-as | Error |  |
+| --copy-as | Supported |  |
 | --copy-dest | Supported |  |
-| --copy-devices | Error |  |
+| --copy-devices | Supported |  |
 | --copy-dirlinks | Supported |  |
 | --copy-links | Supported |  |
 | --copy-unsafe-links | Supported |  |
 | --crtimes | Supported |  |
 | --cvs-exclude | Supported |  |
-| --debug | Error |  |
-| --del | Error | an alias for --delete-during |
-| --delay-updates | Error |  |
+| --debug | Ignored |  |
+| --delay-updates | Ignored |  |
 | --delete | Supported |  |
 | --delete-after | Supported |  |
 | --delete-before | Supported |  |
 | --delete-delay | Supported |  |
-| --delete-during | Supported |  |
+| --delete-during | Supported | an alias for --delete-during |
 | --delete-excluded | Supported |  |
-| --delete-missing-args | Error |  |
+| --delete-missing-args | Supported |  |
 | --devices | Supported |  |
 | --dirs | Supported |  |
 | --dry-run | Supported |  |
-| --early-input | Error |  |
+| --early-input | Supported |  |
 | --exclude | Supported |  |
 | --exclude-from | Supported |  |
 | --executability | Supported |  |
 | --existing | Supported |  |
-| --fake-super | Error |  |
+| --fake-super | Ignored |  |
 | --files-from | Supported |  |
 | --filter | Supported |  |
-| --force | Error |  |
+| --force | Ignored |  |
 | --from0 | Supported |  |
-| --fsync | Error |  |
-| --fuzzy | Error |  |
+| --fsync | Ignored |  |
+| --fuzzy | Ignored |  |
 | --group | Supported |  |
-| --groupmap | Error |  |
+| --groupmap | Supported |  |
 | --hard-links | Supported |  |
 | --help | Supported |  |
 | --human-readable | Supported |  |
-| --iconv | Error |  |
-| --ignore-errors | Error |  |
+| --iconv | Ignored |  |
+| --ignore-errors | Supported |  |
 | --ignore-existing | Supported |  |
-| --ignore-missing-args | Error |  |
+| --ignore-missing-args | Supported |  |
 | --ignore-times | Supported |  |
 | --include | Supported |  |
 | --include-from | Supported |  |
-| --info | Error |  |
+| --info | Ignored |  |
 | --inplace | Supported |  |
 | --ipv4 | Supported |  |
 | --ipv6 | Supported |  |
 | --itemize-changes | Supported |  |
-| --keep-dirlinks | Error |  |
+| --keep-dirlinks | Ignored |  |
 | --link-dest | Supported |  |
 | --links | Supported |  |
 | --list-only | Supported |  |
-| --log-file | Error |  |
-| --log-file-format | Error |  |
-| --max-alloc | Error |  |
-| --max-delete | Error |  |
-| --max-size | Error |  |
-| --min-size | Error |  |
-| --mkpath | Error |  |
-| --modify-window | Error |  |
-| --munge-links | Error |  |
-| --no-OPTION | Error |  |
-| --no-implied-dirs | Error |  |
+| --log-file | Ignored |  |
+| --log-file-format | Ignored |  |
+| --max-alloc | Ignored |  |
+| --max-delete | Supported |  |
+| --max-size | Supported |  |
+| --min-size | Supported |  |
+| --mkpath | Ignored |  |
+| --modify-window | Ignored |  |
+| --munge-links | Ignored |  |
+| --no-OPTION | Ignored |  |
+| --no-implied-dirs | Ignored |  |
 | --no-motd | Supported |  |
 | --numeric-ids | Supported |  |
-| --old-args | Error |  |
-| --old-d | Error | alias for --old-dirs |
-| --old-dirs | Error |  |
+| --old-args | Ignored |  |
+| --old-dirs | Ignored |  |
 | --omit-dir-times | Supported |  |
 | --omit-link-times | Supported |  |
-| --one-file-system | Error |  |
-| --only-write-batch | Error |  |
-| --open-noatime | Error |  |
-| --out-format | Error |  |
-| --outbuf | Error |  |
+| --one-file-system | Ignored |  |
+| --only-write-batch | Ignored |  |
+| --open-noatime | Ignored |  |
+| --out-format | Ignored |  |
+| --outbuf | Ignored |  |
 | --owner | Supported |  |
 | --partial | Supported |  |
 | --partial-dir | Supported |  |
@@ -110,86 +108,35 @@
 | --protocol | Supported |  |
 | --prune-empty-dirs | Supported |  |
 | --quiet | Supported |  |
-| --read-batch | Error |  |
+| --read-batch | Ignored |  |
 | --recursive | Supported |  |
 | --relative | Supported |  |
-| --remote-option | Error |  |
-| --remove-source-files | Error |  |
+| --remote-option | Supported |  |
+| --remove-source-files | Supported |  |
 | --rsh | Supported |  |
 | --rsync-path | Supported |  |
 | --safe-links | Supported |  |
-| --secluded-args | Error |  |
+| --secluded-args | Supported |  |
 | --size-only | Supported |  |
 | --skip-compress | Supported |  |
-| --sockopts | Error |  |
+| --sockopts | Supported |  |
 | --sparse | Supported |  |
 | --specials | Supported |  |
 | --stats | Supported |  |
-| --stderr | Error |  |
-| --stop-after | Error |  |
-| --stop-at | Error |  |
-| --suffix | Error |  |
-| --super | Error |  |
+| --stderr | Ignored |  |
+| --stop-after | Ignored |  |
+| --stop-at | Ignored |  |
+| --suffix | Ignored |  |
+| --super | Ignored |  |
 | --temp-dir | Supported |  |
 | --timeout | Supported |  |
 | --times | Supported |  |
-| --trust-sender | Error |  |
+| --trust-sender | Ignored |  |
 | --update | Supported |  |
-| --usermap | Error |  |
-| --verbose | Error |  |
-| --version | Error |  |
+| --usermap | Supported |  |
+| --verbose | Supported |  |
+| --version | Supported |  |
 | --whole-file | Supported |  |
-| --write-batch | Error |  |
+| --write-batch | Supported |  |
 | --write-devices | Supported |  |
-| --xattrs | Error |  |
-| -0 | Error | alias for --from0 |
-| -4 | Alias | alias for --ipv4 |
-| -6 | Alias | alias for --ipv6 |
-| -8 | Error | alias for --8-bit-output |
-| -@ | Error | alias for --modify-window |
-| -A | Error | alias for --acls |
-| -B | Alias | alias for --block-size |
-| -C | Alias | alias for --cvs-exclude |
-| -D | Error | same as --devices --specials |
-| -E | Alias | alias for --executability |
-| -F | Error | same as --filter='dir-merge /.rsync-filter' |
-| -H | Error | alias for --hard-links |
-| -I | Alias | alias for --ignore-times |
-| -J | Alias | alias for --omit-link-times |
-| -K | Error | alias for --keep-dirlinks |
-| -L | Alias | alias for --copy-links |
-| -M | Error | alias for --remote-option |
-| -N | Alias | alias for --crtimes |
-| -O | Alias | alias for --omit-dir-times |
-| -P | Supported | same as --partial --progress |
-| -R | Alias | alias for --relative |
-| -S | Alias | alias for --sparse |
-| -T | Alias | alias for --temp-dir |
-| -U | Alias | alias for --atimes |
-| -V | Error | alias for --version |
-| -W | Alias | alias for --whole-file |
-| -X | Error | alias for --xattrs |
-| -a | Alias | alias for --archive |
-| -b | Alias | alias for --backup |
-| -c | Alias | alias for --checksum |
-| -d | Alias | alias for --dirs |
-| -e | Alias | alias for --rsh |
-| -f | Alias | alias for --filter |
-| -g | Error | alias for --group |
-| -h | Alias | alias for --help |
-| -i | Alias | alias for --itemize-changes |
-| -k | Alias | alias for --copy-dirlinks |
-| -l | Error | alias for --links |
-| -m | Alias | alias for --prune-empty-dirs |
-| -n | Alias | alias for --dry-run |
-| -o | Error | alias for --owner |
-| -p | Error | alias for --perms |
-| -q | Alias | alias for --quiet |
-| -r | Alias | alias for --recursive |
-| -s | Error | alias for --secluded-args |
-| -t | Error | alias for --times |
-| -u | Alias | alias for --update |
-| -v | Alias | alias for --verbose |
-| -x | Error | alias for --one-file-system |
-| -y | Error | alias for --fuzzy |
-| -z | Alias | alias for --compress |
+| --xattrs | Ignored |  |


### PR DESCRIPTION
## Summary
- parse `--ignore-missing-args` and wire through to engine
- document `--ignore-missing-args` and `--ignore-times`
- enhance flag matrix tool to check rsync flag coverage via docs
- add integration test for `--ignore-missing-args`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: this function has too many arguments (12/7))*
- `cargo test` *(fails: use of unresolved module or unlinked crate `meta`)*
- `cargo test --test ignore_missing_args`
- `make verify-comments` *(fails: tests/daemon.rs contains disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4b6989580832399abf48f04f93c12