### PR TITLE
fix default_umask bits type

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -99,13 +99,14 @@ fn ensure_max_alloc(len: u64, opts: &SyncOptions) -> Result<()> {
 }
 
 #[cfg(unix)]
+#[allow(clippy::useless_conversion)]
 fn default_umask() -> u32 {
     static UMASK: OnceLock<u32> = OnceLock::new();
     *UMASK.get_or_init(|| {
         use nix::sys::stat::{umask, Mode};
         let old = umask(Mode::from_bits_truncate(0));
         umask(old);
-        old.bits()
+        u32::from(old.bits())
     })
 }
 

--- a/crates/meta/src/stub.rs
+++ b/crates/meta/src/stub.rs
@@ -13,9 +13,9 @@ mod non_unix {
     type XattrFilter = Rc<dyn Fn(&OsStr) -> bool>;
     use std::io;
     use std::path::Path;
-    use std::sync::Arc;
     #[cfg(feature = "xattr")]
     use std::rc::Rc;
+    use std::sync::Arc;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub enum ChmodTarget {

--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -9,9 +9,9 @@ use nix::errno::Errno;
 use nix::sys::stat::{self, FchmodatFlags, Mode, SFlag};
 use nix::unistd::{self, FchownatFlags, Gid, Uid};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
-use std::sync::Arc;
 #[cfg(feature = "xattr")]
 use std::rc::Rc;
+use std::sync::Arc;
 use users::{get_group_by_gid, get_group_by_name, get_user_by_name, get_user_by_uid};
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary
- convert umask value from `Mode` to `u32` in engine's `default_umask`

## Testing
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon tests unable to mount, some tests hang over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68b62543a94483238690ac0f645748d0