### PR TITLE
Handle modify-window timestamp tolerance

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -347,6 +347,8 @@ struct ClientOpts {
     timeout: Option<Duration>,
     #[arg(long = "contimeout", value_name = "SECONDS", value_parser = parse_duration, help_heading = "Misc")]
     contimeout: Option<Duration>,
+    #[arg(long = "modify-window", value_name = "SECONDS", value_parser = parse_duration, help_heading = "Misc")]
+    modify_window: Option<Duration>,
     #[arg(
         long = "protocol",
         value_name = "VER",
@@ -1197,6 +1199,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         append_verify: opts.append_verify,
         numeric_ids: opts.numeric_ids,
         inplace: opts.inplace || opts.write_devices,
+        modify_window: opts.modify_window.unwrap_or(Duration::ZERO),
         bwlimit: opts.bwlimit,
         block_size,
         link_dest: opts.link_dest.clone(),

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -13,6 +13,7 @@ use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, MetadataExt};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 
 use checksums::{ChecksumConfig, ChecksumConfigBuilder};
 pub use checksums::{ModernHash, StrongHash};
@@ -677,7 +678,12 @@ impl Sender {
         if let (Ok(src_meta), Ok(dst_meta)) = (fs::metadata(path), fs::metadata(dest)) {
             if src_meta.len() == dst_meta.len() {
                 if let (Ok(sm), Ok(dm)) = (src_meta.modified(), dst_meta.modified()) {
-                    return sm == dm;
+                    let diff = if sm > dm {
+                        sm.duration_since(dm).unwrap_or(Duration::ZERO)
+                    } else {
+                        dm.duration_since(sm).unwrap_or(Duration::ZERO)
+                    };
+                    return diff <= self.opts.modify_window;
                 }
             }
         }
@@ -1283,6 +1289,7 @@ pub struct SyncOptions {
     pub append_verify: bool,
     pub numeric_ids: bool,
     pub inplace: bool,
+    pub modify_window: Duration,
     pub bwlimit: Option<u64>,
     pub block_size: usize,
     pub link_dest: Option<PathBuf>,
@@ -1372,6 +1379,7 @@ impl Default for SyncOptions {
             append_verify: false,
             numeric_ids: false,
             inplace: false,
+            modify_window: Duration::ZERO,
             bwlimit: None,
             block_size: 1024,
             link_dest: None,
@@ -1722,7 +1730,13 @@ pub fn sync(
                                 (src_meta.modified(), dst_meta.modified())
                             {
                                 if dst_mtime > src_mtime {
-                                    continue;
+                                    if dst_mtime
+                                        .duration_since(src_mtime)
+                                        .unwrap_or(Duration::ZERO)
+                                        > opts.modify_window
+                                    {
+                                        continue;
+                                    }
                                 }
                             }
                         }

--- a/crates/filelist/src/lib.rs
+++ b/crates/filelist/src/lib.rs
@@ -81,7 +81,7 @@ impl Decoder {
         let path = String::from_utf8(path_bytes).map_err(|_| DecodeError::Utf8)?;
         let (uid, rest) = decode_id(input, &mut self.uid_table, true)?;
         let (gid, rest) = decode_id(rest, &mut self.gid_table, false)?;
-        if !rest.is_empty() {}
+        debug_assert!(rest.is_empty());
         self.prev_path = path.clone();
         Ok(Entry { path, uid, gid })
     }

--- a/tests/modify_window.rs
+++ b/tests/modify_window.rs
@@ -1,0 +1,51 @@
+// tests/modify_window.rs
+
+use assert_cmd::Command;
+use filetime::{set_file_mtime, FileTime};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn modify_window_treats_close_times_as_equal() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file"), b"hi").unwrap();
+    fs::write(dst.join("file"), b"hi").unwrap();
+
+    let newer = FileTime::from_unix_time(1_000_000, 0);
+    let older = FileTime::from_unix_time(999_999, 0);
+    set_file_mtime(src.join("file"), newer).unwrap();
+    set_file_mtime(dst.join("file"), older).unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--itemize-changes",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(">f"));
+
+    set_file_mtime(dst.join("file"), older).unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--itemize-changes",
+            "--modify-window=2",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr("");
+}


### PR DESCRIPTION
## Summary
- add `--modify-window` flag to CLI and plumb into sync options
- treat file mtimes within the modify window as equal during sync
- cover timestamp granularity differences with new tests

## Testing
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: op_ref, while-let-loop, suspicious-open-options, seek-from-current, collapsible-if, unnecessary-map-or, map-flatten, too-many-arguments, get-first, needless-lifetimes, redundant-closure, unnecessary-map-or)*
- `cargo test` *(fails: daemon tests missing daemon start)*


------
https://chatgpt.com/codex/tasks/task_e_68b4d2bec4c08323b01c4015d05ff929