### PR TITLE
chore: update checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             use-cross: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -118,7 +118,7 @@ jobs:
     name: Verify comment headers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -137,7 +137,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
             use-cross: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -166,7 +166,7 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -190,7 +190,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
## Summary
- bump `actions/checkout` to v4 in CI workflows

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo test` *(fails: Command oc-rsync-cli: Argument names must be unique, but 'port' is in use by more than one argument or group)*
- `act -j verify-comments` *(fails: Cannot connect to the Docker daemon)*
- `act -W .github/workflows/coverage.yml -j coverage` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b54ed65abc8323925ae35b8ce07fcf