### PR TITLE
feat(engine): track hard links by inode

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1097,6 +1097,9 @@ impl Receiver {
                 self.pending_links
                     .push((existing.clone(), dest.to_path_buf()));
             } else {
+                if dest.exists() {
+                    fs::remove_file(dest).map_err(|e| io_context(dest, e))?;
+                }
                 fs::hard_link(existing, dest).map_err(|e| io_context(dest, e))?;
             }
             Ok(false)

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -14,7 +14,6 @@ coverage so progress can be tracked as features land.
 - `--acls` — ACL support requires optional feature and lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs)
 - `--devices` — device file handling lacks parity. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)
 - `--groupmap` — numeric gid mapping only; group names unsupported. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
-- `--hard-links` — hard link tracking incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)
 - `--links` — symlink handling lacks parity. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--owner` — ownership restoration lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--perms` — permission preservation incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -162,7 +162,7 @@ fn daemon_inherits_default_acls() {
     assert_eq!(dacl_src.entries(), dacl_dst.entries());
 
     let dacl_src_sub = PosixACL::read_default_acl(&sub).unwrap();
-    let dacl_dst_sub = PosixACL::read_default_acl(&srv.join("sub")).unwrap();
+    let dacl_dst_sub = PosixACL::read_default_acl(srv.join("sub")).unwrap();
     assert_eq!(dacl_src_sub.entries(), dacl_dst_sub.entries());
 
     let acl_src_file = PosixACL::read_acl(&file).unwrap();

--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -542,6 +542,48 @@ fn sync_preserves_multiple_hard_links() {
 
 #[cfg(unix)]
 #[test]
+fn sync_preserves_hard_links_with_link_dest() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let link = tmp.path().join("link");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&link).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    let f1 = src.join("f1");
+    fs::write(&f1, b"hi").unwrap();
+    let f2 = src.join("f2");
+    fs::hard_link(&f1, &f2).unwrap();
+    fs::write(link.join("f1"), b"hi").unwrap();
+    fs::write(link.join("f2"), b"hi").unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--hard-links",
+            "--link-dest",
+            link.to_str().unwrap(),
+            &format!("{}/", src.display()),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout("")
+        .stderr("");
+
+    use std::os::unix::fs::MetadataExt;
+    let link1 = fs::metadata(link.join("f1")).unwrap().ino();
+    let link2 = fs::metadata(link.join("f2")).unwrap().ino();
+    assert_ne!(link1, link2);
+    let m1 = fs::metadata(dst.join("f1")).unwrap().ino();
+    let m2 = fs::metadata(dst.join("f2")).unwrap().ino();
+    assert_eq!(m1, link1);
+    assert_eq!(m1, m2);
+}
+
+#[cfg(unix)]
+#[test]
 fn sync_preserves_symlinks() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");


### PR DESCRIPTION
## Summary
- handle existing files during inode-based hard-link registration
- exercise link-dest hard-link preservation
- remove outdated hard-link gap doc

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(hangs in daemon tests; killed after waiting)*
- `cargo test sync_preserves_hard_links_with_link_dest --test local_sync_tree`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5a58fdea88323852adf1a7213115e