### PR TITLE
Add systemd service and example daemon config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: oc-rsync-${{ matrix.target }}
-          path: target/${{ matrix.target }}/release/oc-rsync
+          path: |
+            target/${{ matrix.target }}/release/oc-rsync
+            packaging/rsyncd.conf.example
+            packaging/systemd/oc-rsyncd.service
 
   fuzz:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ cargo build -p oc-rsync-bin --bin oc-rsync
 cargo run -p oc-rsync-bin -- "<SRC>" "<DEST>"
 ```
 
+## Packaging
+
+Release tarballs include sample files under `packaging/` to help run the
+daemon:
+
+- `packaging/rsyncd.conf.example` – example configuration file
+- `packaging/systemd/oc-rsyncd.service` – systemd service unit
+
 ## Milestone Roadmap
 1. **M1—Bootstrap** – repository builds; `walk` and `checksums` crates generate file signatures.
 2. **M2—Delta Engine** – `engine` drives local delta transfers with metadata preservation.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -7,6 +7,14 @@ The default listener binds to all IPv4 interfaces on port 873. Supply
 listener to IPv4 or IPv6 addresses respectively. These can be combined with
 `--address` to bind a specific interface.
 
+## Example packaging
+
+Sample files for running the daemon are provided under `packaging/` and are
+included in release artifacts:
+
+- `packaging/rsyncd.conf.example` – example configuration file
+- `packaging/systemd/oc-rsyncd.service` – systemd service unit
+
 ## Module setup
 
 Modules map a name to a directory on disk. Each module is supplied on the command line:

--- a/packaging/rsyncd.conf.example
+++ b/packaging/rsyncd.conf.example
@@ -1,0 +1,10 @@
+# Sample oc-rsync daemon configuration
+# Installed at /etc/oc-rsyncd/rsyncd.conf
+
+pid file = /run/oc-rsyncd.pid
+log file = /var/log/oc-rsyncd.log
+
+[data]
+    path = /srv/oc-rsync/data
+    comment = Exported data
+    read only = false

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=oc-rsync daemon
+Documentation=man:oc-rsync(1) man:oc-rsyncd.conf(5)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config /etc/oc-rsyncd/rsyncd.conf
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add systemd unit for oc-rsync daemon and example rsyncd.conf
- document packaging paths and mention inclusion in release tarballs
- ship sample configuration and service in release artifacts

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: too many arguments, missing allows)*
- `cargo test --all-features` *(fails: cannot find -lacl)*
- `make verify-comments` *(fails: tests contain disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4bcae4f348323b406cb77ed3a0010