### PR TITLE
Enable FileTypeExt on all Unix systems in local sync test

### DIFF
--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -11,7 +11,7 @@ use nix::sys::stat::Mode;
 use nix::sys::stat::SFlag;
 use std::collections::BTreeMap;
 use std::fs;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use std::os::unix::fs::FileTypeExt;
 #[cfg(unix)]
 use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};


### PR DESCRIPTION
## Summary
- broaden FileTypeExt import to #[cfg(unix)] in `local_sync_tree` test so any Unix target can access the trait

## Testing
- `cargo fmt --all`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: this function has too many arguments in crates/transport/src/ssh.rs)*
- `make verify-comments` *(fails: crates/filelist/src/lib.rs contains disallowed comments)*
- `cargo test` *(fails: daemon tests unable to start)*
- `cargo test --test local_sync_tree`


------
https://chatgpt.com/codex/tasks/task_e_68b4c762fa1c8323b9c2a349bf74dc0e