### PR TITLE
Expand CI matrix and add resume-progress tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: CI
 
 on:
   push:
@@ -11,11 +11,17 @@ env:
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/tests/interop/run_matrix.sh
+++ b/tests/interop/run_matrix.sh
@@ -30,6 +30,7 @@ SCENARIOS=(
   "append_verify --append-verify"
   "resume --partial"
   "progress --progress"
+  "resume_progress --partial --progress"
 )
 
 # Options used for all transfers. -a implies -rtgoD, we add -A and -X for ACLs
@@ -224,7 +225,7 @@ for c in "${CLIENT_VERSIONS[@]}"; do
             if [[ "$name" == drop_connection ]]; then
               dd if=/dev/zero of="$src/big.bin" bs=1M count=20 >/dev/null 2>&1
               timeout 1 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" -e "$ssh" "$src/" "root@localhost:$tmpdir" >/dev/null || true
-            elif [[ "$name" == resume ]]; then
+            elif [[ "$name" == resume* ]]; then
               dd if=/dev/zero of="$src/big.bin" bs=1M count=20 >/dev/null 2>&1
               timeout 1 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" -e "$ssh" "$src/" "root@localhost:$tmpdir" >/dev/null || true
               "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" -e "$ssh" "$src/" "root@localhost:$tmpdir" >/dev/null
@@ -270,7 +271,7 @@ for c in "${CLIENT_VERSIONS[@]}"; do
               if [[ "$name" == drop_connection ]]; then
                 dd if=/dev/zero of="$src/big.bin" bs=1M count=20 >/dev/null 2>&1
                 timeout 1 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" "$src/" "rsync://localhost:$port/mod" >/dev/null || true
-              elif [[ "$name" == resume ]]; then
+              elif [[ "$name" == resume* ]]; then
                 dd if=/dev/zero of="$src/big.bin" bs=1M count=20 >/dev/null 2>&1
                 timeout 1 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" "$src/" "rsync://localhost:$port/mod" >/dev/null || true
                 "$client_bin" "${COMMON_FLAGS[@]}" "${extra[@]}" "$src/" "rsync://localhost:$port/mod" >/dev/null


### PR DESCRIPTION
## Summary
- run CI on Ubuntu, macOS, and Windows runners
- test resume plus progress combination in interop matrix

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: hanging integration tests)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b60d5eb1948323911021d1006987a4