### PR TITLE
Add username UID mapping and tests

### DIFF
--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -635,7 +635,23 @@ fn set_file_crtime(_path: &Path, _crtime: FileTime) -> io::Result<()> {
 }
 
 pub fn uid_from_name(name: &str) -> Option<u32> {
-    get_user_by_name(name).map(|u| u.uid())
+    get_user_by_name(name).map(|u| u.uid()).or_else(|| {
+        fs::read_to_string("/etc/passwd").ok().and_then(|data| {
+            data.lines().find_map(|line| {
+                if line.starts_with('#') {
+                    return None;
+                }
+                let mut parts = line.split(':');
+                let user_name = parts.next()?;
+                if user_name != name {
+                    return None;
+                }
+                parts.next();
+                let uid_str = parts.next()?;
+                uid_str.parse().ok()
+            })
+        })
+    })
 }
 
 pub fn gid_from_name(name: &str) -> Option<u32> {
@@ -667,7 +683,25 @@ pub fn gid_from_name_or_id(spec: &str) -> Option<u32> {
 }
 
 pub fn uid_to_name(uid: u32) -> Option<String> {
-    get_user_by_uid(uid).map(|u| u.name().to_string_lossy().into_owned())
+    get_user_by_uid(uid)
+        .map(|u| u.name().to_string_lossy().into_owned())
+        .or_else(|| {
+            fs::read_to_string("/etc/passwd").ok().and_then(|data| {
+                data.lines().find_map(|line| {
+                    if line.starts_with('#') {
+                        return None;
+                    }
+                    let mut parts = line.split(':');
+                    let name = parts.next()?;
+                    parts.next();
+                    let uid_str = parts.next()?;
+                    match uid_str.parse::<u32>() {
+                        Ok(u) if u == uid => Some(name.to_string()),
+                        _ => None,
+                    }
+                })
+            })
+        })
 }
 
 pub fn gid_to_name(gid: u32) -> Option<String> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -17,7 +17,7 @@ use std::thread;
 use std::time::Duration;
 use tempfile::{tempdir, tempdir_in};
 #[cfg(unix)]
-use users::{get_current_gid, get_current_uid, get_group_by_gid};
+use users::{get_current_gid, get_current_uid, get_group_by_gid, get_user_by_uid};
 #[cfg(all(unix, feature = "xattr"))]
 use xattr as _;
 
@@ -708,6 +708,84 @@ fn user_and_group_ids_are_mapped() {
     let meta = std::fs::metadata(dst_dir.join("id.txt")).unwrap();
     assert_eq!(meta.uid(), mapped_uid);
     assert_eq!(meta.gid(), mapped_gid);
+}
+
+#[cfg(unix)]
+#[test]
+fn user_names_are_mapped_even_with_numeric_ids() {
+    let uid = get_current_uid();
+    if uid != 0 {
+        eprintln!(
+            "skipping user_names_are_mapped_even_with_numeric_ids: requires root or CAP_CHOWN"
+        );
+        return;
+    }
+    {
+        let dir = tempdir().unwrap();
+        let probe = dir.path().join("probe");
+        std::fs::write(&probe, b"probe").unwrap();
+        if let Err(err) = chown(&probe, Some(Uid::from_raw(1)), Some(Gid::from_raw(1))) {
+            match err {
+                nix::errno::Errno::EPERM => {
+                    eprintln!(
+                        "skipping user_names_are_mapped_even_with_numeric_ids: lacks CAP_CHOWN"
+                    );
+                    return;
+                }
+                _ => panic!("unexpected chown error: {err}"),
+            }
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    let file = src_dir.join("id.txt");
+    std::fs::write(&file, b"ids").unwrap();
+
+    let src_arg = format!("{}/", src_dir.display());
+    let uname = get_user_by_uid(uid)
+        .unwrap()
+        .name()
+        .to_string_lossy()
+        .into_owned();
+    let passwd_data = std::fs::read_to_string("/etc/passwd").unwrap();
+    let (other_name, other_uid) = passwd_data
+        .lines()
+        .find_map(|line| {
+            if line.starts_with('#') || line.trim().is_empty() {
+                return None;
+            }
+            let mut parts = line.split(':');
+            let name = parts.next()?;
+            parts.next();
+            let uid_str = parts.next()?;
+            let uid_val: u32 = uid_str.parse().ok()?;
+            if uid_val != uid {
+                Some((name.to_string(), uid_val))
+            } else {
+                None
+            }
+        })
+        .expect("no alternate user found");
+
+    let usermap = format!("--usermap={uname}:{other_name}");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--numeric-ids",
+            usermap.as_str(),
+            src_arg.as_str(),
+            dst_dir.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let meta = std::fs::metadata(dst_dir.join("id.txt")).unwrap();
+    assert_eq!(meta.uid(), other_uid);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- resolve usernames to UIDs via `/etc/passwd` fallback
- verify username mapping works even with `--numeric-ids`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test` *(fails: tests hang for over 60s)*


------
https://chatgpt.com/codex/tasks/task_e_68b60cddc52c8323babb76413f50767d