### PR TITLE
daemon: reject denied hosts before reading options

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -472,7 +472,7 @@ pub fn handle_connection<T: Transport>(
     transport.send(&LATEST_VERSION.to_be_bytes())?;
     negotiate_version(LATEST_VERSION, peer_ver).map_err(|e| io::Error::other(e.to_string()))?;
 
-    let (token, global_allowed, no_motd) = authenticate(transport, secrets)?;
+    let (mut token, global_allowed, no_motd) = authenticate(transport, secrets)?;
 
     if !no_motd {
         if let Some(mpath) = motd {
@@ -484,11 +484,25 @@ pub fn handle_connection<T: Transport>(
             }
         }
     }
+    let name = if token.is_some() && global_allowed.is_empty() && secrets.is_none() {
+        token.take().unwrap()
+    } else {
+        let mut name_buf = [0u8; 256];
+        let n = transport.receive(&mut name_buf)?;
+        String::from_utf8_lossy(&name_buf[..n]).trim().to_string()
+    };
+    if let Some(module) = modules.get(&name) {
+        if let Ok(ip) = peer.parse::<IpAddr>() {
+            if !host_allowed(&ip, &module.hosts_allow, &module.hosts_deny) {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "host denied",
+                ));
+            }
+        }
+    }
     transport.send(b"@RSYNCD: OK\n")?;
 
-    let mut name_buf = [0u8; 256];
-    let n = transport.receive(&mut name_buf)?;
-    let name = String::from_utf8_lossy(&name_buf[..n]).trim().to_string();
     let mut opt_buf = [0u8; 256];
     loop {
         let n = transport.receive(&mut opt_buf)?;
@@ -503,15 +517,6 @@ pub fn handle_connection<T: Transport>(
         }
     }
     if let Some(module) = modules.get(&name) {
-        if let Ok(ip) = peer.parse::<IpAddr>() {
-            if !host_allowed(&ip, &module.hosts_allow, &module.hosts_deny) {
-                let _ = transport.send(b"@ERROR: access denied");
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    "host denied",
-                ));
-            }
-        }
         let allowed = if let Some(path) = module.secrets_file.as_deref() {
             match token.as_deref() {
                 Some(tok) => authenticate_token(tok, path)?,


### PR DESCRIPTION
## Summary
- check module host allow/deny lists before parsing daemon options
- drop connections for disallowed hosts without sending `@ERROR`

## Testing
- `cargo fmt --all`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `cargo test daemon_respects_module_host_lists`


------
https://chatgpt.com/codex/tasks/task_e_68b58cf48a148323b755fbf8c0db8811