### PR TITLE
Ensure archive mode implies recursive in CLI

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -844,6 +844,9 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         .dst
         .take()
         .ok_or_else(|| EngineError::Other("missing DST".into()))?;
+    if opts.archive {
+        opts.recursive = true;
+    }
     let matcher = build_matcher(&opts, matches)?;
     let addr_family = if opts.ipv4 {
         Some(AddressFamily::V4)


### PR DESCRIPTION
## Summary
- Guarantee `-a/--archive` implies recursive mode in CLI client

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: daemon_respects_module_host_lists)*
- `cargo test --test cli archive_implies_recursive`
- `cargo run -p oc-rsync-bin --bin oc-rsync -- --local -a /tmp/src/ /tmp/dst`

------
https://chatgpt.com/codex/tasks/task_e_68b570704af48323bf777a01cabf5590