### PR TITLE
harden systemd unit for oc-rsyncd

### DIFF
--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -1,10 +1,14 @@
+# packaging/systemd/oc-rsyncd.service
 [Unit]
 Description=oc-rsync daemon
 Documentation=man:oc-rsync(1) man:oc-rsyncd.conf(5)
-After=network.target
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=simple
+User=oc-rsyncd
+Group=oc-rsyncd
 ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config /etc/oc-rsyncd/rsyncd.conf
 Restart=on-failure
 NoNewPrivileges=yes
@@ -12,9 +16,15 @@ ProtectSystem=strict
 ProtectHome=read-only
 PrivateTmp=yes
 PrivateDevices=yes
+PrivateUsers=yes
+PrivateMounts=yes
+ProtectHostname=yes
+ProtectClock=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes
+ProtectProc=invisible
+ProcSubset=pid
 RestrictSUIDSGID=yes
 RestrictRealtime=yes
 LockPersonality=yes
@@ -23,6 +33,9 @@ CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 MemoryDenyWriteExecute=yes
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
 StateDirectory=oc-rsyncd
 
 [Install]


### PR DESCRIPTION
## Summary
- harden systemd oc-rsyncd unit with network-online target, explicit user/group and additional sandboxing

## Testing
- `cargo fmt --all` *(fails: unclosed delimiter in crates/engine/src/lib.rs:2416:3)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unclosed delimiter in crates/engine/src/lib.rs:2416:3)*
- `cargo test --all-features` *(fails: unclosed delimiter in crates/engine/src/lib.rs:2416:3)*
- `make verify-comments` *(fails: unclosed delimiter in crates/engine/src/lib.rs:2416:3)*
- `make lint` *(fails: unclosed delimiter in crates/engine/src/lib.rs:2416:3)*


------
https://chatgpt.com/codex/tasks/task_e_68b4dbce428c8323bd200612cb6969a7