### PR TITLE
Respect quiet flag across CLI and engine

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -7,19 +7,34 @@ use protocol::ExitCode;
 
 fn main() {
     if std::env::args().any(|a| a == "--version" || a == "-V") {
-        println!("oc-rsync {}", env!("CARGO_PKG_VERSION"));
+        if !std::env::args().any(|a| a == "--quiet" || a == "-q") {
+            println!("oc-rsync {}", env!("CARGO_PKG_VERSION"));
+        }
         return;
     }
     let matches = cli_command().get_matches();
-    let verbose = matches.get_count("verbose") as u8;
-    let info: Vec<InfoFlag> = matches
-        .get_many::<InfoFlag>("info")
-        .map(|v| v.copied().collect())
-        .unwrap_or_default();
-    let debug: Vec<DebugFlag> = matches
-        .get_many::<DebugFlag>("debug")
-        .map(|v| v.copied().collect())
-        .unwrap_or_default();
+    let quiet = matches.get_flag("quiet");
+    let verbose = if quiet {
+        0
+    } else {
+        matches.get_count("verbose") as u8
+    };
+    let info: Vec<InfoFlag> = if quiet {
+        Vec::new()
+    } else {
+        matches
+            .get_many::<InfoFlag>("info")
+            .map(|v| v.copied().collect())
+            .unwrap_or_default()
+    };
+    let debug: Vec<DebugFlag> = if quiet {
+        Vec::new()
+    } else {
+        matches
+            .get_many::<DebugFlag>("debug")
+            .map(|v| v.copied().collect())
+            .unwrap_or_default()
+    };
     let log_format = matches
         .get_one::<String>("log_format")
         .map(|f| {
@@ -30,7 +45,7 @@ fn main() {
             }
         })
         .unwrap_or(LogFormat::Text);
-    logging::init(log_format, verbose, &info, &debug);
+    logging::init(log_format, verbose, &info, &debug, quiet);
     if let Err(e) = oc_rsync_cli::run(&matches) {
         let code = match e {
             EngineError::MaxAlloc => ExitCode::Malloc,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -618,7 +618,7 @@ pub fn run(matches: &clap::ArgMatches) -> Result<()> {
     let probe_opts =
         ProbeOpts::from_arg_matches(matches).map_err(|e| EngineError::Other(e.to_string()))?;
     if probe_opts.probe {
-        return run_probe(probe_opts);
+        return run_probe(probe_opts, matches.get_flag("quiet"));
     }
     let mut opts =
         ClientOpts::from_arg_matches(matches).map_err(|e| EngineError::Other(e.to_string()))?;
@@ -1265,6 +1265,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         copy_devices: opts.copy_devices,
         write_devices: opts.write_devices,
         fake_super: opts.fake_super,
+        quiet: opts.quiet,
     };
     sync_opts.prepare_remote();
     let stats = if opts.local {
@@ -1907,6 +1908,7 @@ fn run_daemon(opts: DaemonOpts, matches: &ArgMatches) -> Result<()> {
     };
 
     let handler: Arc<daemon::Handler> = Arc::new(|_| Ok(()));
+    let quiet = matches.get_flag("quiet");
 
     daemon::run_daemon(
         modules,
@@ -1926,12 +1928,13 @@ fn run_daemon(opts: DaemonOpts, matches: &ArgMatches) -> Result<()> {
         65534,
         65534,
         handler,
+        quiet,
     )
     .map_err(|e| EngineError::Other(format!("daemon failed to bind to port {port}: {e}")))
 }
 
 #[allow(dead_code)]
-fn run_probe(opts: ProbeOpts) -> Result<()> {
+fn run_probe(opts: ProbeOpts, quiet: bool) -> Result<()> {
     if let Some(addr) = opts.addr {
         let mut stream = TcpStream::connect(&addr)?;
         stream.write_all(&LATEST_VERSION.to_be_bytes())?;
@@ -1940,12 +1943,16 @@ fn run_probe(opts: ProbeOpts) -> Result<()> {
         let peer = u32::from_be_bytes(buf);
         let ver = negotiate_version(LATEST_VERSION, peer)
             .map_err(|e| EngineError::Other(e.to_string()))?;
-        println!("negotiated version {}", ver);
+        if !quiet {
+            println!("negotiated version {}", ver);
+        }
         Ok(())
     } else {
         let ver = negotiate_version(LATEST_VERSION, opts.peer_version)
             .map_err(|e| EngineError::Other(e.to_string()))?;
-        println!("negotiated version {}", ver);
+        if !quiet {
+            println!("negotiated version {}", ver);
+        }
         Ok(())
     }
 }

--- a/crates/cli/tests/logging_flags.rs
+++ b/crates/cli/tests/logging_flags.rs
@@ -48,7 +48,7 @@ fn verbose_and_log_format_json_parity() {
     } else {
         logging::LogFormat::Text
     };
-    logging::init(log_format, verbose, &info, &debug);
+    logging::init(log_format, verbose, &info, &debug, false);
     oc_rsync_cli::run(&matches).unwrap();
 }
 
@@ -61,7 +61,7 @@ fn info_flag_enables_progress() {
         .get_many::<logging::InfoFlag>("info")
         .map(|v| v.copied().collect())
         .unwrap_or_default();
-    let sub = logging::subscriber(logging::LogFormat::Text, 0, &info, &[]);
+    let sub = logging::subscriber(logging::LogFormat::Text, 0, &info, &[], false);
     with_default(sub, || {
         assert!(tracing::enabled!(
             target: logging::InfoFlag::Progress.target(),
@@ -83,7 +83,7 @@ fn debug_flag_enables_flist() {
         .get_many::<logging::DebugFlag>("debug")
         .map(|v| v.copied().collect())
         .unwrap_or_default();
-    let sub = logging::subscriber(logging::LogFormat::Text, 0, &[], &debug);
+    let sub = logging::subscriber(logging::LogFormat::Text, 0, &[], &debug, false);
     with_default(sub, || {
         assert!(tracing::enabled!(
             target: logging::DebugFlag::Flist.target(),

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -568,6 +568,7 @@ pub fn run_daemon(
     uid: u32,
     gid: u32,
     handler: Arc<Handler>,
+    quiet: bool,
 ) -> io::Result<()> {
     let _lock = if let Some(path) = lock_file {
         let mut f = OpenOptions::new()
@@ -605,7 +606,7 @@ pub fn run_daemon(
     }
 
     let (listener, real_port) = TcpTransport::listen(address, port, family)?;
-    if port == 0 {
+    if port == 0 && !quiet {
         println!("{}", real_port);
         io::stdout().flush()?;
     }
@@ -650,7 +651,9 @@ pub fn run_daemon(
                 )
             };
             if let Err(e) = res {
-                eprintln!("connection error: {}", e);
+                if !quiet {
+                    eprintln!("connection error: {}", e);
+                }
             }
         });
     }

--- a/crates/logging/tests/levels.rs
+++ b/crates/logging/tests/levels.rs
@@ -4,7 +4,7 @@ use tracing::Level;
 
 #[test]
 fn info_not_emitted_by_default() {
-    let sub = subscriber(LogFormat::Text, 0, &[], &[]);
+    let sub = subscriber(LogFormat::Text, 0, &[], &[], false);
     with_default(sub, || {
         assert!(!tracing::enabled!(Level::INFO));
     });
@@ -12,7 +12,7 @@ fn info_not_emitted_by_default() {
 
 #[test]
 fn verbose_enables_info() {
-    let sub = subscriber(LogFormat::Text, 1, &[], &[]);
+    let sub = subscriber(LogFormat::Text, 1, &[], &[], false);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -20,7 +20,7 @@ fn verbose_enables_info() {
 
 #[test]
 fn debug_enables_debug() {
-    let sub = subscriber(LogFormat::Text, 0, &[], &[DebugFlag::Flist]);
+    let sub = subscriber(LogFormat::Text, 0, &[], &[DebugFlag::Flist], false);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -28,7 +28,7 @@ fn debug_enables_debug() {
 
 #[test]
 fn debug_with_two_v() {
-    let sub = subscriber(LogFormat::Text, 2, &[], &[]);
+    let sub = subscriber(LogFormat::Text, 2, &[], &[], false);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -36,7 +36,7 @@ fn debug_with_two_v() {
 
 #[test]
 fn info_flag_enables_info() {
-    let sub = subscriber(LogFormat::Text, 0, &[InfoFlag::Progress], &[]);
+    let sub = subscriber(LogFormat::Text, 0, &[InfoFlag::Progress], &[], false);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -44,7 +44,7 @@ fn info_flag_enables_info() {
 
 #[test]
 fn json_verbose_enables_info() {
-    let sub = subscriber(LogFormat::Json, 1, &[], &[]);
+    let sub = subscriber(LogFormat::Json, 1, &[], &[], false);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ impl Default for SyncConfig {
 }
 
 pub fn synchronize_with_config(src: &Path, dst: &Path, cfg: &SyncConfig) -> Result<()> {
-    let sub = subscriber(cfg.log_format, cfg.verbose, &cfg.info, &cfg.debug);
+    let sub = subscriber(cfg.log_format, cfg.verbose, &cfg.info, &cfg.debug, false);
     with_default(sub, || -> Result<()> {
         if !dst.exists() {
             fs::create_dir_all(dst)?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -692,6 +692,8 @@ fn quiet_flag_suppresses_output() {
         "--local",
         "--recursive",
         "--quiet",
+        "--progress",
+        "--stats",
         &src_arg,
         dst_dir.to_str().unwrap(),
     ]);


### PR DESCRIPTION
## Summary
- gate user-visible output and logging with the `--quiet` flag across CLI, engine, and daemon layers
- add quiet flag to sync options and progress reporting
- regression test ensures no output when `--quiet` is used

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test cli quiet_flag_suppresses_output --quiet`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5691efd748323a88d5eea20879009