### PR TITLE
feat(engine): gate blake3-based CDC behind feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ doc:
 	cargo doc --no-deps --all-features
 
 test:
+	cargo test
 	cargo test --all-features
 
 coverage:

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -12,8 +12,8 @@ compress = { path = "../compress" }
 filelist = { path = "../filelist" }
 nix = { version = "0.27", features = ["user", "fs"] }
 meta = { path = "../meta", default-features = false }
-blake3 = "1"
-fastcdc = "3.2"
+blake3 = { version = "1", optional = true }
+fastcdc = { version = "3.2", optional = true }
 logging = { path = "../logging" }
 libc = "0.2"
 memmap2 = "0.9"
@@ -48,4 +48,4 @@ lz4 = ["compress/lz4"]
 zstd = []
 xattr = ["meta/xattr"]
 acl = ["meta/acl"]
-blake3 = ["checksums/blake3"]
+blake3 = ["checksums/blake3", "dep:blake3", "dep:fastcdc"]

--- a/crates/engine/src/cdc.rs
+++ b/crates/engine/src/cdc.rs
@@ -1,4 +1,5 @@
 // crates/engine/src/cdc.rs
+
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{self, Read, Write};
@@ -7,36 +8,6 @@ use std::path::{Path, PathBuf};
 use blake3::Hash;
 use fastcdc::v2020::StreamCDC;
 use memmap2::MmapOptions;
