### PR TITLE
Reuse protocol CharsetConv in CLI

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -177,7 +177,7 @@ fn iconv_option_sent_to_daemon() {
         &sync_opts,
         SUPPORTED_PROTOCOLS[0],
         None,
-        Some(&cv),
+        Some(cv.as_ref()),
     )
     .unwrap();
     handle.join().unwrap();


### PR DESCRIPTION
## Summary
- refactor CLI to wrap protocol::CharsetConv and drop duplicate local struct
- update parse_iconv and daemon session calls to work with unified charset conversion
- adjust tests to use new charset wrapper

## Testing
- `cargo check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b642b06a588323bdebaa550cb57b12