### PR TITLE
feat(cli): add charset translation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "engine"
 version = "0.1.0"
 dependencies = [
@@ -908,6 +917,7 @@ dependencies = [
  "clap",
  "compress",
  "daemon",
+ "encoding_rs",
  "engine",
  "filters",
  "logging",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -16,6 +16,7 @@ meta = { path = "../meta", default-features = false }
 daemon = { path = "../daemon" }
 logging = { path = "../logging" }
 tracing = "0.1"
+encoding_rs = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,11 +2,14 @@
 
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
+use engine::SyncOptions;
 use filetime::{set_file_mtime, FileTime};
 use logging::progress_formatter;
 #[cfg(unix)]
 use nix::unistd::{chown, mkfifo, Gid, Uid};
+use oc_rsync_cli::{parse_iconv, spawn_daemon_session};
 use predicates::prelude::PredicateBooleanExt;
+use protocol::SUPPORTED_PROTOCOLS;
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};
 #[cfg(unix)]
@@ -49,6 +52,102 @@ fn remote_option_short_flag_is_accepted() {
         .args(["-M", "--log-file=/tmp/foo", "--version"])
         .assert()
         .success();
+}
+
+#[test]
+fn iconv_invalid_charset_fails() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--iconv=FOO",
+            &src_arg,
+            dst_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "iconv_open(\"UTF-8\", \"FOO\") failed",
+        ));
+}
+
+#[test]
+fn iconv_option_sent_to_daemon() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut buf = [0u8; 4];
+        stream.read_exact(&mut buf).unwrap();
+        stream
+            .write_all(&SUPPORTED_PROTOCOLS[0].to_be_bytes())
+            .unwrap();
+        let mut b = [0u8; 1];
+        loop {
+            stream.read_exact(&mut b).unwrap();
+            if b[0] == b'\n' {
+                break;
+            }
+        }
+        stream.write_all(b"@RSYNCD: OK\n").unwrap();
+        let mut line = Vec::new();
+        loop {
+            stream.read_exact(&mut b).unwrap();
+            if b[0] == b'\n' {
+                break;
+            }
+            line.push(b[0]);
+        }
+        assert_eq!(line, b"mod");
+        let mut got = false;
+        loop {
+            line.clear();
+            loop {
+                stream.read_exact(&mut b).unwrap();
+                if b[0] == b'\n' {
+                    break;
+                }
+                line.push(b[0]);
+            }
+            if line.is_empty() {
+                break;
+            }
+            if line == b"--iconv=utf8,latin1" {
+                got = true;
+            }
+        }
+        assert!(got);
+    });
+
+    let mut sync_opts = SyncOptions::default();
+    sync_opts.remote_options.push("--iconv=utf8,latin1".into());
+    let cv = parse_iconv("utf8,latin1").unwrap();
+    let _ = spawn_daemon_session(
+        "127.0.0.1",
+        "mod",
+        Some(port),
+        None,
+        true,
+        None,
+        None,
+        None,
+        &[],
+        &sync_opts,
+        SUPPORTED_PROTOCOLS[0],
+        None,
+        Some(&cv),
+    )
+    .unwrap();
+    handle.join().unwrap();
 }
 
 #[test]

--- a/tests/interop/remote_option.rs
+++ b/tests/interop/remote_option.rs
@@ -119,6 +119,7 @@ fn daemon_remote_option_forwarded() {
         &sync_opts,
         protocol::LATEST_VERSION,
         None,
+        None,
     )
     .unwrap();
     std::thread::sleep(std::time::Duration::from_millis(50));

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -162,6 +162,7 @@ fn daemon_handshake_timeout() {
         &SyncOptions::default(),
         31,
         None,
+        None,
     );
     match res {
         Ok(_) => panic!("expected timeout"),


### PR DESCRIPTION
## Summary
- add `--iconv` option and charset translation for daemon sessions
- translate remote messages and propagate iconv errors
- test iconv flag handling and daemon negotiation

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon tests run longer than 60s)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60ce7f50c832395a7fb1fb0150abf