-
-const RSYNC_BLOCK_SIZE: usize = 700;
-const RSYNC_MAX_BLOCK_SIZE: usize = 1 << 17;
-
-pub fn block_size(len: u64) -> usize {
-    if len <= (RSYNC_BLOCK_SIZE * RSYNC_BLOCK_SIZE) as u64 {
-        return RSYNC_BLOCK_SIZE;
-    }
-
-    let mut c: usize = 1;
-    let mut l = len;
-    while l >> 2 > 0 {
-        l >>= 2;
-        c <<= 1;
-    }
-
-    if c >= RSYNC_MAX_BLOCK_SIZE || c == 0 {
-        RSYNC_MAX_BLOCK_SIZE
-    } else {
-        let mut blength: usize = 0;
-        while c >= 8 {
-            blength |= c;
-            if len < (blength as u64).wrapping_mul(blength as u64) {
-                blength &= !c;
-            }
-            c >>= 1;
-        }
-        blength.max(RSYNC_BLOCK_SIZE)
-    }
-}
 
 #[derive(Debug, Clone)]
 pub struct Chunk {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -27,9 +27,41 @@ use filters::Matcher;
 use logging::progress_formatter;
 use thiserror::Error;
 
+#[cfg(feature = "blake3")]
 pub mod cdc;
+#[cfg(feature = "blake3")]
 use cdc::{chunk_file, Manifest};
 pub mod flist;
+
+const RSYNC_BLOCK_SIZE: usize = 700;
+const RSYNC_MAX_BLOCK_SIZE: usize = 1 << 17;
+
+pub fn block_size(len: u64) -> usize {
+    if len <= (RSYNC_BLOCK_SIZE * RSYNC_BLOCK_SIZE) as u64 {
+        return RSYNC_BLOCK_SIZE;
+    }
+
+    let mut c: usize = 1;
+    let mut l = len;
+    while l >> 2 > 0 {
+        l >>= 2;
+        c <<= 1;
+    }
+
+    if c >= RSYNC_MAX_BLOCK_SIZE || c == 0 {
+        RSYNC_MAX_BLOCK_SIZE
+    } else {
+        let mut blength: usize = 0;
+        while c >= 8 {
+            blength |= c;
+            if len < (blength as u64).wrapping_mul(blength as u64) {
+                blength &= !c;
+            }
+            c >>= 1;
+        }
+        blength.max(RSYNC_BLOCK_SIZE)
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum EngineError {
@@ -858,7 +890,7 @@ impl Sender {
         let src_len = meta.len();
         ensure_max_alloc(src_len, &self.opts)?;
         let block_size = if self.block_size == 0 {
-            cdc::block_size(src_len)
+            block_size(src_len)
         } else {
             self.block_size
         };
@@ -1127,7 +1159,7 @@ impl Receiver {
             .build();
         let src_len = fs::metadata(src).map(|m| m.len()).unwrap_or(0);
         let block_size = if self.opts.block_size == 0 {
-            cdc::block_size(src_len)
+            block_size(src_len)
         } else {
             self.opts.block_size
         };
@@ -1499,6 +1531,7 @@ pub enum DeleteMode {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModernCdc {
+    #[cfg(feature = "blake3")]
     Fastcdc,
     Off,
 }
@@ -1991,6 +2024,7 @@ pub fn sync(
     let matcher = matcher.clone().with_root(src_root.clone());
     let mut sender = Sender::new(opts.block_size, matcher.clone(), codec, opts.clone());
     let mut receiver = Receiver::new(codec, opts.clone());
+    #[cfg(feature = "blake3")]
     let mut manifest = if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
         Manifest::load()
     } else {
@@ -2078,6 +2112,7 @@ pub fn sync(
                         continue;
                     }
                     if !dest_path.exists() && !partial_exists {
+                        #[cfg(feature = "blake3")]
                         if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
                             if let Ok(chunks) = chunk_file(
                                 &path,
@@ -2171,6 +2206,7 @@ pub fn sync(
                         if opts.itemize_changes && !opts.quiet {
                             println!(">f+++++++++ {}", rel.display());
                         }
+                        #[cfg(feature = "blake3")]
                         if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
                             if let Ok(chunks) = chunk_file(
                                 &dest_path,
@@ -2367,6 +2403,7 @@ pub fn sync(
     for (src_dir, dest_dir) in dir_meta.into_iter().rev() {
         receiver.copy_metadata(&src_dir, &dest_dir)?;
     }
+    #[cfg(feature = "blake3")]
     if matches!(opts.modern_cdc, ModernCdc::Fastcdc) {
         manifest.save()?;
     }

--- a/crates/engine/tests/cdc.rs
+++ b/crates/engine/tests/cdc.rs
@@ -1,4 +1,5 @@
 // crates/engine/tests/cdc.rs
+#![cfg(feature = "blake3")]
 use engine::cdc::chunk_bytes;
 
 #[test]

--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::needless_range_loop)]
 
 use checksums::ChecksumConfigBuilder;
-use engine::{cdc, compute_delta, Op, SyncOptions};
+use engine::{block_size, compute_delta, Op, SyncOptions};
 use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::tempdir;
@@ -33,7 +33,7 @@ fn cdc_block_size_heuristics() {
         (1_000_000_000_000, 131_072),
     ];
     for (len, expected) in cases {
-        assert_eq!(cdc::block_size(len), expected, "len={len}");
+        assert_eq!(block_size(len), expected, "len={len}");
     }
 }
 

--- a/tests/cdc.rs
+++ b/tests/cdc.rs
@@ -1,4 +1,5 @@
 // tests/cdc.rs
+#![cfg(feature = "blake3")]
 
 use compress::available_codecs;
 use engine::{sync, ModernCdc, SyncOptions};

--- a/tests/resume.rs
+++ b/tests/resume.rs
@@ -100,7 +100,7 @@ fn partial_dir_transfer_resumes_after_interrupt() {
 
 #[cfg(unix)]
 #[test]
-fn remote_nested_partial_dir_transfer_resumes_after_interrupt() {
+fn remote_nested_partial_dir_transfer_resumes_after_interrupt_remote() {
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
     let dst_dir = dir.path().join("dst");


### PR DESCRIPTION
## Summary
- make blake3 and fastcdc optional and expose a `blake3` feature in engine
- guard CDC functionality and CLI flags behind the `blake3` feature
- run tests with and without the `blake3` feature

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test` *(fails: client_authenticates_with_password_file)*
- `cargo test --all-features --no-run` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b59fa6f0648323bb0ef008a858a1ab