### PR TITLE
docs: prune resolved differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The upstream rsync(1) and rsyncd.conf(5) man pages from rsync 3.4.x are bundled 
 
 ## CLI
 Documentation for invoking the command line interface, available flags, and
-configuration precedence lives in [docs/cli.md](docs/cli.md). Differences from
-classic `rsync` are covered in [docs/differences.md](docs/differences.md).
+configuration precedence lives in [docs/cli.md](docs/cli.md). Any differences from
+classic `rsync` are tracked in [docs/differences.md](docs/differences.md) (currently none).
 
 Quick links:
 

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,20 +1,7 @@
 # Differences from rsync
 
-oc-rsync implements the standard rsync protocol version 32.
+oc-rsync currently has no known behavioral differences from upstream rsync 3.4.x.
 
-See [gaps.md](gaps.md) and [feature_matrix.md](feature_matrix.md) for any remaining parity notes.
-
-## Exit codes
-
-`oc-rsync` mirrors `rsync`'s exit code semantics and forwards unknown values
-across transports. Behavior is validated in
-[crates/protocol/tests/exit_codes.rs](../crates/protocol/tests/exit_codes.rs)
-and end-to-end scenarios like
-[tests/partial_transfer_resume.sh](../tests/partial_transfer_resume.sh).
-
-## File list encoding
-
-Paths in the file list are delta-encoded and use uid/gid lookup tables, matching
-the behavior of upstream rsync.
+Parity gaps and unsupported options are tracked in [gaps.md](gaps.md) and [feature_matrix.md](feature_matrix.md).
 
 Keep this document updated as new differences are introduced.

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -1,8 +1,7 @@
 # Feature Matrix
 
 This table tracks the implementation status of rsync 3.4.x command-line options.
-See [differences.md](differences.md) for a summary of notable behavioral differences and [gaps.md](gaps.md) for
-outstanding parity gaps.
+Behavioral differences from upstream rsync are tracked in [differences.md](differences.md) (currently none) and outstanding parity gaps appear in [gaps.md](gaps.md).
 
 Classic `rsync` protocol versions 31–32 are supported.
 


### PR DESCRIPTION
## Summary
- prune resolved differences from differences.md
- reference lack of differences in README and feature matrix

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(hangs during daemon tests; aborted after >60s)*
- `cargo test --all-features` *(linker failure: `linking with \`cc\` failed`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6267fdf8483238616a50994b57958