### PR TITLE
Add repo-relative path comments

### DIFF
--- a/crates/cli/tests/logging_flags.rs
+++ b/crates/cli/tests/logging_flags.rs
@@ -1,3 +1,4 @@
+// crates/cli/tests/logging_flags.rs
 use assert_cmd::Command;
 use oc_rsync_cli::cli_command;
 use tempfile::tempdir;

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -1,3 +1,4 @@
+// crates/meta/src/lib.rs
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 mod unix;
 #[cfg(any(target_os = "linux", target_os = "macos"))]

--- a/crates/meta/src/parse.rs
+++ b/crates/meta/src/parse.rs
@@ -1,3 +1,4 @@
+// crates/meta/src/parse.rs
 use crate::{normalize_mode, Chmod, ChmodOp, ChmodTarget};
 use std::result::Result as StdResult;
 use std::sync::Arc;

--- a/crates/meta/tests/chmod.rs
+++ b/crates/meta/tests/chmod.rs
@@ -1,3 +1,4 @@
+// crates/meta/tests/chmod.rs
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 

--- a/crates/meta/tests/gid_table.rs
+++ b/crates/meta/tests/gid_table.rs
@@ -1,3 +1,4 @@
+// crates/meta/tests/gid_table.rs
 use meta::{parse_chown, parse_id_map, GidTable, IdKind};
 
 #[test]

--- a/crates/meta/tests/id_map.rs
+++ b/crates/meta/tests/id_map.rs
@@ -1,3 +1,4 @@
+// crates/meta/tests/id_map.rs
 use std::fs;
 use std::sync::Arc;
 

--- a/crates/meta/tests/uid_table.rs
+++ b/crates/meta/tests/uid_table.rs
@@ -1,3 +1,4 @@
+// crates/meta/tests/uid_table.rs
 use meta::{parse_chown, parse_id_map, IdKind, UidTable};
 
 #[test]

--- a/crates/transport/tests/sockopts.rs
+++ b/crates/transport/tests/sockopts.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/sockopts.rs
 use transport::{parse_sockopts, SockOpt};
 
 #[test]

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -1,3 +1,4 @@
+// tests/cli_flags.rs
 use assert_cmd::Command;
 use tempfile::NamedTempFile;
 

--- a/tests/fake_super.rs
+++ b/tests/fake_super.rs
@@ -1,3 +1,4 @@
+// tests/fake_super.rs
 #[cfg(all(unix, feature = "xattr"))]
 use assert_cmd::Command;
 #[cfg(all(unix, feature = "xattr"))]

--- a/tests/fuzzy.rs
+++ b/tests/fuzzy.rs
@@ -1,3 +1,4 @@
+// tests/fuzzy.rs
 use assert_cmd::Command;
 use std::fs;
 use tempfile::tempdir;

--- a/tests/ignore_missing_args.rs
+++ b/tests/ignore_missing_args.rs
@@ -1,3 +1,4 @@
+// tests/ignore_missing_args.rs
 use assert_cmd::Command;
 use tempfile::tempdir;
 

--- a/tests/interop/remote_option.rs
+++ b/tests/interop/remote_option.rs
@@ -1,3 +1,4 @@
+// tests/interop/remote_option.rs
 #![cfg(unix)]
 
 

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -1,3 +1,4 @@
+// tests/packaging.rs
 use std::process::Command;
 
 #[test]

--- a/tests/sockopts.rs
+++ b/tests/sockopts.rs
@@ -1,3 +1,4 @@
+// tests/sockopts.rs
 use assert_cmd::Command;
 use std::fs;
 use tempfile::tempdir;

--- a/tests/write_batch.rs
+++ b/tests/write_batch.rs
@@ -1,3 +1,4 @@
+// tests/write_batch.rs
 use assert_cmd::Command;
 use std::fs;
 use tempfile::tempdir;

--- a/tests/write_devices.rs
+++ b/tests/write_devices.rs
@@ -1,3 +1,4 @@
+// tests/write_devices.rs
 use assert_cmd::Command;
 use std::fs;
 use std::os::unix::fs::FileTypeExt;


### PR DESCRIPTION
## Summary
- add repo-relative path header comments to miscellaneous tests and meta module files

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(incomplete: terminated after >60s)*
- `cargo test --all-features` *(fails: cannot find -lacl)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68b5d0f1eefc832387de2c33871c896d