### PR TITLE
feat: support daemon chroot and numeric id options

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1788,6 +1788,7 @@ fn run_daemon(opts: DaemonOpts, matches: &ArgMatches) -> Result<()> {
     let mut address = opts.address;
     let timeout = matches.get_one::<Duration>("timeout").copied();
     let bwlimit = matches.get_one::<u64>("bwlimit").copied();
+    let numeric_ids_flag = matches.get_flag("numeric_ids");
     if let Some(cfg_path) = matches.get_one::<PathBuf>("config") {
         let cfg = parse_config_file(cfg_path).map_err(|e| EngineError::Other(e.to_string()))?;
         for m in cfg.modules {
@@ -1814,10 +1815,21 @@ fn run_daemon(opts: DaemonOpts, matches: &ArgMatches) -> Result<()> {
         if !cfg.hosts_deny.is_empty() {
             hosts_deny = cfg.hosts_deny;
         }
+        if let Some(val) = cfg.numeric_ids {
+            for m in modules.values_mut() {
+                m.numeric_ids = val;
+            }
+        }
     }
 
     for m in opts.module {
         modules.insert(m.name.clone(), m);
+    }
+
+    if numeric_ids_flag {
+        for m in modules.values_mut() {
+            m.numeric_ids = true;
+        }
     }
 
     let addr_family = if matches.get_flag("ipv4") {


### PR DESCRIPTION
## Summary
- add `use chroot` and `numeric ids` directives to daemon config
- allow dropping privileges without chroot
- exercise auth, chroot, and numeric-id scenarios in daemon tests

## Testing
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: client_respects_no_motd, daemon_accepts_authorized_client, daemon_accepts_connection_on_ephemeral_port, daemon_allows_path_traversal_without_chroot timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68b60ce04e14832399b23c70af10610e