### PR TITLE
Add SIMD-optimized zstd and lz4 compression paths

### DIFF
--- a/crates/engine/benches/compress.rs
+++ b/crates/engine/benches/compress.rs
@@ -1,9 +1,9 @@
 // crates/engine/benches/compress.rs
-use compress::Compressor;
 #[cfg(feature = "lz4")]
 use compress::Lz4;
 #[cfg(feature = "zstd")]
 use compress::Zstd;
+use compress::{Compressor, Decompressor};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn bench_compress(c: &mut Criterion) {
@@ -11,18 +11,30 @@ fn bench_compress(c: &mut Criterion) {
     #[cfg(feature = "zstd")]
     {
         let zstd = Zstd::default();
+        let compressed = zstd.compress(&data).unwrap();
         c.bench_function("zstd_compress_1mb", |b| {
             b.iter(|| {
                 zstd.compress(&data).unwrap();
+            });
+        });
+        c.bench_function("zstd_decompress_1mb", |b| {
+            b.iter(|| {
+                zstd.decompress(&compressed).unwrap();
             });
         });
     }
     #[cfg(feature = "lz4")]
     {
         let lz4 = Lz4;
+        let compressed = lz4.compress(&data).unwrap();
         c.bench_function("lz4_compress_1mb", |b| {
             b.iter(|| {
                 lz4.compress(&data).unwrap();
+            });
+        });
+        c.bench_function("lz4_decompress_1mb", |b| {
+            b.iter(|| {
+                lz4.decompress(&compressed).unwrap();
             });
         });
     }


### PR DESCRIPTION
## Summary
- implement SSE4.2/AVX2/AVX512 zstd compression and decompression using `zstd_safe`
- wire up lz4 compression/decompression via liblz4 and expose SIMD-specific wrappers
- add tests for SIMD parity and extend benchmarks with decompression cases

## Testing
- `cargo test --all-features -p compress`
- `cargo test` *(fails: duplicate test name in tests/resume.rs)*
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -p compress -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b59f9c8da48323a8be540fb735fc95