### PR TITLE
Add iconv-based filename conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "checksums",
  "compress",
  "criterion",
+ "encoding_rs",
  "filelist",
  "filetime",
  "filters",
@@ -425,6 +426,7 @@ dependencies = [
  "meta",
  "nix 0.27.1",
  "posix-acl",
+ "protocol",
  "tempfile",
  "thiserror",
  "walk",
@@ -1074,6 +1076,7 @@ dependencies = [
  "byteorder",
  "checksums",
  "compress",
+ "encoding_rs",
  "filelist",
  "indexmap",
 ]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -10,6 +10,7 @@ walk = { path = "../walk" }
 filters = { path = "../filters" }
 compress = { path = "../compress" }
 filelist = { path = "../filelist" }
+protocol = { path = "../protocol" }
 nix = { version = "0.27", features = ["user", "fs"] }
 meta = { path = "../meta", default-features = false }
 logging = { path = "../logging" }
@@ -23,6 +24,7 @@ criterion = { version = "0.5", default-features = false }
 filetime = "0.2"
 xattr = "1.3"
 posix-acl = "1.2"
+encoding_rs = "0.8"
 
 [[bench]]
 name = "large_files"

--- a/crates/engine/tests/flist.rs
+++ b/crates/engine/tests/flist.rs
@@ -1,27 +1,42 @@
 // crates/engine/tests/flist.rs
+use encoding_rs::Encoding;
 use engine::flist;
 use filelist::Entry;
+use protocol::CharsetConv;
 
 #[test]
 fn roundtrip() {
     let entries = vec![
         Entry {
-            path: "a".into(),
+            path: b"a".to_vec(),
             uid: 1,
             gid: 2,
         },
         Entry {
-            path: "a/b".into(),
+            path: b"a/b".to_vec(),
             uid: 1,
             gid: 3,
         },
         Entry {
-            path: "c".into(),
+            path: b"c".to_vec(),
             uid: 4,
             gid: 3,
         },
     ];
-    let payloads = flist::encode(&entries);
-    let decoded = flist::decode(&payloads).unwrap();
+    let payloads = flist::encode(&entries, None);
+    let decoded = flist::decode(&payloads, None).unwrap();
+    assert_eq!(decoded, entries);
+}
+
+#[test]
+fn iconv_roundtrip() {
+    let cv = CharsetConv::new(Encoding::for_label(b"latin1").unwrap());
+    let entries = vec![Entry {
+        path: "Grüße".as_bytes().to_vec(),
+        uid: 0,
+        gid: 0,
+    }];
+    let payloads = flist::encode(&entries, Some(&cv));
+    let decoded = flist::decode(&payloads, Some(&cv)).unwrap();
     assert_eq!(decoded, entries);
 }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -9,6 +9,7 @@ indexmap = "2"
 compress = { path = "../compress" }
 checksums = { path = "../checksums" }
 filelist = { path = "../filelist" }
+encoding_rs = "0.8"
 
 [features]
 default = []

--- a/crates/protocol/src/demux.rs
+++ b/crates/protocol/src/demux.rs
@@ -51,7 +51,7 @@ impl Demux {
 
     pub fn ingest(&mut self, frame: Frame) -> std::io::Result<()> {
         let id = frame.header.channel;
-        let msg = Message::from_frame(frame.clone())?;
+        let msg = Message::from_frame(frame.clone(), None)?;
 
         if let Message::Error(text) = &msg {
             if let Some(ch) = self.channels.get_mut(&id) {

--- a/crates/protocol/src/mux.rs
+++ b/crates/protocol/src/mux.rs
@@ -79,20 +79,20 @@ impl Mux {
                 Ok(msg) => {
                     ch.last_sent = now;
                     self.next = (idx + 1) % len;
-                    return Some(msg.into_frame(id));
+                    return Some(msg.into_frame(id, None));
                 }
                 Err(TryRecvError::Empty) => {
                     if now.duration_since(ch.last_sent) >= self.keepalive {
                         ch.last_sent = now;
                         self.next = (idx + 1) % len;
-                        return Some(Message::KeepAlive.into_frame(id));
+                        return Some(Message::KeepAlive.into_frame(id, None));
                     }
                 }
                 Err(TryRecvError::Disconnected) => {
                     if now.duration_since(ch.last_sent) >= self.keepalive {
                         ch.last_sent = now;
                         self.next = (idx + 1) % len;
-                        return Some(Message::KeepAlive.into_frame(id));
+                        return Some(Message::KeepAlive.into_frame(id, None));
                     }
                 }
             }

--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -84,11 +84,11 @@ impl<R: Read, W: Write> Server<R, W> {
         if self.caps & CAP_CODECS != 0 {
             match Frame::decode(&mut self.reader) {
                 Ok(frame) => {
-                    let msg = Message::from_frame(frame.clone())?;
+                    let msg = Message::from_frame(frame.clone(), None)?;
                     if let Message::Codecs(buf) = msg {
                         peer_codecs = decode_codecs(&buf)?;
                         let payload = encode_codecs(codecs);
-                        let frame = Message::Codecs(payload).to_frame(0);
+                        let frame = Message::Codecs(payload).to_frame(0, None);
                         frame.encode(&mut self.writer)?;
                         self.writer.flush()?;
                     } else {

--- a/crates/protocol/tests/exit_codes.rs
+++ b/crates/protocol/tests/exit_codes.rs
@@ -114,7 +114,7 @@ fn mux_send_exit_code_channel0() {
 #[test]
 fn demux_nonzero_exit_errors() {
     let mut demux = Demux::new(Duration::from_millis(50));
-    let frame = Message::Data(vec![1]).to_frame(0);
+    let frame = Message::Data(vec![1]).to_frame(0, None);
     let err = demux.ingest(frame).unwrap_err();
     assert!(matches!(
         demux.take_exit_code(),
@@ -127,7 +127,7 @@ fn demux_nonzero_exit_errors() {
 fn demux_remote_error_propagates() {
     let mut demux = Demux::new(Duration::from_millis(50));
     let rx = demux.register_channel(5);
-    let frame = Message::Error("oops".into()).to_frame(5);
+    let frame = Message::Error("oops".into()).to_frame(5, None);
     let err = demux.ingest(frame).unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::Other);
     assert_eq!(demux.take_remote_error().as_deref(), Some("oops"));

--- a/crates/protocol/tests/golden_frames.rs
+++ b/crates/protocol/tests/golden_frames.rs
@@ -6,7 +6,7 @@ fn decode_version_golden() {
     const VERSION: [u8; 12] = [0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 32];
     let frame = Frame::decode(&VERSION[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Version);
-    let msg = Message::from_frame(frame).unwrap();
+    let msg = Message::from_frame(frame, None).unwrap();
     assert_eq!(msg, Message::Version(32));
 }
 
@@ -15,7 +15,7 @@ fn decode_keepalive_golden() {
     const KEEPALIVE: [u8; 8] = [0, 0, 1, 3, 0, 0, 0, 0];
     let frame = Frame::decode(&KEEPALIVE[..]).unwrap();
     assert_eq!(frame.header.tag, Tag::KeepAlive);
-    let msg = Message::from_frame(frame).unwrap();
+    let msg = Message::from_frame(frame, None).unwrap();
     assert_eq!(msg, Message::KeepAlive);
 }
 
@@ -24,7 +24,7 @@ fn decode_progress_golden() {
     const PROG: [u8; 16] = [0, 0, 0, 7, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0x30, 0x39];
     let frame = Frame::decode(&PROG[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Progress);
-    let msg = Message::from_frame(frame).unwrap();
+    let msg = Message::from_frame(frame, None).unwrap();
     assert_eq!(msg, Message::Progress(0x3039));
 }
 
@@ -33,6 +33,6 @@ fn decode_error_golden() {
     const ERR: [u8; 12] = [0, 0, 0, 6, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
     let frame = Frame::decode(&ERR[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Error);
-    let msg = Message::from_frame(frame).unwrap();
+    let msg = Message::from_frame(frame, None).unwrap();
     assert_eq!(msg, Message::Error("oops".to_string()));
 }

--- a/crates/protocol/tests/mux_demux.rs
+++ b/crates/protocol/tests/mux_demux.rs
@@ -78,13 +78,13 @@ fn unregister_channel_rejects_frames() {
     let mut demux = Demux::new(Duration::from_millis(100));
 
     let rx = demux.register_channel(1);
-    let frame = Message::Data(b"msg".to_vec()).into_frame(1);
+    let frame = Message::Data(b"msg".to_vec()).into_frame(1, None);
     demux.ingest(frame).unwrap();
     assert_eq!(rx.try_recv().unwrap(), Message::Data(b"msg".to_vec()));
 
     demux.unregister_channel(1);
     assert!(rx.try_recv().is_err());
 
-    let frame = Message::Data(b"other".to_vec()).into_frame(1);
+    let frame = Message::Data(b"other".to_vec()).into_frame(1, None);
     assert!(demux.ingest(frame).is_err());
 }

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 fn server_negotiates_version() {
     let local = available_codecs();
     let payload = encode_codecs(&local);
-    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
+    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0, None);
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
     let latest = SUPPORTED_PROTOCOLS[0];
@@ -42,7 +42,7 @@ fn server_negotiates_version() {
 fn server_accepts_legacy_version() {
     let legacy = V32;
     let payload = encode_codecs(&available_codecs());
-    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
+    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0, None);
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
     let mut input = Cursor::new({
@@ -76,7 +76,7 @@ fn server_accepts_legacy_version() {
 fn server_classic_versions() {
     let local = available_codecs();
     let payload = encode_codecs(&local);
-    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
+    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0, None);
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
 
@@ -109,7 +109,7 @@ fn server_classic_versions() {
 fn server_negotiates_zstd() {
     let local = vec![Codec::Zstd, Codec::Zlib];
     let payload = encode_codecs(&local);
-    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
+    let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0, None);
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
     let latest = SUPPORTED_PROTOCOLS[0];
@@ -132,7 +132,7 @@ fn server_negotiates_zstd() {
 fn server_propagates_handshake_error() {
     let mut buf = Vec::new();
     protocol::Message::Error("fail".into())
-        .to_frame(0)
+        .to_frame(0, None)
         .encode(&mut buf)
         .unwrap();
     let latest = SUPPORTED_PROTOCOLS[0];
@@ -154,7 +154,7 @@ fn server_propagates_handshake_error() {
 fn server_propagates_handshake_exit_code() {
     let mut buf = Vec::new();
     protocol::Message::Data(vec![1])
-        .to_frame(0)
+        .to_frame(0, None)
         .encode(&mut buf)
         .unwrap();
     let latest = SUPPORTED_PROTOCOLS[0];
@@ -179,7 +179,7 @@ fn server_propagates_handshake_exit_code() {
 fn server_parses_args_and_env() {
     let local = available_codecs();
     let payload = encode_codecs(&local);
-    let frame = protocol::Message::Codecs(payload.clone()).to_frame(0);
+    let frame = protocol::Message::Codecs(payload.clone()).to_frame(0, None);
     let mut frame_buf = Vec::new();
     frame.encode(&mut frame_buf).unwrap();
     let latest = SUPPORTED_PROTOCOLS[0];

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -225,7 +225,7 @@ impl SshStdioTransport {
         let mut peer_codecs = vec![Codec::Zlib];
         if caps & CAP_CODECS != 0 {
             let payload = compress::encode_codecs(&available_codecs());
-            let frame = Message::Codecs(payload).to_frame(0);
+            let frame = Message::Codecs(payload).to_frame(0, None);
             let mut buf = Vec::new();
             frame
                 .encode(&mut buf)
@@ -263,7 +263,8 @@ impl SshStdioTransport {
                 },
                 payload,
             };
-            let msg = Message::from_frame(frame).map_err(|e| io::Error::other(e.to_string()))?;
+            let msg =
+                Message::from_frame(frame, None).map_err(|e| io::Error::other(e.to_string()))?;
             if let Message::Codecs(data) = msg {
                 peer_codecs =
                     compress::decode_codecs(&data).map_err(|e| io::Error::other(e.to_string()))?;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -62,7 +62,7 @@ fn server_handshake_succeeds() {
 
     let codecs = available_codecs();
     let payload = encode_codecs(&codecs);
-    let frame = Message::Codecs(payload).to_frame(0);
+    let frame = Message::Codecs(payload).to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
     stdin.write_all(&buf).unwrap();
@@ -86,7 +86,7 @@ fn server_handshake_succeeds() {
         },
         payload: payload.clone(),
     };
-    let msg = Message::from_frame(frame).unwrap();
+    let msg = Message::from_frame(frame, None).unwrap();
     let server_codecs = match msg {
         Message::Codecs(data) => decode_codecs(&data).unwrap(),
         _ => panic!("expected codecs message"),
@@ -128,7 +128,7 @@ fn server_handshake_parses_args() {
 
     let codecs = available_codecs();
     let payload = encode_codecs(&codecs);
-    let frame = Message::Codecs(payload).to_frame(0);
+    let frame = Message::Codecs(payload).to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
     stdin.write_all(&buf).unwrap();
@@ -198,12 +198,12 @@ fn server_exit_code_roundtrip() {
 
     let codecs = available_codecs();
     let payload = encode_codecs(&codecs);
-    let frame = Message::Codecs(payload).to_frame(0);
+    let frame = Message::Codecs(payload).to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
     stdin.write_all(&buf).unwrap();
 
-    let exit_frame = Message::Data(vec![ExitCode::Partial.into()]).to_frame(0);
+    let exit_frame = Message::Data(vec![ExitCode::Partial.into()]).to_frame(0, None);
     let mut exit_buf = Vec::new();
     exit_frame.encode(&mut exit_buf).unwrap();
     stdin.write_all(&exit_buf).unwrap();


### PR DESCRIPTION
## Summary
- support charset conversion via `--iconv` throughout message framing and file lists
- encode/decode file list entries as raw bytes to handle non-UTF8 names
- add tests covering cross-encoding round trips

## Testing
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: daemon_accepts_authorized_client; others running over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68b6284cddcc8323b156e3a239297509