### PR TITLE
Handle cross-device temp files

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -656,12 +656,22 @@ fn temp_dir_cross_filesystem_temp_file_in_dest() {
         .spawn()
         .unwrap();
 
-    let tmp_in_dst = dst_dir.join("a.tmp");
-    let tmp_in_tmp = tmp_dir.path().join("a.tmp");
     let mut found = false;
     for _ in 0..50 {
-        if tmp_in_dst.exists() {
-            assert!(!tmp_in_tmp.exists());
+        let tmp_present = fs::read_dir(&dst_dir)
+            .unwrap()
+            .filter_map(|e| {
+                let name = e.ok()?.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with(".a.txt.") {
+                    Some(e.path())
+                } else {
+                    None
+                }
+            })
+            .next();
+        if tmp_present.is_some() {
+            assert!(fs::read_dir(tmp_dir.path()).unwrap().next().is_none());
             found = true;
             break;
         }


### PR DESCRIPTION
## Summary
- ensure temp files fall back to destination filesystem when --temp-dir lives elsewhere using unique prefix
- test cross-filesystem temp behavior by detecting random temp names in destination

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: use of unstable library feature `io_error_more`)*
- `cargo test` *(fails: use of unstable library feature `io_error_more`)*
- `make verify-comments` *(fails: use of unstable library feature `io_error_more`)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b62d0dd9008323a4be85170a903c60