### PR TITLE
Harden oc-rsyncd service unit and test packaging artifacts

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -15,6 +15,15 @@ included in release artifacts:
 - `packaging/rsyncd.conf.example` – example configuration file
 - `packaging/systemd/oc-rsyncd.service` – systemd service unit
 
+### systemd hardening
+
+The bundled `oc-rsyncd.service` applies systemd sandboxing features to reduce
+attack surface. It enables `NoNewPrivileges=yes` and mounts the host filesystem
+read-only with `ProtectSystem=strict`. The unit grants only the
+`CAP_NET_BIND_SERVICE` capability via `CapabilityBoundingSet`/`AmbientCapabilities`
+and creates an isolated state directory with `StateDirectory=oc-rsyncd`.
+These settings may be relaxed if the daemon requires additional privileges.
+
 ## Module setup
 
 Modules map a name to a directory on disk. Each module is supplied on the command line:

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -7,6 +7,23 @@ After=network.target
 Type=simple
 ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config /etc/oc-rsyncd/rsyncd.conf
 Restart=on-failure
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+RestrictNamespaces=yes
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+MemoryDenyWriteExecute=yes
+StateDirectory=oc-rsyncd
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+
+#[test]
+fn packaging_includes_service_unit() {
+    let output = Command::new("cargo")
+        .args(["package", "--list", "--allow-dirty", "--no-verify"])
+        .output()
+        .expect("failed to run cargo package");
+    assert!(output.status.success(), "cargo package failed");
+    let listing = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        listing
+            .lines()
+            .any(|l| l.trim() == "packaging/systemd/oc-rsyncd.service"),
+        "service unit missing from package list:\n{}",
+        listing
+    );
+    assert!(
+        listing
+            .lines()
+            .any(|l| l.trim() == "packaging/rsyncd.conf.example"),
+        "example config missing from package list:\n{}",
+        listing
+    );
+}


### PR DESCRIPTION
## Summary
- expand `oc-rsyncd.service` with systemd security directives and state directory isolation
- document new hardening measures in daemon guide
- add CI test ensuring packaging files ship with the crate

## Testing
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: function has too many arguments and other lints in transport crate)*
- `cargo test` *(fails: daemon tests did not start)*
- `make verify-comments`
- `cargo test --test packaging`


------
https://chatgpt.com/codex/tasks/task_e_68b4d2b3c1888323bebc401b4ab1171a