### PR TITLE
feat: align server handshake with rsync

### DIFF
--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -60,13 +60,11 @@ impl<R: Read, W: Write> Server<R, W> {
         self.writer.flush()?;
         self.version = ver;
 
-        self.reader.read_exact(&mut buf)?;
-        let peer_caps = u32::from_be_bytes(buf);
-
-        let negotiated = peer_caps & caps;
-        self.caps = negotiated;
         self.writer.write_all(&caps.to_be_bytes())?;
         self.writer.flush()?;
+        self.reader.read_exact(&mut buf)?;
+        let peer_caps = u32::from_be_bytes(buf);
+        self.caps = peer_caps & caps;
 
         let mut peer_codecs = vec![Codec::Zlib];
         if self.caps & CAP_CODECS != 0 {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -327,7 +327,8 @@ fn progress_flag_human_readable() {
         .assert()
         .success();
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr).into_owned();
-    let path_line = stderr.lines().next().unwrap();
+    let mut lines = stderr.lines();
+    let path_line = lines.next().unwrap();
     assert_eq!(path_line, dst_dir.join("a.txt").display().to_string());
     let progress_line = lines
         .next()


### PR DESCRIPTION
## Summary
- align server capability negotiation with upstream rsync ordering
- add stock rsync interop tests for SSH and daemon modes
- fix CLI progress test output parsing

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_respects_module_host_lists)*
- `cargo test --test server stock_rsync_interop_over_ssh -- --nocapture` *(fails: rsync: connection unexpectedly closed (code 12))*
- `cargo test --test server stock_rsync_interop_daemon -- --nocapture` *(fails: rsync: did not see server greeting (code 5))*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b556a1913083239cd4f386ca8264b6