### PR TITLE
Handle from0 list entries

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1202,12 +1202,7 @@ pub fn parse_list(input: &[u8], from0: bool) -> Vec<String> {
                 if end == 0 {
                     return None;
                 }
-                let pat = String::from_utf8_lossy(&s[..end]).trim().to_string();
-                if pat.is_empty() || pat.starts_with('#') {
-                    None
-                } else {
-                    Some(pat)
-                }
+                Some(String::from_utf8_lossy(&s[..end]).to_string())
             })
             .collect()
     } else {
@@ -1215,7 +1210,7 @@ pub fn parse_list(input: &[u8], from0: bool) -> Vec<String> {
         s.lines()
             .map(|l| l.trim_end_matches('\r'))
             .map(|l| l.trim())
-            .filter(|l| !l.is_empty() && !l.starts_with('#'))
+            .filter(|l| !l.is_empty() && !l.trim_start().starts_with('#'))
             .map(|l| l.to_string())
             .collect()
     }
@@ -1238,13 +1233,18 @@ pub fn parse_from_bytes(
             if part.is_empty() {
                 continue;
             }
-            let s = String::from_utf8_lossy(part);
-            let line = s.trim();
-            if line.is_empty() || line.starts_with('#') {
+            let mut end = part.len();
+            while end > 0 && (part[end - 1] == b'\n' || part[end - 1] == b'\r') {
+                end -= 1;
+            }
+            if end == 0 {
                 continue;
             }
-            let mut buf = String::new();
-            buf.push_str(line);
+            let line = String::from_utf8_lossy(&part[..end]).to_string();
+            if line.is_empty() {
+                continue;
+            }
+            let mut buf = line;
             buf.push('\n');
             rules.extend(parse(&buf, visited, depth)?);
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1226,6 +1226,70 @@ fn exclude_from_zero_separated_list_with_crlf() {
 }
 
 #[test]
+fn include_from_zero_separated_list_with_crlf() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("keep.txt"), b"k").unwrap();
+    std::fs::write(src.join("skip.txt"), b"s").unwrap();
+    let inc = dir.path().join("include.lst");
+    let exc = dir.path().join("exclude.lst");
+    std::fs::write(&inc, b"keep.txt\r\n\0").unwrap();
+    std::fs::write(&exc, b"*\r\n\0").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--from0",
+            "--include-from",
+            inc.to_str().unwrap(),
+            "--exclude-from",
+            exc.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(dst.join("keep.txt").exists());
+    assert!(!dst.join("skip.txt").exists());
+}
+
+#[test]
+fn files_from_zero_separated_list_allows_hash() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(src.join("#keep.txt"), b"k").unwrap();
+    std::fs::write(src.join("skip.txt"), b"s").unwrap();
+    let list = dir.path().join("files.lst");
+    std::fs::write(&list, b"#keep.txt\0").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--from0",
+            "--files-from",
+            list.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(dst.join("#keep.txt").exists());
+    assert!(!dst.join("skip.txt").exists());
+}
+
+#[test]
 fn files_from_list_file() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");


### PR DESCRIPTION
## Summary
- handle `--from0` list parsing without trimming or comment removal
- allow comment-prefixed filenames with `--from0`
- test `--include-from` and `--files-from` using null-separated lists

## Testing
- `make verify-comments`
- `make lint`
- `cargo test` *(fails: progress_flag_human_readable, resumes_from_partial_dir_with_subdirs, destination_is_replaced_atomically)*
- `cargo test --release --test cli include_from_zero_separated_list_with_crlf`
- `cargo test --release --test cli files_from_zero_separated_list_allows_hash`


------
https://chatgpt.com/codex/tasks/task_e_68b54a49c5248323a03f820b5801880b