### PR TITLE
Prefer v32 protocol version with v31 fallback

### DIFF
--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -1,5 +1,5 @@
 // crates/protocol/tests/protocol.rs
-use protocol::{negotiate_version, Frame, Message, Msg, Tag};
+use protocol::{negotiate_version, Frame, Message, Msg, Tag, V31, V32};
 
 #[test]
 fn frame_roundtrip() {
@@ -38,13 +38,11 @@ fn keepalive_roundtrip() {
 
 #[test]
 fn version_negotiation() {
-    assert_eq!(negotiate_version(73, 73), Ok(73));
-    assert_eq!(negotiate_version(73, 40), Ok(40));
-    assert_eq!(negotiate_version(40, 73), Ok(40));
-    for v in 27..=40 {
-        assert_eq!(negotiate_version(73, v), Ok(v));
-    }
-    assert!(negotiate_version(27, 26).is_err());
+    assert_eq!(negotiate_version(V32, V32), Ok(V32));
+    assert_eq!(negotiate_version(V32, V31), Ok(V31));
+    assert_eq!(negotiate_version(V31, V32), Ok(V31));
+    assert_eq!(negotiate_version(V31, V31), Ok(V31));
+    assert!(negotiate_version(V32, 30).is_err());
 }
 
 #[test]

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -4,7 +4,7 @@ use checksums::StrongHash;
 use compress::{available_codecs, encode_codecs, Codec};
 #[cfg(feature = "blake3")]
 use protocol::CAP_BLAKE3;
-use protocol::{Server, CAP_CODECS, CAP_LZ4, CAP_ZSTD, LATEST_VERSION, SUPPORTED_CAPS};
+use protocol::{Server, CAP_CODECS, CAP_LZ4, CAP_ZSTD, LATEST_VERSION, SUPPORTED_CAPS, V31, V32};
 use std::io::Cursor;
 use std::time::Duration;
 
@@ -82,7 +82,7 @@ fn server_classic_versions() {
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
 
-    for ver in 27u32..=32 {
+    for ver in [V31, V32] {
         let mut input = Cursor::new({
             let mut v = vec![0];
             v.extend_from_slice(&ver.to_be_bytes());


### PR DESCRIPTION
## Summary
- define protocol version constants `V32` and `V31`
- negotiate v32 when possible, falling back to v31
- exercise v32/v31 version negotiation in protocol tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: this function has too many arguments, get_first, etc.)*
- `cargo test --all-features` *(fails: linking with `cc` failed: exit status: 1)*
- `cargo test -p protocol --all-features`
- `make lint`
- `make verify-comments` *(fails: tests/daemon.rs contains disallowed comments)*

------
https://chatgpt.com/codex/tasks/task_e_68b4bcc611e48323ac332cbc304813d9