### PR TITLE
Add daemon address and protocol option parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "checksums",
  "clap_complete",
  "compress",
+ "daemon",
  "engine",
  "filetime",
  "filters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ shell-words = "1.1"
 wait-timeout = "0.2"
 users = "0.11"
 meta = { path = "crates/meta" }
+daemon = { path = "crates/daemon" }
 
 [[bin]]
 name = "flag_matrix"

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -3,6 +3,7 @@
 
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
+use daemon::parse_daemon_args;
 use protocol::LATEST_VERSION;
 use serial_test::serial;
 use std::fs;
@@ -14,7 +15,7 @@ use std::process::{Child, Command as StdCommand, Stdio};
 use std::sync::mpsc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
-use transport::{TcpTransport, Transport};
+use transport::{AddressFamily, TcpTransport, Transport};
 use wait_timeout::ChildExt;
 
 struct Skip;
@@ -23,6 +24,37 @@ fn require_network() -> Result<(), Skip> {
     let listener = TcpListener::bind("127.0.0.1:0").map_err(|_| Skip)?;
     TcpStream::connect(listener.local_addr().unwrap()).map_err(|_| Skip)?;
     Ok(())
+}
+
+#[test]
+fn parse_daemon_args_parses_options() {
+    let args = vec![
+        "--address".to_string(),
+        "127.0.0.1".to_string(),
+        "--port".to_string(),
+        "1234".to_string(),
+        "--ipv4".to_string(),
+    ];
+    let opts = parse_daemon_args(args).unwrap();
+    assert_eq!(opts.address, Some("127.0.0.1".parse().unwrap()));
+    assert_eq!(opts.port, 1234);
+    assert!(matches!(opts.family, Some(AddressFamily::V4)));
+}
+
+#[test]
+fn parse_daemon_args_rejects_mismatch() {
+    let args = vec![
+        "--address".to_string(),
+        "127.0.0.1".to_string(),
+        "--ipv6".to_string(),
+    ];
+    assert!(parse_daemon_args(args).is_err());
+}
+
+#[test]
+fn parse_daemon_args_invalid_port() {
+    let args = vec!["--port".to_string(), "not-a-number".to_string()];
+    assert!(parse_daemon_args(args).is_err());
 }
 
 fn read_port(child: &mut Child) -> io::Result<u16> {


### PR DESCRIPTION
## Summary
- parse `--address`, `--port`, `--ipv4`, and `--ipv6` for the daemon
- validate address family mismatches when binding
- test daemon argument parsing for valid and invalid inputs

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` *(fails: cannot find -lacl)*
- `make verify-comments` *(fails: crates/meta/tests/fake_super.rs, tests/delay_updates.rs contain disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b52ad374d483238ed020f99300d144