### PR TITLE
feat(cli): integrate daemon opts

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -661,10 +661,11 @@ fn temp_dir_cross_filesystem_temp_file_in_dest() {
         let tmp_present = fs::read_dir(&dst_dir)
             .unwrap()
             .filter_map(|e| {
-                let name = e.ok()?.file_name();
+                let entry = e.ok()?;
+                let name = entry.file_name();
                 let name = name.to_string_lossy();
                 if name.starts_with(".a.txt.") {
-                    Some(e.path())
+                    Some(entry.path())
                 } else {
                     None
                 }
@@ -684,7 +685,7 @@ fn temp_dir_cross_filesystem_temp_file_in_dest() {
         "temp file not created in destination during transfer"
     );
     assert!(
-        !tmp_in_tmp.exists(),
+        fs::read_dir(tmp_dir.path()).unwrap().next().is_none(),
         "temp dir used despite differing filesystems"
     );
 

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -92,7 +92,7 @@ fn try_set_xattr(path: &std::path::Path, name: &str, value: &[u8]) -> bool {
     }
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(all(unix, feature = "xattr", not(feature = "acl")))]
 fn spawn_rsync_daemon(root: &std::path::Path) -> (Child, u16) {
     let port = TcpListener::bind("127.0.0.1:0")
         .unwrap()


### PR DESCRIPTION
## Summary
- parse daemon flags directly via `ClientOpts`
- clean up unused `#[allow(dead_code)]`
- fix tests for daemon feature conflicts

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6354535c88323a030313de09351e1