### PR TITLE
Track hard link groups in file list

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1100,7 +1100,7 @@ pub struct Receiver {
     matcher: Matcher,
     delayed: Vec<(PathBuf, PathBuf, PathBuf)>,
     #[cfg(unix)]
-    link_map: HashMap<(u64, u64), Vec<PathBuf>>,
+    link_map: HashMap<u64, Vec<PathBuf>>,
 }
 
 impl Default for Receiver {
@@ -1123,8 +1123,8 @@ impl Receiver {
     }
 
     #[cfg(unix)]
-    fn register_hard_link(&mut self, dev: u64, inode: u64, dest: &Path) -> Result<bool> {
-        let entry = self.link_map.entry((dev, inode)).or_default();
+    fn register_hard_link(&mut self, group: u64, dest: &Path) -> Result<bool> {
+        let entry = self.link_map.entry(group).or_default();
         if entry.is_empty() {
             entry.push(dest.to_path_buf());
             Ok(true)
@@ -2074,6 +2074,10 @@ pub fn sync(
         1024,
         opts.links || opts.copy_links || opts.copy_dirlinks || opts.copy_unsafe_links,
     );
+    #[cfg(unix)]
+    let mut link_groups: HashMap<(u64, u64), u64> = HashMap::new();
+    #[cfg(unix)]
+    let mut next_group: u64 = 0;
     while let Some(batch) = walker.next() {
         let batch = batch.map_err(|e| EngineError::Other(e.to_string()))?;
         for entry in batch {
@@ -2118,17 +2122,20 @@ pub fn sync(
                         }
                     }
                     #[cfg(unix)]
-                    if opts.hard_links
-                        && !receiver.register_hard_link(
-                            walker.devs()[entry.dev],
-                            walker.inodes()[entry.inode],
-                            &dest_path,
-                        )?
-                    {
-                        if let Some(parent) = dest_path.parent() {
-                            fs::create_dir_all(parent).map_err(|e| io_context(parent, e))?;
+                    if opts.hard_links && src_meta.nlink() > 1 {
+                        let dev = walker.devs()[entry.dev];
+                        let ino = walker.inodes()[entry.inode];
+                        let group = *link_groups.entry((dev, ino)).or_insert_with(|| {
+                            let id = next_group;
+                            next_group += 1;
+                            id
+                        });
+                        if !receiver.register_hard_link(group, &dest_path)? {
+                            if let Some(parent) = dest_path.parent() {
+                                fs::create_dir_all(parent).map_err(|e| io_context(parent, e))?;
+                            }
+                            continue;
                         }
-                        continue;
                     }
                     let partial_exists = if opts.partial {
                         let partial_path = if let Some(ref dir) = opts.partial_dir {

--- a/crates/engine/tests/flist.rs
+++ b/crates/engine/tests/flist.rs
@@ -9,16 +9,19 @@ fn roundtrip() {
             path: "a".into(),
             uid: 1,
             gid: 2,
+            group: None,
         },
         Entry {
             path: "a/b".into(),
             uid: 1,
             gid: 3,
+            group: None,
         },
         Entry {
             path: "c".into(),
             uid: 4,
             gid: 3,
+            group: None,
         },
     ];
     let payloads = flist::encode(&entries);


### PR DESCRIPTION
## Summary
- detect hard link groups during walk and key receiver registration by group id
- encode optional hard link group IDs in file list entries
- add regression test ensuring separate hard link groups remain distinct

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: sparse_files_preserved test exceeds 60s and was interrupted)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b62b81b2ac83238b64aca4fac3f687