### PR TITLE
docs: note progress test failure

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -135,7 +135,7 @@ negotiates version 73.
 | `--perms` | `-p` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--port` | — | ✅ | ❌ | [tests/daemon.rs](../tests/daemon.rs) | overrides default port | ≤3.2 |
 | `--preallocate` | — | ✅ | ✅ | [tests/perf_limits.rs](../tests/perf_limits.rs) |  | ≤3.2 |
-| `--progress` | — | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
+| `--progress` | — | ⚠️ | ❌ | [tests/cli.rs#L332](../tests/cli.rs#L332) | progress tests fail to compile | ≤3.2 |
 | `--protocol` | — | ✅ | ❌ | [tests/cli_flags.rs](../tests/cli_flags.rs) |  | ≤3.2 |
 | `--prune-empty-dirs` | `-m` | ✅ | ✅ | [tests/filter_corpus.rs](../tests/filter_corpus.rs) |  | ≤3.2 |
 | `--quiet` | `-q` | ✅ | ✅ | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | ≤3.2 |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -45,7 +45,7 @@ coverage so progress can be tracked as features land.
 - `--partial-dir` — remote partial directory handling lacks parity. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs) *(needs dedicated test)*
 
 ## Progress & Exit Codes
-- `--progress` — progress output differs from upstream. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)
+- `--progress` — progress output differs from upstream and current progress tests fail to compile. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs#L332](../tests/cli.rs#L332)
 - Exit code propagation across transports lacks coverage. [protocol/src/lib.rs](../crates/protocol/src/lib.rs) · [crates/protocol/tests/exit_codes.rs](../crates/protocol/tests/exit_codes.rs)
 
 ## Error Propagation


### PR DESCRIPTION
## Summary
- Document that `--progress` tests currently fail to compile
- Highlight failing progress support in the feature matrix

## Testing
- `cargo build --workspace`
- `cargo test --workspace` *(fails: cannot find value `lines` in tests/cli.rs:332)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: cannot find value `lines` in tests/cli.rs:332)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b554cefd288323897c6d2330e28c7e