### PR TITLE
Support anchored filter rules and stdin rule lists

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1725,7 +1725,13 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
 
 fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
     fn load_patterns(path: &Path, from0: bool) -> io::Result<Vec<String>> {
-        filters::parse_list_file(path, from0).map_err(|e| io::Error::other(format!("{:?}", e)))
+        if path == Path::new("-") {
+            let mut buf = Vec::new();
+            io::stdin().read_to_end(&mut buf)?;
+            Ok(filters::parse_list(&buf, from0))
+        } else {
+            filters::parse_list_file(path, from0).map_err(|e| io::Error::other(format!("{:?}", e)))
+        }
     }
 
     let mut entries: Vec<(usize, usize, Rule)> = Vec::new();

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1140,7 +1140,15 @@ pub fn parse(
         }
 
         let mut pattern = rest.to_string();
+        let mut has_anchor = false;
+        while pattern.starts_with("./") {
+            has_anchor = true;
+            pattern = pattern[2..].to_string();
+        }
         if mods.contains('/') && !pattern.starts_with('/') {
+            pattern = format!("/{}", pattern);
+        }
+        if has_anchor && !pattern.starts_with('/') {
             pattern = format!("/{}", pattern);
         }
         let anchored = pattern.starts_with('/');

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1949,6 +1949,33 @@ fn include_before_per_dir_merge_allows_file() {
 }
 
 #[test]
+fn exclude_dot_anchor_only_skips_root() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(src.join("sub")).unwrap();
+    std::fs::write(src.join("root.txt"), b"r").unwrap();
+    std::fs::write(src.join("sub/root.txt"), b"s").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--exclude=./root.txt",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(!dst.join("root.txt").exists());
+    assert!(dst.join("sub/root.txt").exists());
+}
+
+#[test]
 fn exclude_complex_pattern_skips_nested_files() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");

--- a/tests/filter_corpus/edge_dot.rules
+++ b/tests/filter_corpus/edge_dot.rules
@@ -1,0 +1,1 @@
+--filter='- ./root.txt' --filter='- tmp/***'


### PR DESCRIPTION
## Summary
- handle './' anchored filter patterns in filter matcher
- allow CLI to read pattern lists from stdin
- test dot-anchored excludes and add corresponding corpus fixture

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `cargo test` *(fails: daemon_accepts_authorized_client; other daemon tests hang)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68b628391cdc8323b07b183c72beb157