### PR TITLE
feat(protocol): add supported protocols list

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
-use protocol::{negotiate_version, LATEST_VERSION};
+use protocol::{negotiate_version, SUPPORTED_PROTOCOLS};
 use sd_notify::{self, NotifyState};
 use transport::{AddressFamily, RateLimitedTransport, TcpTransport, TimeoutTransport, Transport};
 
@@ -485,8 +485,9 @@ pub fn handle_connection<T: Transport>(
         return Ok(());
     }
     let peer_ver = u32::from_be_bytes(buf);
-    transport.send(&LATEST_VERSION.to_be_bytes())?;
-    negotiate_version(LATEST_VERSION, peer_ver).map_err(|e| io::Error::other(e.to_string()))?;
+    let latest = SUPPORTED_PROTOCOLS[0];
+    transport.send(&latest.to_be_bytes())?;
+    negotiate_version(latest, peer_ver).map_err(|e| io::Error::other(e.to_string()))?;
     let (mut token, global_allowed, no_motd) = authenticate(transport, secrets, password)?;
     if !no_motd {
         if let Some(mpath) = motd {

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -1,6 +1,6 @@
 // crates/protocol/tests/protocol.rs
 use filelist::{Decoder as FDecoder, Encoder as FEncoder, Entry as FEntry};
-use protocol::{negotiate_version, Frame, Message, Msg, Tag, V31, V32};
+use protocol::{negotiate_version, Frame, Message, Msg, Tag, MIN_VERSION, SUPPORTED_PROTOCOLS};
 
 #[test]
 fn frame_roundtrip() {
@@ -39,11 +39,12 @@ fn keepalive_roundtrip() {
 
 #[test]
 fn version_negotiation() {
-    assert_eq!(negotiate_version(V32, V32), Ok(V32));
-    assert_eq!(negotiate_version(V32, V31), Ok(V31));
-    assert_eq!(negotiate_version(V31, V32), Ok(V31));
-    assert_eq!(negotiate_version(V31, V31), Ok(V31));
-    assert!(negotiate_version(V32, 30).is_err());
+    let latest = SUPPORTED_PROTOCOLS[0];
+    for &peer in SUPPORTED_PROTOCOLS {
+        assert_eq!(negotiate_version(latest, peer), Ok(peer));
+        assert_eq!(negotiate_version(peer, latest), Ok(peer));
+    }
+    assert!(negotiate_version(latest, MIN_VERSION - 1).is_err());
 }
 
 #[test]

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -1,7 +1,7 @@
 // crates/protocol/tests/server.rs
 use compress::{available_codecs, encode_codecs, Codec};
 use protocol::{
-    ExitCode, Message, Server, CAP_CODECS, CAP_ZSTD, LATEST_VERSION, SUPPORTED_CAPS, V31, V32,
+    ExitCode, Message, Server, CAP_CODECS, CAP_ZSTD, SUPPORTED_CAPS, SUPPORTED_PROTOCOLS, V31, V32,
 };
 use std::io::Cursor;
 use std::time::Duration;
@@ -13,23 +13,22 @@ fn server_negotiates_version() {
     let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
+    let latest = SUPPORTED_PROTOCOLS[0];
     let mut input = Cursor::new({
         let mut v = vec![0];
-        v.extend_from_slice(&LATEST_VERSION.to_be_bytes());
+        v.extend_from_slice(&latest.to_be_bytes());
         v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
         v.extend_from_slice(&codecs_buf);
         v
     });
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
-    let (caps, peer_codecs) = srv
-        .handshake(LATEST_VERSION, SUPPORTED_CAPS, &local)
-        .unwrap();
-    assert_eq!(srv.version, LATEST_VERSION);
+    let (caps, peer_codecs) = srv.handshake(latest, SUPPORTED_CAPS, &local).unwrap();
+    assert_eq!(srv.version, latest);
     assert_eq!(caps, SUPPORTED_CAPS);
     assert_eq!(peer_codecs, local);
     let expected = {
-        let mut v = LATEST_VERSION.to_be_bytes().to_vec();
+        let mut v = latest.to_be_bytes().to_vec();
         v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
         let mut out_frame = Vec::new();
         codecs_frame.encode(&mut out_frame).unwrap();
@@ -55,8 +54,9 @@ fn server_accepts_legacy_version() {
     });
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
+    let latest = SUPPORTED_PROTOCOLS[0];
     let (caps, peer_codecs) = srv
-        .handshake(LATEST_VERSION, SUPPORTED_CAPS, &available_codecs())
+        .handshake(latest, SUPPORTED_CAPS, &available_codecs())
         .unwrap();
     assert_eq!(srv.version, legacy);
     assert_eq!(caps & CAP_CODECS, CAP_CODECS);
@@ -90,8 +90,8 @@ fn server_classic_versions() {
         });
         let mut output = Vec::new();
         let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
-        srv.handshake(LATEST_VERSION, SUPPORTED_CAPS, &local)
-            .unwrap();
+        let latest = SUPPORTED_PROTOCOLS[0];
+        srv.handshake(latest, SUPPORTED_CAPS, &local).unwrap();
         assert_eq!(srv.version, ver);
         let expected = {
             let mut v = ver.to_be_bytes().to_vec();
@@ -112,18 +112,17 @@ fn server_negotiates_zstd() {
     let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
+    let latest = SUPPORTED_PROTOCOLS[0];
     let mut input = Cursor::new({
         let mut v = vec![0];
-        v.extend_from_slice(&LATEST_VERSION.to_be_bytes());
+        v.extend_from_slice(&latest.to_be_bytes());
         v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
         v.extend_from_slice(&codecs_buf);
         v
     });
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
-    let (caps, _) = srv
-        .handshake(LATEST_VERSION, SUPPORTED_CAPS, &local)
-        .unwrap();
+    let (caps, _) = srv.handshake(latest, SUPPORTED_CAPS, &local).unwrap();
     assert_eq!(caps & CAP_ZSTD, CAP_ZSTD);
     assert_eq!(srv.mux.compressor, Codec::Zstd);
     assert_eq!(srv.demux.compressor, Codec::Zstd);
@@ -136,18 +135,17 @@ fn server_propagates_handshake_error() {
         .to_frame(0)
         .encode(&mut buf)
         .unwrap();
+    let latest = SUPPORTED_PROTOCOLS[0];
     let mut input = Cursor::new({
         let mut v = vec![0];
-        v.extend_from_slice(&LATEST_VERSION.to_be_bytes());
+        v.extend_from_slice(&latest.to_be_bytes());
         v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
         v.extend_from_slice(&buf);
         v
     });
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
-    let err = srv
-        .handshake(LATEST_VERSION, SUPPORTED_CAPS, &[])
-        .unwrap_err();
+    let err = srv.handshake(latest, SUPPORTED_CAPS, &[]).unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::Other);
     assert_eq!(srv.demux.take_remote_error().as_deref(), Some("fail"));
 }
@@ -159,18 +157,17 @@ fn server_propagates_handshake_exit_code() {
         .to_frame(0)
         .encode(&mut buf)
         .unwrap();
+    let latest = SUPPORTED_PROTOCOLS[0];
     let mut input = Cursor::new({
         let mut v = vec![0];
-        v.extend_from_slice(&LATEST_VERSION.to_be_bytes());
+        v.extend_from_slice(&latest.to_be_bytes());
         v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
         v.extend_from_slice(&buf);
         v
     });
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
-    let err = srv
-        .handshake(LATEST_VERSION, SUPPORTED_CAPS, &[])
-        .unwrap_err();
+    let err = srv.handshake(latest, SUPPORTED_CAPS, &[]).unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::Other);
     assert!(matches!(
         srv.demux.take_exit_code(),


### PR DESCRIPTION
## Summary
- add `SUPPORTED_PROTOCOLS` list and iterate through it during version negotiation
- default to the latest supported protocol in daemon/CLI handshakes
- cover protocol negotiation for peer subsets in unit tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p protocol`
- `cargo test -p daemon`
- `cargo test -p oc-rsync-cli --lib` *(fails: Command oc-rsync-cli: Argument or group 'daemon' specified in 'required_unless*' for 'src' does not exist)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5dbcfddf08323b7c6559d194ace5e