### PR TITLE
Allow forced deletion of non-empty directories

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1440,7 +1440,8 @@ fn delete_non_empty_dir_without_force_fails() {
             dst.to_str().unwrap(),
         ])
         .assert()
-        .failure();
+        .failure()
+        .stderr(predicates::str::contains("Directory not empty"));
 
     assert!(dst.join("sub/file.txt").exists());
 }


### PR DESCRIPTION
## Summary
- remove non-empty directories when `--force` is supplied
- check deletion failure message for non-empty directories

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test` *(fails: daemon_accepts_authorized_client)*
- `cargo test --test cli delete_non_empty_dir_without_force_fails -- --nocapture`
- `cargo test --test cli force_allows_non_empty_dir_deletion -- --nocapture`
- `cargo test --test cli force_removes_nested_non_empty_dirs -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b62847e5b08323a4eec23bfacfea13