### PR TITLE
test: rely on progress formatter for progress output

### DIFF
--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -161,6 +161,14 @@ pub fn progress_formatter(bytes: u64, human_readable: bool) -> String {
     if human_readable {
         human_bytes(bytes)
     } else {
-        format!("{} bytes", bytes)
+        let s = bytes.to_string();
+        let mut out = String::new();
+        for (i, c) in s.chars().rev().enumerate() {
+            if i > 0 && i % 3 == 0 {
+                out.push(',');
+            }
+            out.push(c);
+        }
+        out.chars().rev().collect()
     }
 }


### PR DESCRIPTION
## Summary
- add thousands separators to `progress_formatter`
- use `progress_formatter` in CLI progress tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test cli -- --test-threads=1`
- `cargo test` *(fails: daemon_respects_module_host_lists)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b575dfb2a08323a9f4e38a6d3f426d