### PR TITLE
Align progress reporting with rsync

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -489,11 +489,13 @@ fn format_number(n: u64) -> String {
 struct Progress<'a> {
     total: u64,
     written: u64,
-    last: std::time::Instant,
+    last_print: std::time::Instant,
     human_readable: bool,
     #[allow(dead_code)]
     dest: &'a Path,
 }
+
+const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_secs(1);
 
 impl<'a> Progress<'a> {
     fn new(dest: &'a Path, total: u64, human_readable: bool, initial: u64) -> Self {
@@ -501,7 +503,7 @@ impl<'a> Progress<'a> {
         Self {
             total,
             written: initial,
-            last: std::time::Instant::now(),
+            last_print: std::time::Instant::now() - PROGRESS_UPDATE_INTERVAL,
             human_readable,
             dest,
         }
@@ -509,9 +511,9 @@ impl<'a> Progress<'a> {
 
     fn add(&mut self, bytes: u64) {
         self.written += bytes;
-        if self.last.elapsed() >= std::time::Duration::from_secs(1) && self.written < self.total {
+        if self.last_print.elapsed() >= PROGRESS_UPDATE_INTERVAL && self.written < self.total {
             self.print(false);
-            self.last = std::time::Instant::now();
+            self.last_print = std::time::Instant::now();
         }
     }
 
@@ -532,9 +534,9 @@ impl<'a> Progress<'a> {
             self.written * 100 / self.total
         };
         if done {
-            eprintln!("\r{:>11} {:>3}%", bytes, percent);
+            eprintln!("\r{:>15} {:>3}%", bytes, percent);
         } else {
-            eprint!("\r{:>11} {:>3}%", bytes, percent);
+            eprint!("\r{:>15} {:>3}%", bytes, percent);
             let _ = std::io::stderr().flush();
         }
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -300,16 +300,10 @@ fn progress_flag_shows_output() {
         .assert()
         .success();
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
-    let mut lines = stderr.lines();
-    let path_line = lines.next().unwrap();
+    let path_line = stderr.lines().next().unwrap();
     assert_eq!(path_line, dst_dir.join("a.txt").display().to_string());
-    let progress_line = lines.next().unwrap().trim_start_matches('\r');
-    let bytes = progress_line
-        .split_whitespace()
-        .next()
-        .unwrap()
-        .replace(",", "");
-    assert_eq!(bytes.parse::<u64>().unwrap(), 2048);
+    let progress_line = stderr.split('\r').next_back().unwrap().trim_end();
+    assert_eq!(progress_line, format!("{:>15} {:>3}%", "2,048", 100));
 }
 
 #[test]
@@ -333,11 +327,10 @@ fn progress_flag_human_readable() {
         .assert()
         .success();
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
-    let mut lines = stderr.lines();
-    let path_line = lines.next().unwrap();
+    let path_line = stderr.lines().next().unwrap();
     assert_eq!(path_line, dst_dir.join("a.txt").display().to_string());
-    let progress_line = lines.next().unwrap().trim_start_matches('\r');
-    assert!(progress_line.starts_with("2.00KiB"));
+    let progress_line = stderr.split('\r').next_back().unwrap().trim_end();
+    assert_eq!(progress_line, format!("{:>15} {:>3}%", "2.00KiB", 100));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Use rsync's 15-character field for progress bytes
- Emit initial progress line immediately and throttle updates to 1s
- Verify progress lines byte-for-byte in CLI tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test --all-features` *(fails: thread 'main' panicked at clap_builder debug asserts; multiple tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b54a7f46b083238eda3b22fa91183f