### PR TITLE
Showcase more rsyncd options

### DIFF
--- a/packaging/rsyncd.conf.example
+++ b/packaging/rsyncd.conf.example
@@ -1,10 +1,39 @@
 # Sample oc-rsync daemon configuration
 # Installed at /etc/oc-rsyncd/rsyncd.conf
 
+# PID file location
 pid file = /run/oc-rsyncd.pid
+
+# Log file location
 log file = /var/log/oc-rsyncd.log
 
+# Hosts permitted to connect
+hosts allow = 192.0.2.0/24 198.51.100.23
+
+# Deny all other hosts
+hosts deny = *
+
+# Credentials file for authenticated modules
+secrets file = /etc/oc-rsyncd/rsyncd.secrets
+
+# Enable chroot jail for modules
+use chroot = yes
+
+# Data module (read/write)
 [data]
+    # Directory served to clients
     path = /srv/oc-rsync/data
+    # Description shown to clients
     comment = Exported data
+    # Allow clients to write
     read only = false
+
+# Backup module (read-only)
+[backup]
+    # Directory served to clients
+    path = /srv/oc-rsync/backup
+    # Description shown to clients
+    comment = Backup area
+    # Make module read-only
+    read only = true
+


### PR DESCRIPTION
## Summary
- Expand example rsyncd configuration with hosts allow/deny, secrets file, and chroot usage
- Demonstrate multiple modules with descriptive comments

## Testing
- ⚠️ `cargo fmt --all` (fails: unclosed delimiter in crates/engine/src/lib.rs)
- ⚠️ `cargo clippy --all-targets --all-features -- -D warnings` (fails: unclosed delimiter in crates/engine/src/lib.rs)
- ⚠️ `cargo test --all-features` (fails: unclosed delimiter in crates/engine/src/lib.rs)
- ⚠️ `make verify-comments` (fails: unclosed delimiter in crates/engine/src/lib.rs)
- ⚠️ `make lint` (fails: unclosed delimiter in crates/engine/src/lib.rs)


------
https://chatgpt.com/codex/tasks/task_e_68b4dbd0dfd48323b9885142064215e6