### PR TITLE
Align symlink handling with upstream

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2263,14 +2263,19 @@ pub fn sync(
                     let target = fs::read_link(&path).map_err(|e| io_context(&path, e))?;
                     let target_path = if target.is_absolute() {
                         target.clone()
+                    } else if let Some(parent) = path.parent() {
+                        parent.join(&target)
                     } else {
-                        path.parent().unwrap_or(Path::new("")).join(&target)
+                        src_root.join(&target)
                     };
                     let is_unsafe = match fs::canonicalize(&target_path) {
                         Ok(p) => !p.starts_with(&src_root),
                         Err(_) => true,
                     };
                     if opts.safe_links && is_unsafe {
+                        continue;
+                    }
+                    if opts.ignore_existing && dest_path.exists() {
                         continue;
                     }
                     let meta = fs::metadata(&target_path).ok();

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -95,7 +95,7 @@ negotiates version 73.
 | `--itemize-changes` | `-i` | ✅ | ✅ | [tests/golden/cli_parity/itemize-changes.sh](../tests/golden/cli_parity/itemize-changes.sh) |  | 3.2 |
 | `--keep-dirlinks` | `-K` | ✅ | ✅ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) |  | ≤3.2 |
 | `--link-dest` | — | ✅ | ✅ | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) |  | ≤3.2 |
-| `--links` | `-l` | ✅ | ❌ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
+| `--links` | `-l` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) | preserves relative/absolute targets; supports dangling links | ≤3.2 |
 | `--list-only` | — | ✅ | ✅ | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) |  | ≤3.2 |
 | `--log-file` | — | ✅ | ❌ | [tests/log_file.rs](../tests/log_file.rs) | limited format support | ≤3.2 |
 | `--log-file-format` | — | ✅ | ❌ | [tests/log_file.rs](../tests/log_file.rs) | limited format support | ≤3.2 |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -15,7 +15,6 @@ coverage so progress can be tracked as features land.
 - `--devices` — device file handling lacks parity. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)
 - `--groupmap` — numeric gid mapping only; group names unsupported. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--hard-links` — hard link tracking incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)
-- `--links` — symlink handling lacks parity. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--owner` — ownership restoration lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--perms` — permission preservation incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--usermap` — numeric uid mapping only; user names unsupported. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1506,6 +1506,68 @@ fn links_preserve_symlinks() {
 
 #[cfg(unix)]
 #[test]
+fn links_copy_dangling_symlink() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    symlink("missing", src.join("dangling")).unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--local", "--links", &src_arg, dst.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let meta = std::fs::symlink_metadata(dst.join("dangling")).unwrap();
+    assert!(meta.file_type().is_symlink());
+    let target = std::fs::read_link(dst.join("dangling")).unwrap();
+    assert_eq!(target, std::path::PathBuf::from("missing"));
+}
+
+#[cfg(unix)]
+#[test]
+fn links_replace_and_skip_existing() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(&dst).unwrap();
+    std::fs::write(src.join("file"), b"data").unwrap();
+    symlink("file", src.join("link")).unwrap();
+    std::fs::write(dst.join("link"), b"old").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--local", "--links", &src_arg, dst.to_str().unwrap()])
+        .assert()
+        .success();
+    let meta = std::fs::symlink_metadata(dst.join("link")).unwrap();
+    assert!(meta.file_type().is_symlink());
+    std::fs::remove_file(dst.join("link")).unwrap();
+    std::fs::write(dst.join("link"), b"old").unwrap();
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--links",
+            "--ignore-existing",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let meta = std::fs::symlink_metadata(dst.join("link")).unwrap();
+    assert!(!meta.file_type().is_symlink());
+    let content = std::fs::read(dst.join("link")).unwrap();
+    assert_eq!(content, b"old");
+}
+
+#[cfg(unix)]
+#[test]
 fn links_preserve_directory_symlinks() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -162,7 +162,7 @@ fn daemon_inherits_default_acls() {
     assert_eq!(dacl_src.entries(), dacl_dst.entries());
 
     let dacl_src_sub = PosixACL::read_default_acl(&sub).unwrap();
-    let dacl_dst_sub = PosixACL::read_default_acl(&srv.join("sub")).unwrap();
+    let dacl_dst_sub = PosixACL::read_default_acl(srv.join("sub")).unwrap();
     assert_eq!(dacl_src_sub.entries(), dacl_dst_sub.entries());
 
     let acl_src_file = PosixACL::read_acl(&file).unwrap();


### PR DESCRIPTION
## Summary
- ensure symlink targets resolve relative to their parents and honour `--ignore-existing`
- test dangling symlinks and replacement vs skip behaviour
- document symlink parity and remove outdated gap

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5a593ffa48323aa4652cb2d0f897d