### PR TITLE
Add systemd notify support and sample config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ version = "0.1.0"
 dependencies = [
  "nix 0.27.1",
  "protocol",
+ "sd-notify",
  "tempfile",
  "transport",
 ]
@@ -1310,6 +1311,15 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sd-notify"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b943eadf71d8b69e661330cb0e2656e31040acf21ee7708e2c238a0ec6af2bf4"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "serde"

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 transport = { path = "../transport" }
 nix = { version = "0.27", features = ["user", "fs"] }
 protocol = { path = "../protocol" }
+sd-notify = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use std::os::unix::fs::PermissionsExt;
 
 use protocol::{negotiate_version, LATEST_VERSION};
+use sd_notify::{self, NotifyState};
 use transport::{AddressFamily, RateLimitedTransport, TcpTransport, TimeoutTransport, Transport};
 
 fn parse_list(val: &str) -> Vec<String> {
@@ -633,6 +634,9 @@ pub fn run_daemon(
         println!("{}", real_port);
         io::stdout().flush()?;
     }
+    std::thread::spawn(|| {
+        let _ = sd_notify::notify(false, &[NotifyState::Ready]);
+    });
     loop {
         let (stream, addr) = TcpTransport::accept(&listener, &hosts_allow, &hosts_deny)?;
         let peer = addr.ip().to_string();

--- a/packaging/oc-rsyncd.conf
+++ b/packaging/oc-rsyncd.conf
@@ -1,11 +1,12 @@
-# Sample oc-rsync daemon configuration
-# Installed at /etc/oc-rsyncd/rsyncd.conf
+# packaging/oc-rsyncd.conf
+# Sample oc-rsync daemon configuration mirroring rsyncd.conf semantics
+# Installed at /etc/oc-rsyncd.conf
 
 # PID file location
-pid file = /run/oc-rsyncd.pid
+pid file = /run/oc-rsyncd/oc-rsyncd.pid
 
 # Log file location
-log file = /var/log/oc-rsyncd.log
+log file = /var/log/oc-rsyncd/oc-rsyncd.log
 
 # Hosts permitted to connect
 hosts allow = 192.0.2.0/24 198.51.100.23
@@ -14,7 +15,7 @@ hosts allow = 192.0.2.0/24 198.51.100.23
 hosts deny = *
 
 # Credentials file for authenticated modules
-secrets file = /etc/oc-rsyncd/rsyncd.secrets
+secrets file = /etc/oc-rsyncd/oc-rsyncd.secrets
 
 # Enable chroot jail for modules
 use chroot = yes

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -6,10 +6,11 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
 User=oc-rsyncd
 Group=oc-rsyncd
-ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config /etc/oc-rsyncd/rsyncd.conf
+ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config /etc/oc-rsyncd.conf
 Restart=on-failure
 NoNewPrivileges=yes
 ProtectSystem=strict
@@ -36,7 +37,10 @@ MemoryDenyWriteExecute=yes
 SystemCallFilter=@system-service
 SystemCallFilter=~@privileged
 SystemCallFilter=~@resources
+RuntimeDirectory=oc-rsyncd
+LogsDirectory=oc-rsyncd
 StateDirectory=oc-rsyncd
+ConfigurationDirectory=oc-rsyncd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- update systemd service to use Type=notify and create standard runtime/logs/state/config directories
- send READY notifications with sd-notify when daemon starts
- provide example `/etc/oc-rsyncd.conf` mirroring `rsyncd.conf`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_authenticates_with_password_file)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5c4102568832385c35c5a0a0adad2