### PR TITLE
Handle deferred hard link creation

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2079,6 +2079,9 @@ pub fn sync(
                             &dest_path,
                         )?
                     {
+                        if let Some(parent) = dest_path.parent() {
+                            fs::create_dir_all(parent).map_err(|e| io_context(parent, e))?;
+                        }
                         continue;
                     }
                     let partial_exists = if opts.partial {


### PR DESCRIPTION
## Summary
- ensure parent directories exist before deferring hard link creation

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments` *(fails: crates/logging/tests/info_flags.rs: contains disallowed comments)*
- `make lint`
- `cargo test --test local_sync_tree sync_preserves_hard_links -- --nocapture`
- `cargo test --test local_sync_tree sync_preserves_multiple_hard_links -- --nocapture`
- `cargo test --test local_sync_tree -- --nocapture` *(fails: sync_keep_dirlinks_preserves_symlinked_dir, sync_preserves_executability)*

------
https://chatgpt.com/codex/tasks/task_e_68b61765b5308323a50d47db9f3ea4a6