### PR TITLE
feat: improve progress output

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -304,7 +304,9 @@ fn progress_flag_shows_output() {
     let path_line = stderr.lines().next().unwrap();
     assert_eq!(path_line, dst_dir.join("a.txt").display().to_string());
     let progress_line = stderr.split('\r').next_back().unwrap().trim_end();
-    let expected = format!("{:>15} {:>3}%", progress_formatter(2048, false), 100);
+    let bytes = progress_formatter(2048, false);
+    let rate = format!("{}B/s", bytes);
+    let expected = format!("{:>15} {:>3}% {:>15}", bytes, 100, rate);
     assert_eq!(progress_line, expected);
 }
 
@@ -333,7 +335,9 @@ fn progress_flag_human_readable() {
     let path_line = lines.next().unwrap();
     assert_eq!(path_line, dst_dir.join("a.txt").display().to_string());
     let progress_line = lines.next().unwrap().trim_start_matches('\r').trim_end();
-    let expected = format!("{:>15} {:>3}%", progress_formatter(2 * 1024, true), 100);
+    let bytes = progress_formatter(2 * 1024, true);
+    let rate = format!("{}/s", bytes);
+    let expected = format!("{:>15} {:>3}% {:>15}", bytes, 100, rate);
     assert_eq!(progress_line, expected);
 }
 


### PR DESCRIPTION
## Summary
- format progress output using shared `progress_formatter`
- display transfer rate during progress updates
- adjust CLI tests for new progress format

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(failed: daemon_respects_module_host_lists)*
- `make verify-comments`
- `make lint`
- `tests/interop/run_matrix.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b5896ac1b08323aef1a573c3143294