### PR TITLE
test: verify module host list rejection

### DIFF
--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -941,6 +941,8 @@ fn daemon_respects_module_host_lists() {
         .set_read_timeout(Some(Duration::from_millis(200)))
         .unwrap();
     stream.write_all(&LATEST_VERSION.to_be_bytes()).unwrap();
+    stream.read_exact(&mut buf).unwrap();
+    stream.write_all(b"data\n").unwrap();
     let res = stream.read(&mut buf);
     assert!(res.is_err() || res.unwrap() == 0);
     let _ = child.kill();


### PR DESCRIPTION
## Summary
- exercise module host allow/deny logic by sending module name after handshake and ensuring the daemon closes connection

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test --all-features` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b57a598b3083238eb03d4a0004e273