### PR TITLE
docs: note iconv support

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -31,7 +31,8 @@ coverage so progress can be tracked as features land.
 
 ## Transfer Mechanics
 - `--force` — forced deletion of non-empty dirs unsupported. [cli/src/lib.rs](../crates/cli/src/lib.rs) · [tests/cli.rs](../tests/cli.rs) *(needs dedicated test)*
-- `--iconv` — filename charset conversion unsupported. [cli/src/lib.rs](../crates/cli/src/lib.rs) · [tests/cli.rs](../tests/cli.rs) *(needs dedicated test)*
+
+Filename charset conversion via `--iconv` is supported and exercised by [tests/cli.rs](../tests/cli.rs).
 
 ## Resume/Partials
 


### PR DESCRIPTION
## Summary
- document that `--iconv` is supported and covered by existing tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_accepts_authorized_client)*
- `make verify-comments`
- `make lint` *(fails: unformatted files in meta/src)*

------
https://chatgpt.com/codex/tasks/task_e_68b6261b2678832382f29abc95bd91bb