### PR TITLE
Add macOS preallocation fallback

### DIFF
--- a/docs/perf.md
+++ b/docs/perf.md
@@ -10,9 +10,10 @@ Two new options improve resource usage during transfers:
 * `--max-alloc` limits in-memory buffer sizes. The engine now enforces this cap
   before allocating buffers in core routines, preventing pathological memory
   spikes during large transfers.
-* `--preallocate` uses platform-specific `fallocate`/`posix_fallocate` to
-  allocate destination files up front, reducing fragmentation and surfacing
-  out-of-space errors early.
+* `--preallocate` uses platform-specific `fallocate`, `posix_fallocate`, or
+  macOS `fcntl` with `F_PREALLOCATE` (falling back to `ftruncate`) to allocate
+  destination files up front, reducing fragmentation and surfacing out-of-space
+  errors early.
 
 Benchmarks are available under `crates/engine/benches`. Running on the default
 CI environment produced the following sample results:


### PR DESCRIPTION
## Summary
- handle file preallocation per-platform: fallocate on Linux/Android, `F_PREALLOCATE` on macOS, `posix_fallocate` or `set_len` elsewhere
- document macOS preallocation behavior in perf guide

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy warnings in transport and engine crates)*
- `cargo test` *(fails: unresolved import in tests/local_sync_tree.rs)*
- `make verify-comments` *(fails: tests/daemon.rs contains disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4b748fca083239f13cd7fec525367