### PR TITLE
daemon: validate module input and test secrets permissions

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -67,11 +67,18 @@ pub fn parse_module(s: &str) -> std::result::Result<Module, String> {
     let name = parts
         .next()
         .ok_or_else(|| "missing module name".to_string())?
-        .to_string();
-    let path = parts
+        .trim();
+    if name.is_empty() {
+        return Err("missing module name".to_string());
+    }
+    let path_str = parts
         .next()
-        .ok_or_else(|| "missing module path".to_string())?;
-    let raw = PathBuf::from(path);
+        .ok_or_else(|| "missing module path".to_string())?
+        .trim();
+    if path_str.is_empty() {
+        return Err("missing module path".to_string());
+    }
+    let raw = PathBuf::from(path_str);
     let abs = if raw.is_absolute() {
         raw
     } else {
@@ -79,7 +86,7 @@ pub fn parse_module(s: &str) -> std::result::Result<Module, String> {
     };
     let canonical = fs::canonicalize(abs).map_err(|e| e.to_string())?;
     Ok(Module {
-        name,
+        name: name.to_string(),
         path: canonical,
         hosts_allow: Vec::new(),
         hosts_deny: Vec::new(),

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -699,6 +699,53 @@ fn daemon_allows_module_access() {
 
 #[test]
 #[serial]
+fn daemon_rejects_world_readable_secrets_file() {
+    if require_network().is_err() {
+        eprintln!("skipping daemon test: network access required");
+        return;
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let secrets = dir.path().join("auth");
+    fs::write(&secrets, "secret data\n").unwrap();
+    #[cfg(unix)]
+    fs::set_permissions(&secrets, fs::Permissions::from_mode(0o644)).unwrap();
+    let port = TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    let mut child = StdCommand::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--daemon",
+            "--module",
+            &format!("data={}", dir.path().display()),
+            "--port",
+            &port.to_string(),
+            "--secrets-file",
+            secrets.to_str().unwrap(),
+        ])
+        .current_dir(dir.path())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_for_daemon(port);
+    let mut t = TcpTransport::connect("127.0.0.1", port, None, None).unwrap();
+    t.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+    t.send(&LATEST_VERSION.to_be_bytes()).unwrap();
+    let mut buf = [0u8; 4];
+    t.receive(&mut buf).unwrap();
+    assert_eq!(u32::from_be_bytes(buf), LATEST_VERSION);
+
+    t.authenticate(Some("secret"), false).unwrap();
+    let n = t.receive(&mut buf).unwrap_or(0);
+    assert_eq!(n, 0);
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+#[serial]
 fn daemon_rejects_invalid_token() {
     if require_network().is_err() {
         eprintln!("skipping daemon test: network access required");


### PR DESCRIPTION
## Summary
- reject empty names and paths when parsing daemon modules
- test that world-readable secrets files are refused

## Testing
- `cargo test --test daemon daemon_rejects_world_readable_secrets_file`
- `cargo test` *(fails: mount: permission denied)*
- `make verify-comments` *(fails: crates/logging/tests/info_flags.rs: contains disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6178160748323b1ab9e6c4c9e0d3d