### PR TITLE
Allow walker to process sub-kilobyte files

### DIFF
--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -7,7 +7,6 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
-const MIN_FILE_SIZE: u64 = 1024;
 #[derive(Debug, Clone)]
 pub struct Entry {
     pub prefix_len: usize,
@@ -103,11 +102,6 @@ impl Iterator for Walk {
                         Ok(m) => m,
                         Err(e) => return Some(Err(e)),
                     };
-                    let len = meta.len();
-                    if entry.file_type().is_file() && len < MIN_FILE_SIZE {
-                        continue;
-                    }
-
                     if let Some(max) = self.max_file_size {
                         if meta.is_file() && meta.len() > max {
                             continue;

--- a/crates/walk/tests/walk.rs
+++ b/crates/walk/tests/walk.rs
@@ -40,7 +40,9 @@ fn walk_includes_files_dirs_and_symlinks() {
     assert!(entries
         .iter()
         .any(|(p, t)| p == &link_path && t.is_symlink()));
-    assert!(!entries.iter().any(|(p, _)| p == &root.join("small.txt")));
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p == &root.join("small.txt") && t.is_file()));
 }
 
 #[test]
@@ -70,8 +72,10 @@ fn walk_preserves_order_and_bounds_batches() {
         root.to_path_buf(),
         root.join("dir"),
         root.join("dir/big1"),
+        root.join("dir/small1"),
         root.join("dir/sub"),
         root.join("dir/sub/big2"),
+        root.join("top_small.txt"),
     ];
     assert_eq!(paths, expected);
 }

--- a/tests/perf_limits.rs
+++ b/tests/perf_limits.rs
@@ -128,3 +128,23 @@ fn min_size_skips_small_files() {
     assert!(!dst.join("small.bin").exists());
     assert!(dst.join("large.bin").exists());
 }
+
+#[test]
+fn transfers_sub_kilobyte_files() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("tiny.bin"), vec![0u8; 512]).unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--local", "--recursive", &src_arg, dst.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let meta = fs::metadata(dst.join("tiny.bin")).unwrap();
+    assert_eq!(meta.len(), 512);
+}


### PR DESCRIPTION
## Summary
- remove hardcoded minimum file size filter from filesystem walker so all files are yielded
- update walker tests and add integration test transferring sub-kilobyte files

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: too many arguments, get_first, etc.)*
- `cargo test` *(fails: unresolved import `meta` in tests/local_sync_tree.rs)*
- `cargo test --test perf_limits`
- `cargo test -p walk`
- `make verify-comments` *(fails: disallowed comments in tests/daemon.rs and tests/ignore_missing_args.rs)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4bcd81f188323940eab7940863a2b