### PR TITLE
engine: remove redundant rename in apply

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1087,30 +1087,20 @@ impl Receiver {
             } else {
                 atomic_rename(&tmp_dest, dest)?;
                 if let Some(tmp_parent) = tmp_dest.parent() {
-                    if dest.parent().map_or(true, |p| p != tmp_parent) {
-                        if tmp_parent
+                    if (dest.parent() != Some(tmp_parent))
+                        && tmp_parent
                             .read_dir()
                             .map(|mut i| i.next().is_none())
                             .unwrap_or(false)
-                        {
-                            let _ = fs::remove_dir(tmp_parent);
-                        }
+                    {
+                        let _ = fs::remove_dir(tmp_parent);
                     }
-            atomic_rename(&tmp_dest, dest)?;
-            if let Some(tmp_parent) = tmp_dest.parent() {
-                if dest.parent() != Some(tmp_parent)
-                    && tmp_parent
-                        .read_dir()
-                        .map(|mut i| i.next().is_none())
-                        .unwrap_or(false)
-                {
-                    let _ = fs::remove_dir(tmp_parent);
-                }
-                #[cfg(unix)]
-                if let Some((uid, gid)) = self.opts.copy_as {
-                    let gid = gid.map(Gid::from_raw);
-                    chown(dest, Some(Uid::from_raw(uid)), gid)
-                        .map_err(|e| io_context(dest, std::io::Error::from(e)))?;
+                    #[cfg(unix)]
+                    if let Some((uid, gid)) = self.opts.copy_as {
+                        let gid = gid.map(Gid::from_raw);
+                        chown(dest, Some(Uid::from_raw(uid)), gid)
+                            .map_err(|e| io_context(dest, std::io::Error::from(e)))?;
+                    }
                 }
             }
         } else {
@@ -1260,14 +1250,13 @@ impl Receiver {
         for (src, tmp, dest) in std::mem::take(&mut self.delayed) {
             atomic_rename(&tmp, &dest)?;
             if let Some(tmp_parent) = tmp.parent() {
-                if dest.parent().map_or(true, |p| p != tmp_parent) {
-                    if tmp_parent
+                if (dest.parent() != Some(tmp_parent))
+                    && tmp_parent
                         .read_dir()
                         .map(|mut i| i.next().is_none())
                         .unwrap_or(false)
-                    {
-                        let _ = fs::remove_dir(tmp_parent);
-                    }
+                {
+                    let _ = fs::remove_dir(tmp_parent);
                 }
             }
             #[cfg(unix)]


### PR DESCRIPTION
## Summary
- remove duplicate rename and simplify cleanup in `Receiver::apply`
- streamline temp directory cleanup when finalizing delayed updates

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: delta_block_size_matches_rsync: Argument names must be unique, 'port' is in use by more than one argument or group)*
- `cargo build`
- `make verify-comments` *(fails: crates/meta/tests/fake_super.rs: contains disallowed comments; tests/delay_updates.rs: contains disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4dca7cf6c8323893ebe1e46a7a918