### PR TITLE
Add archive flag parity test and update docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,6 +892,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "shell-words",
  "tempfile",
  "tracing",
@@ -1304,6 +1305,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ wait-timeout = "0.2"
 users = "0.11"
 meta = { path = "crates/meta" }
 daemon = { path = "crates/daemon" }
+sha2 = "0.10"
 
 [[bin]]
 name = "flag_matrix"

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -21,7 +21,6 @@ use engine::{sync, DeleteMode, IdMapper, Result, Stats, StrongHash, SyncOptions}
 use filters::{default_cvs_rules, parse, Matcher, Rule};
 use logging::{human_bytes, DebugFlag, InfoFlag, LogFormat};
 use meta::{parse_chmod, parse_chown, parse_id_map, IdKind};
-use protocol::CharsetConv;
 use protocol::{negotiate_version, SUPPORTED_PROTOCOLS};
 use shell_words::split as shell_split;
 use transport::{

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -18,7 +18,7 @@ Classic `rsync` protocol versions 31–32 are supported.
 | `--address` | ✅ | Y | [tests/daemon.rs](../tests/daemon.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--append` | ✅ | Y | [tests/resume.rs](../tests/resume.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--append-verify` | ✅ | Y | [tests/resume.rs](../tests/resume.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--archive` | ✅ | N | [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `--archive` | ✅ | Y | [tests/archive.rs](../tests/archive.rs)<br>[tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--atimes` | ✅ | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--backup` | ✅ | Y | [crates/engine/tests/backup.rs](../crates/engine/tests/backup.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | uses `~` suffix without `--backup-dir` |
 | `--backup-dir` | ✅ | Y | [crates/engine/tests/backup.rs](../crates/engine/tests/backup.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | implies `--backup` |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -8,6 +8,7 @@ coverage so progress can be tracked as features land.
 - `--server` — handshake lacks full parity. [protocol/src/server.rs](../crates/protocol/src/server.rs) · [crates/protocol/tests/server.rs](../crates/protocol/tests/server.rs)
 
 ## Metadata
+- `--archive` — composite flag; underlying `--owner`, `--group`, and `--perms` gaps apply. [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) · [tests/archive.rs](../tests/archive.rs)
 - `--acls` — ACL support requires optional feature and lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs)
 - `--groupmap` — numeric gid mapping only; group names unsupported. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--links` — symlink handling lacks parity. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -1,0 +1,110 @@
+// tests/archive.rs
+#[cfg(unix)]
+use assert_cmd::Command;
+#[cfg(unix)]
+use filetime::{set_file_mtime, FileTime};
+#[cfg(unix)]
+use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+#[cfg(unix)]
+use nix::unistd::{chown, mkfifo, Gid, Uid};
+#[cfg(unix)]
+use sha2::{Digest, Sha256};
+#[cfg(unix)]
+use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::{symlink, PermissionsExt};
+#[cfg(unix)]
+use std::path::Path;
+#[cfg(unix)]
+use std::process::Command as StdCommand;
+#[cfg(unix)]
+use tempfile::tempdir;
+
+#[cfg(unix)]
+fn hash_dir(dir: &Path) -> Vec<u8> {
+    let output = StdCommand::new("tar")
+        .args(["--numeric-owner", "-cf", "-", "."])
+        .current_dir(dir)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let mut hasher = Sha256::new();
+    hasher.update(&output.stdout);
+    hasher.finalize().to_vec()
+}
+
+#[cfg(unix)]
+#[test]
+fn archive_matches_combination_and_rsync() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::create_dir(src.join("dir")).unwrap();
+    fs::write(src.join("dir/file"), b"hi").unwrap();
+    set_file_mtime(src.join("dir/file"), FileTime::from_unix_time(1_234_567, 0)).unwrap();
+    fs::set_permissions(src.join("dir/file"), fs::Permissions::from_mode(0o640)).unwrap();
+    chown(
+        src.join("dir/file").as_path(),
+        Some(Uid::from_raw(42)),
+        Some(Gid::from_raw(43)),
+    )
+    .unwrap();
+    symlink("dir/file", src.join("link")).unwrap();
+    mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
+    mknod(
+        &src.join("dev"),
+        SFlag::S_IFCHR,
+        Mode::from_bits_truncate(0o644),
+        makedev(1, 7),
+    )
+    .unwrap();
+
+    let dst_archive = tmp.path().join("dst_archive");
+    let dst_combo = tmp.path().join("dst_combo");
+    let dst_rsync = tmp.path().join("dst_rsync");
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "-a",
+            &format!("{}/", src.display()),
+            dst_archive.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--links",
+            "--perms",
+            "--times",
+            "--group",
+            "--owner",
+            "--devices",
+            "--specials",
+            &format!("{}/", src.display()),
+            dst_combo.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(StdCommand::new("rsync")
+        .args([
+            "-a",
+            &format!("{}/", src.display()),
+            dst_rsync.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap()
+        .success());
+
+    let h_archive = hash_dir(&dst_archive);
+    let h_combo = hash_dir(&dst_combo);
+    let h_rsync = hash_dir(&dst_rsync);
+    assert_eq!(h_archive, h_combo);
+    assert_eq!(h_archive, h_rsync);
+}


### PR DESCRIPTION
## Summary
- add integration test comparing `-a` with explicit options and upstream rsync
- document archive parity in feature matrix and note composite gaps
- drop unused `CharsetConv` import that blocked builds

## Testing
- `make verify-comments`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*

------
https://chatgpt.com/codex/tasks/task_e_68b642e0da4883238fac12b7b9327651