### PR TITLE
feat: add forced deletion guards

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -192,6 +192,12 @@ struct ClientOpts {
     remove_source_files: bool,
     #[arg(long = "ignore-errors", help_heading = "Delete")]
     ignore_errors: bool,
+    #[arg(
+        long,
+        help_heading = "Delete",
+        help = "force deletion of dirs even if not empty"
+    )]
+    force: bool,
     #[arg(long = "max-delete", value_name = "NUM", help_heading = "Delete")]
     max_delete: Option<usize>,
     #[arg(long = "max-alloc", value_name = "SIZE", value_parser = parse_size, help_heading = "Misc")]
@@ -1083,6 +1089,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         delete_missing_args: opts.delete_missing_args,
         remove_source_files: opts.remove_source_files,
         ignore_errors: opts.ignore_errors,
+        force: opts.force,
         max_delete: opts.max_delete,
         max_alloc: opts.max_alloc.unwrap_or(1usize << 30),
         max_size: opts.max_size,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -223,7 +223,12 @@ fn remove_file_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
 }
 
 fn remove_dir_all_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
-    match fs::remove_dir_all(path) {
+    let res = if opts.force {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_dir(path)
+    };
+    match res {
         Ok(_) => Ok(()),
         Err(e) => {
             let e = io_context(path, e);
@@ -1512,6 +1517,7 @@ pub struct SyncOptions {
     pub delete_missing_args: bool,
     pub remove_source_files: bool,
     pub ignore_errors: bool,
+    pub force: bool,
     pub max_delete: Option<usize>,
     pub max_alloc: usize,
     pub max_size: Option<u64>,
@@ -1605,6 +1611,7 @@ impl Default for SyncOptions {
             delete_missing_args: false,
             remove_source_files: false,
             ignore_errors: false,
+            force: false,
             max_delete: None,
             max_alloc: 1 << 30,
             max_size: None,
@@ -1736,15 +1743,14 @@ fn delete_extraneous(
     opts: &SyncOptions,
     stats: &mut Stats,
 ) -> Result<()> {
-    let walker = walk(
+    let mut walker = walk(
         dst,
-        1024,
+        1,
         opts.links || opts.copy_links || opts.copy_dirlinks || opts.copy_unsafe_links,
     );
     let mut state = String::new();
-
     let mut first_err: Option<EngineError> = None;
-    for batch in walker {
+    while let Some(batch) = walker.next() {
         let batch = batch.map_err(|e| EngineError::Other(e.to_string()))?;
         for entry in batch {
             let path = entry.apply(&mut state);
@@ -1754,7 +1760,49 @@ fn delete_extraneous(
                     .is_included_for_delete(rel)
                     .map_err(|e| EngineError::Other(format!("{:?}", e)))?;
                 let src_exists = src.join(rel).exists();
-                if (included && !src_exists) || (!included && opts.delete_excluded) {
+                if file_type.is_dir() {
+                    if (included && !src_exists) || (!included && opts.delete_excluded) {
+                        if let Some(max) = opts.max_delete {
+                            if stats.files_deleted >= max {
+                                return Err(EngineError::Other("max-delete limit exceeded".into()));
+                            }
+                        }
+                        let res = if opts.backup {
+                            let backup_path = if let Some(ref dir) = opts.backup_dir {
+                                dir.join(rel)
+                            } else {
+                                let name = path
+                                    .file_name()
+                                    .map(|n| format!("{}~", n.to_string_lossy()))
+                                    .unwrap_or_else(|| "~".to_string());
+                                path.with_file_name(name)
+                            };
+                            let dir_res = if let Some(parent) = backup_path.parent() {
+                                fs::create_dir_all(parent).map_err(|e| io_context(parent, e))
+                            } else {
+                                Ok(())
+                            };
+                            dir_res
+                                .and_then(|_| atomic_rename(&path, &backup_path))
+                                .err()
+                        } else {
+                            remove_dir_all_opts(&path, opts).err()
+                        };
+                        walker.skip_current_dir();
+                        match res {
+                            None => {
+                                stats.files_deleted += 1;
+                            }
+                            Some(e) => {
+                                if first_err.is_none() {
+                                    first_err = Some(e);
+                                }
+                            }
+                        }
+                    } else if !included {
+                        walker.skip_current_dir();
+                    }
+                } else if (included && !src_exists) || (!included && opts.delete_excluded) {
                     if let Some(max) = opts.max_delete {
                         if stats.files_deleted >= max {
                             return Err(EngineError::Other("max-delete limit exceeded".into()));
@@ -1778,8 +1826,6 @@ fn delete_extraneous(
                         dir_res
                             .and_then(|_| atomic_rename(&path, &backup_path))
                             .err()
-                    } else if file_type.is_dir() {
-                        remove_dir_all_opts(&path, opts).err()
                     } else {
                         remove_file_opts(&path, opts).err()
                     };

--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -63,6 +63,10 @@ impl Walk {
         }
     }
 
+    pub fn skip_current_dir(&mut self) {
+        self.iter.skip_current_dir();
+    }
+
     pub fn uids(&self) -> &[u32] {
         &self.uid_table
     }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -935,6 +935,53 @@ fn checksum_forces_transfer_cli() {
     assert_eq!(std::fs::read(&dst_file).unwrap(), b"aaaa");
 }
 
+#[test]
+fn delete_non_empty_dir_without_force_fails() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(dst.join("sub")).unwrap();
+    std::fs::write(dst.join("sub/file.txt"), b"hi").unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--delete",
+            &format!("{}/", src.display()),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+
+    assert!(dst.join("sub/file.txt").exists());
+}
+
+#[test]
+fn force_allows_non_empty_dir_deletion() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(dst.join("sub")).unwrap();
+    std::fs::write(dst.join("sub/file.txt"), b"hi").unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--delete",
+            "--force",
+            &format!("{}/", src.display()),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(!dst.join("sub").exists());
+}
+
 #[cfg(unix)]
 #[test]
 fn perms_flag_preserves_permissions() {


### PR DESCRIPTION
## Summary
- add `force` option to engine and CLI to guard non-empty directory deletions
- skip walking removed directories to honor safety policies
- test forced deletion behavior from the CLI

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(daemon tests hung: `client_respects_no_motd has been running for over 60 seconds`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60ce1b0608323aa4058910322fcc5