### PR TITLE
Handle xattr include/exclude during metadata copy

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -13,6 +13,8 @@ use std::os::fd::AsRawFd;
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
+#[cfg(feature = "xattr")]
+use std::rc::Rc;
 #[cfg(unix)]
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -1074,6 +1076,7 @@ pub struct Receiver {
     state: ReceiverState,
     codec: Option<Codec>,
     opts: SyncOptions,
+    matcher: Matcher,
     delayed: Vec<(PathBuf, PathBuf, PathBuf)>,
     #[cfg(unix)]
     link_map: HashMap<(u64, u64), PathBuf>,
@@ -1093,6 +1096,7 @@ impl Receiver {
             state: ReceiverState::Idle,
             codec,
             opts,
+            matcher: Matcher::default(),
             delayed: Vec::new(),
             #[cfg(unix)]
             link_map: HashMap::new(),
@@ -1421,6 +1425,11 @@ impl Receiver {
                     }))
                 };
 
+            #[cfg(feature = "xattr")]
+            let m1 = self.matcher.clone();
+            #[cfg(feature = "xattr")]
+            let m2 = self.matcher.clone();
+
             let mut meta_opts = meta::Options {
                 xattrs: {
                     #[cfg(feature = "xattr")]
@@ -1432,6 +1441,14 @@ impl Receiver {
                         false
                     }
                 },
+                #[cfg(feature = "xattr")]
+                xattr_filter: Some(Rc::new(move |name: &std::ffi::OsStr| {
+                    m1.is_xattr_included(name).unwrap_or(false)
+                })),
+                #[cfg(feature = "xattr")]
+                xattr_filter_delete: Some(Rc::new(move |name: &std::ffi::OsStr| {
+                    m2.is_xattr_included_for_delete(name).unwrap_or(false)
+                })),
                 acl: {
                     #[cfg(feature = "acl")]
                     {
@@ -2017,6 +2034,7 @@ pub fn sync(
     let matcher = matcher.clone().with_root(src_root.clone());
     let mut sender = Sender::new(opts.block_size, matcher.clone(), codec, opts.clone());
     let mut receiver = Receiver::new(codec, opts.clone());
+    receiver.matcher = matcher.clone();
     let mut dir_meta: Vec<(PathBuf, PathBuf)> = Vec::new();
     if matches!(opts.delete, Some(DeleteMode::Before)) {
         delete_extraneous(&src_root, dst, &matcher, opts, &mut stats)?;

--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -10,13 +10,18 @@ use nix::sys::stat::{self, FchmodatFlags, Mode, SFlag};
 use nix::unistd::{self, FchownatFlags, Gid, Uid};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::sync::Arc;
+#[cfg(feature = "xattr")]
+use std::rc::Rc;
 use users::{get_group_by_gid, get_group_by_name, get_user_by_name, get_user_by_uid};
 
 #[cfg(target_os = "macos")]
 use std::os::unix::ffi::OsStrExt;
 
 #[cfg(feature = "xattr")]
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
+
+#[cfg(feature = "xattr")]
+type XattrFilter = Rc<dyn Fn(&OsStr) -> bool>;
 
 #[cfg(all(test, feature = "xattr"))]
 mod xattr {
@@ -76,6 +81,10 @@ pub struct Options {
     pub omit_link_times: bool,
     pub uid_map: Option<Arc<dyn Fn(u32) -> u32 + Send + Sync>>,
     pub gid_map: Option<Arc<dyn Fn(u32) -> u32 + Send + Sync>>,
+    #[cfg(feature = "xattr")]
+    pub xattr_filter: Option<XattrFilter>,
+    #[cfg(feature = "xattr")]
+    pub xattr_filter_delete: Option<XattrFilter>,
 }
 
 impl std::fmt::Debug for Options {
@@ -98,6 +107,26 @@ impl std::fmt::Debug for Options {
             .field("omit_link_times", &self.omit_link_times)
             .field("uid_map", &self.uid_map.is_some())
             .field("gid_map", &self.gid_map.is_some())
+            .field("xattr_filter", &{
+                #[cfg(feature = "xattr")]
+                {
+                    self.xattr_filter.is_some()
+                }
+                #[cfg(not(feature = "xattr"))]
+                {
+                    false
+                }
+            })
+            .field("xattr_filter_delete", &{
+                #[cfg(feature = "xattr")]
+                {
+                    self.xattr_filter_delete.is_some()
+                }
+                #[cfg(not(feature = "xattr"))]
+                {
+                    false
+                }
+            })
             .finish()
     }
 }
@@ -183,6 +212,11 @@ impl Metadata {
                                 || name == "system.posix_acl_access"
                                 || name == "system.posix_acl_default"
                             {
+                                continue;
+                            }
+                        }
+                        if let Some(ref filter) = opts.xattr_filter {
+                            if !filter(attr.as_os_str()) {
                                 continue;
                             }
                         }
@@ -441,7 +475,12 @@ impl Metadata {
 
         #[cfg(feature = "xattr")]
         if opts.xattrs {
-            crate::apply_xattrs(path, &self.xattrs)?;
+            crate::apply_xattrs(
+                path,
+                &self.xattrs,
+                opts.xattr_filter.as_deref(),
+                opts.xattr_filter_delete.as_deref(),
+            )?;
         }
 
         #[cfg(feature = "acl")]


### PR DESCRIPTION
## Summary
- support filtering of extended attributes during metadata collection and apply
- wire Receiver to provide include/exclude closures to Metadata
- test daemon xattr filter behaviour for rsync and oc-rsync clients

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` *(fails: super_overrides_fake_super)*
- `make verify-comments` *(fails: crates/logging/tests/info_flags.rs: contains disallowed comments)*
- `make lint` *(failed: make: *** [Makefile:8: lint] Error 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b617680220832395837b73313a72e2