### PR TITLE
Refactor unix metadata bindings

### DIFF
--- a/crates/meta/tests/fake_super.rs
+++ b/crates/meta/tests/fake_super.rs
@@ -1,12 +1,13 @@
 // crates/meta/tests/fake_super.rs
+#[cfg(all(unix, feature = "xattr"))]
 use meta::{Metadata, Options};
+#[cfg(all(unix, feature = "xattr"))]
 use std::fs;
+#[cfg(all(unix, feature = "xattr"))]
 use tempfile::tempdir;
 
 #[cfg(all(unix, feature = "xattr"))]
 use nix::unistd::Uid;
-#[cfg(all(unix, feature = "xattr"))]
-use xattr;
 
 #[cfg(all(unix, feature = "xattr"))]
 #[test]

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -148,7 +148,7 @@ fn roundtrip_acl() -> std::io::Result<()> {
                 std::io::Error::new(ioe.kind(), ioe.to_string())
             }
         } else {
-            std::io::Error::new(std::io::ErrorKind::Other, e)
+            std::io::Error::other(e)
         }
     })?;
     acl.set(Qualifier::User(12345), ACL_READ);
@@ -160,7 +160,7 @@ fn roundtrip_acl() -> std::io::Result<()> {
                 std::io::Error::new(ioe.kind(), ioe.to_string())
             }
         } else {
-            std::io::Error::new(std::io::ErrorKind::Other, e)
+            std::io::Error::other(e)
         }
     })?;
 


### PR DESCRIPTION
## Summary
- avoid unnecessary mutability when reading uid/gid/mode in unix metadata
- tidy clippy warnings in tests

## Testing
- `cargo fmt --all` *(fails: this file contains an unclosed delimiter)*
- `cargo check` *(fails: unclosed delimiter in engine crate)*
- `cargo check -p meta`
- `cargo clippy -p meta --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: unclosed delimiter in engine crate)*
- `cargo test -p meta`
- `make verify-comments` *(fails: unclosed delimiter in engine crate)*
- `make lint` *(fails: unclosed delimiter in engine crate)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dcaa944c8323b39fb2e96d99716e