### PR TITLE
Add JSON log-file format option

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -35,16 +35,9 @@ fn main() {
             .map(|v| v.copied().collect())
             .unwrap_or_default()
     };
-    let log_format = matches
-        .get_one::<String>("log_format")
-        .map(|f| {
-            if f == "json" {
-                LogFormat::Json
-            } else {
-                LogFormat::Text
-            }
-        })
-        .unwrap_or(LogFormat::Text);
+    let log_format = *matches
+        .get_one::<LogFormat>("log_format")
+        .unwrap_or(&LogFormat::Text);
     let log_file = matches.get_one::<PathBuf>("client-log-file").cloned();
     let log_file_fmt = matches.get_one::<String>("client-log-file-format").cloned();
     logging::init(

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -20,7 +20,7 @@ pub use engine::EngineError;
 use engine::ModernHash;
 use engine::{sync, DeleteMode, IdMapper, ModernCdc, Result, Stats, StrongHash, SyncOptions};
 use filters::{default_cvs_rules, parse, Matcher, Rule};
-use logging::{human_bytes, DebugFlag, InfoFlag};
+use logging::{human_bytes, DebugFlag, InfoFlag, LogFormat};
 use meta::{parse_chmod, parse_chown, parse_id_map};
 #[cfg(unix)]
 use nix::unistd::{Uid, User};
@@ -137,8 +137,8 @@ struct ClientOpts {
     ignore_times: bool,
     #[arg(short, long, action = ArgAction::Count, help_heading = "Output")]
     verbose: u8,
-    #[arg(long = "log-format", help_heading = "Output", value_parser = ["text", "json"])]
-    log_format: Option<String>,
+    #[arg(long = "log-format", help_heading = "Output", value_enum)]
+    log_format: Option<LogFormat>,
     #[arg(
         long = "log-file",
         value_name = "FILE",

--- a/crates/cli/tests/logging_flags.rs
+++ b/crates/cli/tests/logging_flags.rs
@@ -42,12 +42,9 @@ fn verbose_and_log_format_json_parity() {
         .get_many::<logging::DebugFlag>("debug")
         .map(|v| v.copied().collect())
         .unwrap_or_default();
-    let log_format = if matches.get_one::<String>("log_format").map(String::as_str) == Some("json")
-    {
-        logging::LogFormat::Json
-    } else {
-        logging::LogFormat::Text
-    };
+    let log_format = *matches
+        .get_one::<logging::LogFormat>("log_format")
+        .unwrap_or(&logging::LogFormat::Text);
     logging::init(log_format, verbose, &info, &debug, false, None);
     oc_rsync_cli::run(&matches).unwrap();
 }
@@ -83,7 +80,7 @@ fn debug_flag_enables_flist() {
         .get_many::<logging::DebugFlag>("debug")
         .map(|v| v.copied().collect())
         .unwrap_or_default();
-    let sub = logging::subscriber(logging::LogFormat::Text, 0, &[], &debug, false);
+    let sub = logging::subscriber(logging::LogFormat::Text, 0, &[], &debug, false, None);
     with_default(sub, || {
         assert!(tracing::enabled!(
             target: logging::DebugFlag::Flist.target(),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -741,6 +741,30 @@ fn log_format_json_outputs_structured_logs() {
 }
 
 #[test]
+fn log_file_format_json_outputs_structured_file() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+
+    let log = dir.path().join("log.json");
+    let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([
+        "--local",
+        "--log-file",
+        log.to_str().unwrap(),
+        "--log-file-format=json",
+        "--verbose",
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+    let contents = std::fs::read_to_string(log).unwrap();
+    assert!(contents.contains("\"message\""));
+}
+
+#[test]
 fn quiet_flag_suppresses_output() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");

--- a/tests/golden/cli_parity/log_file_format.sh
+++ b/tests/golden/cli_parity/log_file_format.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+OC_RSYNC="$ROOT/target/debug/oc-rsync"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/src" "$TMP/dst"
+
+echo data > "$TMP/src/a.txt"
+
+log="$TMP/log.json"
+"$OC_RSYNC" --local --log-file "$log" --log-file-format=json -v "$TMP/src/" "$TMP/dst/" >/dev/null
+
+if ! grep -q '"message"' "$log"; then
+  echo "log file missing json message" >&2
+  cat "$log" >&2
+  exit 1
+fi

--- a/tests/log_file.rs
+++ b/tests/log_file.rs
@@ -25,3 +25,28 @@ fn log_file_writes_messages() {
     let contents = fs::read_to_string(&log).unwrap();
     assert!(contents.contains("verbose level set to 1"), "{}", contents);
 }
+
+#[test]
+fn log_file_format_json_writes_json() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(&src, b"hi").unwrap();
+    let log = tmp.path().join("log.json");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--log-file",
+            log.to_str().unwrap(),
+            "--log-file-format=json",
+            "-v",
+            src.to_str().unwrap(),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let contents = fs::read_to_string(&log).unwrap();
+    assert!(contents.contains("\"message\""), "{}", contents);
+}


### PR DESCRIPTION
## Summary
- support JSON log-file output via new `--log-file-format` and update logging subscriber
- expose structured log format through Clap `LogFormat` enum
- test JSON log-file behaviour and add golden parity script

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(failed: daemon_respects_module_host_lists)*
- `make verify-comments`
- `make lint`
- `tests/golden/cli_parity/log_file_format.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b588f7c4b88323b511d99517683473