### PR TITLE
chore: standardize comment headers

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -1,5 +1,4 @@
-//! Utilities for parsing rsync daemon configuration files.
-
+// crates/daemon/src/lib.rs
 use std::collections::HashMap;
 use std::env;
 use std::fs::{self, OpenOptions};

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,3 +1,4 @@
+// crates/logging/src/lib.rs
 use std::fs::OpenOptions;
 use std::path::PathBuf;
 use tracing::level_filters::LevelFilter;

--- a/crates/meta/src/stub.rs
+++ b/crates/meta/src/stub.rs
@@ -1,5 +1,4 @@
-// On Unix platforms other than Linux and macOS we reuse the full-featured
-
+// crates/meta/src/stub.rs
 #[cfg(unix)]
 include!("unix.rs");
 


### PR DESCRIPTION
## Summary
- add repository-relative header comments for daemon, meta stub, and logging crates
- strip all other comments from these files

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: `remote_nested_partial_dir_transfer_resumes_after_interrupt` defined multiple times)*
- `cargo test --all-features` *(fails: `remote_nested_partial_dir_transfer_resumes_after_interrupt` defined multiple times)*
- `make lint`
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68b59dbe0e6c8323be4924b9016ea88f