### PR TITLE
Allow forced removal of non-empty directories

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -664,7 +664,7 @@ struct ProbeOpts {
 }
 
 pub fn run(matches: &clap::ArgMatches) -> Result<()> {
-    let mut opts =
+    let opts =
         ClientOpts::from_arg_matches(matches).map_err(|e| EngineError::Other(e.to_string()))?;
     if opts.daemon.daemon {
         return run_daemon(opts.daemon, matches);

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -267,15 +267,11 @@ fn remove_file_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
 }
 
 fn remove_dir_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
-    use std::io::ErrorKind;
-
-    let res = fs::remove_dir(path).or_else(|e| {
-        if e.kind() == ErrorKind::DirectoryNotEmpty && opts.force {
-            fs::remove_dir_all(path)
-        } else {
-            Err(e)
-        }
-    });
+    let res = if opts.force {
+        fs::remove_dir_all(path)
+    } else {
+        fs::remove_dir(path)
+    };
     match res {
         Ok(_) => Ok(()),
         Err(e) => {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1583,6 +1583,33 @@ fn force_removes_nested_non_empty_dirs() {
     assert!(!dst.join("sub").exists());
 }
 
+#[test]
+fn force_removes_multiple_non_empty_dirs() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::create_dir_all(dst.join("sub1/nested1")).unwrap();
+    std::fs::create_dir_all(dst.join("sub2/nested2")).unwrap();
+    std::fs::write(dst.join("sub1/nested1/file1.txt"), b"hi").unwrap();
+    std::fs::write(dst.join("sub2/nested2/file2.txt"), b"hi").unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--delete",
+            "--force",
+            &format!("{}/", src.display()),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(!dst.join("sub1").exists());
+    assert!(!dst.join("sub2").exists());
+}
+
 #[cfg(unix)]
 #[test]
 #[serial]


### PR DESCRIPTION
## Summary
- remove directory trees when `--force` is supplied
- add CLI tests validating forced removal of non-empty directories
- address clippy warning for unused mut in CLI

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b62d0b4e088323a5f9c475efe457e4