### PR TITLE
Add optional AVX-512 gating with runtime SIMD dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,6 @@ version = "0.1.0"
 dependencies = [
  "blake2",
  "blake3",
- "cpufeatures",
  "hex",
  "md-5",
  "md4",
@@ -314,7 +313,6 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 name = "compress"
 version = "0.1.0"
 dependencies = [
- "cpufeatures",
  "flate2",
  "lz4",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,5 @@ lz4 = ["engine/lz4"]
 xattr = ["engine/xattr", "oc-rsync-cli/xattr"]
 acl = ["engine/acl", "oc-rsync-cli/acl"]
 blake3 = ["checksums/blake3", "engine/blake3", "oc-rsync-cli/blake3", "protocol/blake3"]
+# Enables AVX-512 implementations requiring a nightly toolchain
+nightly = ["checksums/nightly", "compress/nightly"]

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -8,13 +8,14 @@ md-5 = "0.10"
 sha1 = "0.10"
 md4 = "0.10"
 blake3 = { version = "1", optional = true }
-cpufeatures = "0.2"
 blake2 = "0.10"
 xxhash-rust = { version = "0.8", features = ["xxh3", "xxh64"] }
 
 [features]
 default = []
 blake3 = ["dep:blake3"]
+# AVX-512 implementations (requires nightly Rust)
+nightly = []
 
 [dev-dependencies]
 hex = "0.4"

--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -8,8 +8,9 @@ flate2 = "1"
 zstd = "0.13"
 lz4_flex = { version = "0.11", optional = true }
 lz4 = { version = "1", optional = true }
-cpufeatures = "0.2"
 
 [features]
 default = []
 lz4 = ["dep:lz4_flex", "dep:lz4"]
+# AVX-512 implementations (requires nightly Rust)
+nightly = []


### PR DESCRIPTION
## Summary
- gate AVX-512 implementations behind a `nightly` feature and dispatch at runtime using `is_x86_feature_detected!`
- fall back to SSE4.2/AVX2 or scalar paths when unavailable
- document the `nightly` feature

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace` *(fails: list_parsing_from0_eq_newline)*
- `cargo test --workspace --features nightly -- --skip list_parsing_from0_eq_newline` *(fails: daemon_respects_module_host_lists)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5666022f483238f4236d8fa23eb42