### PR TITLE
Print CLI errors to stderr

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,8 +1,7 @@
 // bin/oc-rsync/src/main.rs
-use engine::EngineError;
 use logging::{DebugFlag, InfoFlag, LogFormat};
 
-use oc_rsync_cli::cli_command;
+use oc_rsync_cli::{cli_command, EngineError};
 use protocol::ExitCode;
 
 fn main() {
@@ -32,6 +31,7 @@ fn main() {
         .unwrap_or(LogFormat::Text);
     logging::init(log_format, verbose, &info, &debug);
     if let Err(e) = oc_rsync_cli::run(&matches) {
+        eprintln!("{e}");
         let code = match e {
             EngineError::MaxAlloc => ExitCode::Malloc,
             _ => ExitCode::Protocol,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -15,11 +15,10 @@ use std::time::Duration;
 use clap::parser::ValueSource;
 use clap::{ArgAction, ArgMatches, Args, CommandFactory, FromArgMatches, Parser};
 use compress::{available_codecs, Codec, ModernCompress};
+pub use engine::EngineError;
 #[cfg(feature = "blake3")]
 use engine::ModernHash;
-use engine::{
-    sync, DeleteMode, EngineError, IdMapper, ModernCdc, Result, Stats, StrongHash, SyncOptions,
-};
+use engine::{sync, DeleteMode, IdMapper, ModernCdc, Result, Stats, StrongHash, SyncOptions};
 use filters::{default_cvs_rules, parse, Matcher, Rule};
 use logging::{human_bytes, DebugFlag, InfoFlag};
 use meta::{parse_chmod, parse_chown, parse_id_map};

--- a/crates/cli/tests/stderr.rs
+++ b/crates/cli/tests/stderr.rs
@@ -1,0 +1,38 @@
+// crates/cli/tests/stderr.rs
+use assert_cmd::Command;
+use tempfile::tempdir;
+
+#[test]
+fn local_sync_without_flag_emits_error_on_stderr() {
+    let src = tempdir().unwrap();
+    let dst = tempdir().unwrap();
+    let src_path = src.path();
+    let dst_path = dst.path();
+
+    let assert = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([src_path.to_str().unwrap(), dst_path.to_str().unwrap()])
+        .assert()
+        .failure();
+    assert!(!assert.get_output().stderr.is_empty());
+}
+
+#[test]
+fn invalid_rsh_env_emits_error_on_stderr() {
+    let src = tempdir().unwrap();
+    let dst = tempdir().unwrap();
+    let src_path = src.path();
+    let dst_path = dst.path();
+
+    let assert = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--rsh",
+            "1BAD=val ssh",
+            src_path.to_str().unwrap(),
+            dst_path.to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+    assert!(!assert.get_output().stderr.is_empty());
+}


### PR DESCRIPTION
## Summary
- print CLI errors to stderr before exiting
- re-export EngineError from CLI crate
- test that invalid operations emit stderr messages

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test --all-features` *(fails: daemon_respects_module_host_lists)*

------
https://chatgpt.com/codex/tasks/task_e_68b57087ff788323b74d84482408b3b9