### PR TITLE
Add granular logging flag support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,6 +805,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 name = "logging"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "tracing",
  "tracing-subscriber",
 ]

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,6 +1,6 @@
 // bin/oc-rsync/src/main.rs
 use engine::Result;
-use logging::LogFormat;
+use logging::{DebugFlag, InfoFlag, LogFormat};
 use oc_rsync_cli::cli_command;
 
 fn main() -> Result<()> {
@@ -10,8 +10,14 @@ fn main() -> Result<()> {
     }
     let matches = cli_command().get_matches();
     let verbose = matches.get_count("verbose") as u8;
-    let info = false;
-    let debug = false;
+    let info: Vec<InfoFlag> = matches
+        .get_many::<InfoFlag>("info")
+        .map(|v| v.copied().collect())
+        .unwrap_or_default();
+    let debug: Vec<DebugFlag> = matches
+        .get_many::<DebugFlag>("debug")
+        .map(|v| v.copied().collect())
+        .unwrap_or_default();
     let log_format = matches
         .get_one::<String>("log_format")
         .map(|f| {
@@ -22,6 +28,6 @@ fn main() -> Result<()> {
             }
         })
         .unwrap_or(LogFormat::Text);
-    logging::init(log_format, verbose, info, debug);
+    logging::init(log_format, verbose, &info, &debug);
     oc_rsync_cli::run(&matches)
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -21,7 +21,7 @@ use engine::{
     sync, DeleteMode, EngineError, IdMapper, ModernCdc, Result, Stats, StrongHash, SyncOptions,
 };
 use filters::{default_cvs_rules, parse, Matcher, Rule};
-use logging::human_bytes;
+use logging::{human_bytes, DebugFlag, InfoFlag};
 use meta::{parse_chmod, parse_chown, parse_id_map};
 #[cfg(unix)]
 use nix::unistd::{Uid, User};
@@ -140,6 +140,22 @@ struct ClientOpts {
     verbose: u8,
     #[arg(long = "log-format", help_heading = "Output", value_parser = ["text", "json"])]
     log_format: Option<String>,
+    #[arg(
+        long,
+        value_name = "FLAGS",
+        value_delimiter = ',',
+        value_enum,
+        help_heading = "Output"
+    )]
+    info: Vec<InfoFlag>,
+    #[arg(
+        long,
+        value_name = "FLAGS",
+        value_delimiter = ',',
+        value_enum,
+        help_heading = "Output"
+    )]
+    debug: Vec<DebugFlag>,
     #[arg(long = "human-readable", help_heading = "Output")]
     human_readable: bool,
     #[arg(short, long, help_heading = "Output")]

--- a/crates/cli/tests/logging_flags.rs
+++ b/crates/cli/tests/logging_flags.rs
@@ -1,6 +1,8 @@
 use assert_cmd::Command;
 use oc_rsync_cli::cli_command;
 use tempfile::tempdir;
+use tracing::subscriber::with_default;
+use tracing::Level;
 
 #[test]
 fn verbose_and_log_format_json_parity() {
@@ -32,14 +34,64 @@ fn verbose_and_log_format_json_parity() {
         ])
         .unwrap();
     let verbose = matches.get_count("verbose") as u8;
-    let info = false;
-    let debug = false;
+    let info: Vec<logging::InfoFlag> = matches
+        .get_many::<logging::InfoFlag>("info")
+        .map(|v| v.copied().collect())
+        .unwrap_or_default();
+    let debug: Vec<logging::DebugFlag> = matches
+        .get_many::<logging::DebugFlag>("debug")
+        .map(|v| v.copied().collect())
+        .unwrap_or_default();
     let log_format = if matches.get_one::<String>("log_format").map(String::as_str) == Some("json")
     {
         logging::LogFormat::Json
     } else {
         logging::LogFormat::Text
     };
-    logging::init(log_format, verbose, info, debug);
+    logging::init(log_format, verbose, &info, &debug);
     oc_rsync_cli::run(&matches).unwrap();
+}
+
+#[test]
+fn info_flag_enables_progress() {
+    let matches = cli_command()
+        .try_get_matches_from(["oc-rsync", "--info=progress", "src", "dst"])
+        .unwrap();
+    let info: Vec<logging::InfoFlag> = matches
+        .get_many::<logging::InfoFlag>("info")
+        .map(|v| v.copied().collect())
+        .unwrap_or_default();
+    let sub = logging::subscriber(logging::LogFormat::Text, 0, &info, &[]);
+    with_default(sub, || {
+        assert!(tracing::enabled!(
+            target: logging::InfoFlag::Progress.target(),
+            Level::INFO
+        ));
+        assert!(!tracing::enabled!(
+            target: logging::InfoFlag::Stats.target(),
+            Level::INFO
+        ));
+    });
+}
+
+#[test]
+fn debug_flag_enables_flist() {
+    let matches = cli_command()
+        .try_get_matches_from(["oc-rsync", "--debug=flist", "src", "dst"])
+        .unwrap();
+    let debug: Vec<logging::DebugFlag> = matches
+        .get_many::<logging::DebugFlag>("debug")
+        .map(|v| v.copied().collect())
+        .unwrap_or_default();
+    let sub = logging::subscriber(logging::LogFormat::Text, 0, &[], &debug);
+    with_default(sub, || {
+        assert!(tracing::enabled!(
+            target: logging::DebugFlag::Flist.target(),
+            Level::DEBUG
+        ));
+        assert!(!tracing::enabled!(
+            target: logging::DebugFlag::Hash.target(),
+            Level::DEBUG
+        ));
+    });
 }

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+clap = { version = "4", features = ["derive"] }

