### PR TITLE
Preserve uid/gid and modes in metadata application

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1409,43 +1409,29 @@ impl Receiver {
             let chown_uid = self.opts.chown.and_then(|(u, _)| u);
             let chown_gid = self.opts.chown.and_then(|(_, g)| g);
 
-            let uid_map: Option<Arc<dyn Fn(u32) -> u32 + Send + Sync>> =
+            let uid_map: Option<Arc<dyn Fn(u32) -> u32 + Send + Sync>> = if self.opts.owner {
                 if let Some(ref map) = self.opts.uid_map {
                     Some(map.0.clone())
                 } else if let Some(uid) = chown_uid {
                     Some(Arc::new(move |_| uid))
-                } else if self.opts.numeric_ids {
-                    None
                 } else {
-                    Some(Arc::new(|uid: u32| {
-                        use nix::unistd::{Uid, User};
-                        if let Ok(Some(u)) = User::from_uid(Uid::from_raw(uid)) {
-                            if let Ok(Some(local)) = User::from_name(&u.name) {
-                                return local.uid.as_raw();
-                            }
-                        }
-                        uid
-                    }))
-                };
+                    None
+                }
+            } else {
+                None
+            };
 
-            let gid_map: Option<Arc<dyn Fn(u32) -> u32 + Send + Sync>> =
+            let gid_map: Option<Arc<dyn Fn(u32) -> u32 + Send + Sync>> = if self.opts.group {
                 if let Some(ref map) = self.opts.gid_map {
                     Some(map.0.clone())
                 } else if let Some(gid) = chown_gid {
                     Some(Arc::new(move |_| gid))
-                } else if self.opts.numeric_ids {
-                    None
                 } else {
-                    Some(Arc::new(|gid: u32| {
-                        use nix::unistd::{Gid, Group};
-                        if let Ok(Some(g)) = Group::from_gid(Gid::from_raw(gid)) {
-                            if let Ok(Some(local)) = Group::from_name(&g.name) {
-                                return local.gid.as_raw();
-                            }
-                        }
-                        gid
-                    }))
-                };
+                    None
+                }
+            } else {
+                None
+            };
 
             #[cfg(feature = "xattr")]
             let m1 = self.matcher.clone();

--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -279,11 +279,27 @@ impl Metadata {
         if opts.owner || opts.group {
             let uid = if let Some(ref map) = opts.uid_map {
                 map(self.uid)
+            } else if !opts.numeric_ids {
+                if let Some(u) = get_user_by_uid(self.uid) {
+                    get_user_by_name(u.name())
+                        .map(|u| u.uid())
+                        .unwrap_or(self.uid)
+                } else {
+                    self.uid
+                }
             } else {
                 self.uid
             };
             let gid = if let Some(ref map) = opts.gid_map {
                 map(self.gid)
+            } else if !opts.numeric_ids {
+                if let Some(g) = get_group_by_gid(self.gid) {
+                    get_group_by_name(g.name())
+                        .map(|g| g.gid())
+                        .unwrap_or(self.gid)
+                } else {
+                    self.gid
+                }
             } else {
                 self.gid
             };

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -859,6 +859,50 @@ fn numeric_ids_are_preserved() {
 
 #[cfg(unix)]
 #[test]
+fn owner_group_and_mode_preserved() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    let file = src_dir.join("a.txt");
+    std::fs::write(&file, b"ids").unwrap();
+    std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o741)).unwrap();
+
+    let dst_file = dst_dir.join("a.txt");
+    std::fs::copy(&file, &dst_file).unwrap();
+    let uid = get_current_uid();
+    let gid = get_current_gid();
+    let new_uid = if uid == 0 { 1 } else { 0 };
+    let new_gid = if gid == 0 { 1 } else { 0 };
+    let _ = chown(
+        &dst_file,
+        Some(Uid::from_raw(new_uid)),
+        Some(Gid::from_raw(new_gid)),
+    );
+    std::fs::set_permissions(&dst_file, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args([
+        "--local",
+        "--owner",
+        "--group",
+        "--perms",
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
+    cmd.assert().success();
+
+    let meta = std::fs::metadata(dst_dir.join("a.txt")).unwrap();
+    assert_eq!(meta.uid(), uid);
+    assert_eq!(meta.gid(), gid);
+    assert_eq!(meta.permissions().mode() & 0o7777, 0o741);
+}
+
+#[cfg(unix)]
+#[test]
 fn numeric_ids_require_privileges() {
     let dir = tempdir().unwrap();
     let probe = dir.path().join("probe");


### PR DESCRIPTION
## Summary
- map uid/gid via local names when numeric IDs aren't requested
- avoid unnecessary ID mapping and support numeric-ids with chmod in engine
- test owner, group, and mode preservation

## Testing
- `cargo +nightly clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `cargo +nightly test --test cli owner_group_and_mode_preserved`
- `cargo +nightly test` *(fails: daemon tests stuck over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68b62b848ccc8323a303b72172d88eb8