### PR TITLE
Remove unused progress dest field

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -593,21 +593,19 @@ fn write_sparse(file: &mut File, data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-struct Progress<'a> {
+struct Progress {
     total: u64,
     written: u64,
     start: std::time::Instant,
     last_print: std::time::Instant,
     human_readable: bool,
-    #[allow(dead_code)]
-    dest: &'a Path,
     quiet: bool,
 }
 
 const PROGRESS_UPDATE_INTERVAL: Duration = Duration::from_secs(1);
 
-impl<'a> Progress<'a> {
-    fn new(dest: &'a Path, total: u64, human_readable: bool, initial: u64, quiet: bool) -> Self {
+impl Progress {
+    fn new(dest: &Path, total: u64, human_readable: bool, initial: u64, quiet: bool) -> Self {
         if !quiet {
             eprintln!("{}", dest.display());
         }
@@ -618,7 +616,6 @@ impl<'a> Progress<'a> {
             start: now,
             last_print: now - PROGRESS_UPDATE_INTERVAL,
             human_readable,
-            dest,
             quiet,
         }
     }


### PR DESCRIPTION
## Summary
- simplify Progress struct by dropping unused destination path field
- adjust progress initialization to only print destination path

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: `spawn_rsync_daemon` redefined; `tmp_in_tmp` not found; missing `path` method)*
- `cargo test` *(fails: `tmp_in_tmp` not found; missing `path` method)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6354e1c4c8323ab5c93de4199a89c