--- a/crates/logging/tests/levels.rs
+++ b/crates/logging/tests/levels.rs
@@ -1,10 +1,10 @@
-use logging::{subscriber, LogFormat};
+use logging::{subscriber, DebugFlag, InfoFlag, LogFormat};
 use tracing::subscriber::with_default;
 use tracing::Level;
 
 #[test]
 fn info_not_emitted_by_default() {
-    let sub = subscriber(LogFormat::Text, 0, false, false);
+    let sub = subscriber(LogFormat::Text, 0, &[], &[]);
     with_default(sub, || {
         assert!(!tracing::enabled!(Level::INFO));
     });
@@ -12,7 +12,7 @@ fn info_not_emitted_by_default() {
 
 #[test]
 fn verbose_enables_info() {
-    let sub = subscriber(LogFormat::Text, 1, false, false);
+    let sub = subscriber(LogFormat::Text, 1, &[], &[]);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -20,7 +20,7 @@ fn verbose_enables_info() {
 
 #[test]
 fn debug_enables_debug() {
-    let sub = subscriber(LogFormat::Text, 0, false, true);
+    let sub = subscriber(LogFormat::Text, 0, &[], &[DebugFlag::Flist]);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -28,7 +28,7 @@ fn debug_enables_debug() {
 
 #[test]
 fn debug_with_two_v() {
-    let sub = subscriber(LogFormat::Text, 2, false, false);
+    let sub = subscriber(LogFormat::Text, 2, &[], &[]);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -36,7 +36,7 @@ fn debug_with_two_v() {
 
 #[test]
 fn info_flag_enables_info() {
-    let sub = subscriber(LogFormat::Text, 0, true, false);
+    let sub = subscriber(LogFormat::Text, 0, &[InfoFlag::Progress], &[]);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -44,7 +44,7 @@ fn info_flag_enables_info() {
 
 #[test]
 fn json_verbose_enables_info() {
-    let sub = subscriber(LogFormat::Json, 1, false, false);
+    let sub = subscriber(LogFormat::Json, 1, &[], &[]);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use compress::available_codecs;
 use engine::{EngineError, Result, SyncOptions};
 use filetime::{set_file_times, set_symlink_file_times, FileTime};
 use filters::Matcher;
-use logging::{subscriber, LogFormat};
+use logging::{subscriber, DebugFlag, InfoFlag, LogFormat};
 #[cfg(unix)]
 use nix::{
     sys::stat::{dev_t, mknod, Mode, SFlag},
@@ -21,8 +21,8 @@ use tracing::subscriber::with_default;
 pub struct SyncConfig {
     pub log_format: LogFormat,
     pub verbose: u8,
-    pub info: bool,
-    pub debug: bool,
+    pub info: Vec<InfoFlag>,
+    pub debug: Vec<DebugFlag>,
 }
 
 impl Default for SyncConfig {
@@ -30,14 +30,14 @@ impl Default for SyncConfig {
         Self {
             log_format: LogFormat::Text,
             verbose: 0,
-            info: false,
-            debug: false,
+            info: Vec::new(),
+            debug: Vec::new(),
         }
     }
 }
 
 pub fn synchronize_with_config(src: &Path, dst: &Path, cfg: &SyncConfig) -> Result<()> {
-    let sub = subscriber(cfg.log_format, cfg.verbose, cfg.info, cfg.debug);
+    let sub = subscriber(cfg.log_format, cfg.verbose, &cfg.info, &cfg.debug);
     with_default(sub, || -> Result<()> {
         if !dst.exists() {
             fs::create_dir_all(dst)?;


### PR DESCRIPTION
## Summary
- support `--info=FLAGS` and `--debug=FLAGS` in CLI
- expose logging verbosity groups and targets
- tests for info/debug flag parsing and log selection

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: op_ref, while_let_loop, suspicious_open_options, seek_from_current, collapsible_if, unnecessary-map-or, map_flatten, while_let_on_iterator, etc.)*
- `cargo test` *(fails: daemon tests did not start)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d289b1a48323917ff7041792eb29