### PR TITLE
Filter unsupported xattrs and document parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ path = "tools/strip_rs_comments.rs"
 [features]
 default = []
 lz4 = ["engine/lz4"]
-xattr = ["engine/xattr", "oc-rsync-cli/xattr"]
+xattr = ["engine/xattr", "oc-rsync-cli/xattr", "meta/xattr"]
 acl = ["engine/acl", "oc-rsync-cli/acl", "meta/acl"]
 blake3 = ["checksums/blake3", "engine/blake3", "oc-rsync-cli/blake3", "protocol/blake3"]
 # Enables AVX-512 implementations requiring a nightly toolchain

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -143,7 +143,10 @@ pub fn apply_xattrs(path: &Path, xattrs: &[(OsString, Vec<u8>)]) -> io::Result<(
     }
     for name in existing {
         if let Some(s) = name.to_str() {
-            if s == "system.posix_acl_access" || s == "system.posix_acl_default" {
+            if s == "system.posix_acl_access"
+                || s == "system.posix_acl_default"
+                || s.starts_with("security.")
+            {
                 continue;
             }
         }

--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -169,11 +169,15 @@ impl Metadata {
         let xattrs = if opts.xattrs || opts.fake_super {
             let mut attrs = Vec::new();
             for attr in xattr::list(path)? {
-                if !opts.fake_super {
-                    if let Some(name) = attr.to_str() {
-                        if name.starts_with("user.rsync.") {
-                            continue;
-                        }
+                if let Some(name) = attr.to_str() {
+                    if !opts.fake_super && name.starts_with("user.rsync.") {
+                        continue;
+                    }
+                    if name.starts_with("security.")
+                        || name == "system.posix_acl_access"
+                        || name == "system.posix_acl_default"
+                    {
+                        continue;
                     }
                 }
                 if let Some(value) = xattr::get(path, &attr)? {

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -172,4 +172,4 @@ negotiates version 73.
 | `--whole-file` | `-W` | ✅ | ✅ | [tests/cli.rs](../tests/cli.rs) |  | ≤3.2 |
 | `--write-batch` | — | ✅ | ✅ | [tests/write_batch.rs](../tests/write_batch.rs) |  | ≤3.2 |
 | `--write-devices` | — | ✅ | ✅ | [tests/write_devices.rs](../tests/write_devices.rs) | writes to existing devices | ≤3.2 |
-| `--xattrs` | `-X` | ✅ | ❌ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | requires `xattr` feature | ≤3.2 |
+| `--xattrs` | `-X` | ✅ | ✅ | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | requires `xattr` feature | ≤3.2 |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -19,7 +19,6 @@ coverage so progress can be tracked as features land.
 - `--owner` — ownership restoration lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--perms` — permission preservation incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--usermap` — numeric uid mapping only; user names unsupported. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
-- `--xattrs` — extended attribute support requires optional feature and lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs)
 
 ## Filters
 - `--exclude` — filter syntax coverage incomplete. [filters/src/lib.rs](../crates/filters/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -65,10 +65,12 @@ fn daemon_preserves_xattrs() {
     let file = src.join("file");
     fs::write(&file, b"hi").unwrap();
     xattr::set(&file, "user.test", b"val").unwrap();
+    xattr::set(&file, "security.test", b"secret").unwrap();
 
     let srv_file = srv.join("file");
     fs::write(&srv_file, b"old").unwrap();
     xattr::set(&srv_file, "user.old", b"junk").unwrap();
+    xattr::set(&srv_file, "security.keep", b"dest").unwrap();
 
     let (mut child, port) = spawn_daemon(&srv);
     wait_for_daemon(port);
@@ -82,6 +84,13 @@ fn daemon_preserves_xattrs() {
     let val = xattr::get(srv.join("file"), "user.test").unwrap().unwrap();
     assert_eq!(&val[..], b"val");
     assert!(xattr::get(srv.join("file"), "user.old").unwrap().is_none());
+    assert!(xattr::get(srv.join("file"), "security.test")
+        .unwrap()
+        .is_none());
+    let keep = xattr::get(srv.join("file"), "security.keep")
+        .unwrap()
+        .unwrap();
+    assert_eq!(&keep[..], b"dest");
 
     let _ = child.kill();
     let _ = child.wait();
@@ -162,7 +171,7 @@ fn daemon_inherits_default_acls() {
     assert_eq!(dacl_src.entries(), dacl_dst.entries());
 
     let dacl_src_sub = PosixACL::read_default_acl(&sub).unwrap();
-    let dacl_dst_sub = PosixACL::read_default_acl(&srv.join("sub")).unwrap();
+    let dacl_dst_sub = PosixACL::read_default_acl(srv.join("sub")).unwrap();
     assert_eq!(dacl_src_sub.entries(), dacl_dst_sub.entries());
 
     let acl_src_file = PosixACL::read_acl(&file).unwrap();


### PR DESCRIPTION
## Summary
- skip security and ACL xattrs when collecting or applying metadata
- add security namespace tests for daemon xattr sync
- mark xattr handling as parity in docs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_authenticates_with_password_file)*
- `cargo test --all-features` *(failed: linking with `cc`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5a5a0489c83238a842b1abf737f5c