### PR TITLE
Handle escaped filter patterns and list files

### DIFF
--- a/crates/filters/tests/escaped_patterns.rs
+++ b/crates/filters/tests/escaped_patterns.rs
@@ -1,0 +1,20 @@
+// crates/filters/tests/escaped_patterns.rs
+use filters::{parse, Matcher};
+use std::collections::HashSet;
+
+fn p(s: &str) -> Matcher {
+    let mut v = HashSet::new();
+    Matcher::new(parse(s, &mut v, 0).unwrap())
+}
+
+#[test]
+fn escaped_hash_and_space() {
+    let m = p("+ foo\\ bar\\#baz\n- *\n");
+    assert!(m.is_included("foo bar#baz").unwrap());
+}
+
+#[test]
+fn escaped_trailing_space() {
+    let m = p("+ file\\ \n- *\n");
+    assert!(m.is_included("file ").unwrap());
+}

--- a/crates/filters/tests/list_parsing.rs
+++ b/crates/filters/tests/list_parsing.rs
@@ -1,0 +1,9 @@
+// crates/filters/tests/list_parsing.rs
+use filters::parse_list;
+
+#[test]
+fn list_file_respects_escapes_and_comments() {
+    let data = b"foo\\ bar\n#comment\nbaz\\#qux\\ \n\n";
+    let out = parse_list(data, false);
+    assert_eq!(out, vec!["foo bar", "baz#qux "]);
+}

--- a/crates/filters/tests/merge_same_index.rs
+++ b/crates/filters/tests/merge_same_index.rs
@@ -1,0 +1,19 @@
+// crates/filters/tests/merge_same_index.rs
+use filters::{parse, Matcher};
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn nested_rsync_filter_order() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("sub")).unwrap();
+    fs::write(root.join(".rsync-filter"), "+ keep\n: sub/.rsync-filter\n").unwrap();
+    fs::write(root.join("sub/.rsync-filter"), "- keep\n").unwrap();
+
+    let mut v = HashSet::new();
+    let rules = parse(": /.rsync-filter\n- *\n", &mut v, 0).unwrap();
+    let m = Matcher::new(rules).with_root(root);
+    assert!(!m.is_included("sub/keep").unwrap());
+}


### PR DESCRIPTION
## Summary
- support escaped spaces, hashes, and inline comments in filter patterns and list files
- ensure per-directory `.rsync-filter` files merge in upstream order
- add CLI and unit tests for files-from and escaped patterns

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(partially: daemon tests exceed time but major suite passes)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60cdf8d048323bb2948dbdf3a1c0c