### PR TITLE
Implement ACL handling and add tests

### DIFF
--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -610,12 +610,8 @@ fn read_acl_from_path(
     let acl = match posix_acl::PosixACL::read_acl(path) {
         Ok(acl) => acl.entries(),
         Err(err) => {
-            if let Some(code) = err.as_io_error().and_then(|e| e.raw_os_error()) {
-                if matches!(code, libc::ENODATA | libc::ENOTSUP | libc::ENOSYS) {
-                    Vec::new()
-                } else {
-                    return Err(acl_to_io(err));
-                }
+            if should_ignore_acl_error(&err) {
+                Vec::new()
             } else {
                 return Err(acl_to_io(err));
             }
@@ -625,12 +621,8 @@ fn read_acl_from_path(
         match posix_acl::PosixACL::read_default_acl(path) {
             Ok(dacl) => dacl.entries(),
             Err(err) => {
-                if let Some(code) = err.as_io_error().and_then(|e| e.raw_os_error()) {
-                    if matches!(code, libc::ENODATA | libc::ENOTSUP | libc::ENOSYS) {
-                        Vec::new()
-                    } else {
-                        return Err(acl_to_io(err));
-                    }
+                if should_ignore_acl_error(&err) {
+                    Vec::new()
                 } else {
                     return Err(acl_to_io(err));
                 }


### PR DESCRIPTION
## Summary
- improve ACL read logic to gracefully ignore permission errors
- compare daemon ACL behavior against upstream rsync daemon

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_accepts_authorized_client, daemon_accepts_listed_auth_user)*
- `cargo test --all-features` *(fails: super_overrides_fake_super)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b62b7809708323a68b493be95228da