### PR TITLE
Use cross-platform makedev in tests

### DIFF
--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -10,8 +10,8 @@ use compress::available_codecs;
 use engine::{sync, IdMapper, SyncOptions};
 use filetime::{set_file_atime, set_file_mtime, set_symlink_file_times, FileTime};
 use filters::Matcher;
-use meta::{parse_chmod, parse_chown, parse_id_map, IdKind};
-use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+use meta::{makedev, parse_chmod, parse_chown, parse_id_map, IdKind};
+use nix::sys::stat::{mknod, Mode, SFlag};
 use nix::unistd::{chown, mkfifo, Gid, Uid};
 #[cfg(feature = "acl")]
 use posix_acl::{PosixACL, Qualifier, ACL_READ, ACL_WRITE};

--- a/crates/engine/tests/write_devices.rs
+++ b/crates/engine/tests/write_devices.rs
@@ -7,7 +7,8 @@ use std::os::unix::fs::FileTypeExt;
 use compress::available_codecs;
 use engine::{sync, SyncOptions};
 use filters::Matcher;
-use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+use meta::makedev;
+use nix::sys::stat::{mknod, Mode, SFlag};
 use tempfile::tempdir;
 
 #[test]

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -4,7 +4,9 @@ use assert_cmd::Command;
 #[cfg(unix)]
 use filetime::{set_file_mtime, FileTime};
 #[cfg(unix)]
-use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+use meta::makedev;
+#[cfg(unix)]
+use nix::sys::stat::{mknod, Mode, SFlag};
 #[cfg(unix)]
 use nix::unistd::{chown, mkfifo, Gid, Uid};
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- import makedev from the meta crate across tests
- prepare engine tests for cross-platform builds

## Testing
- `make verify-comments` *(fails: crates/protocol/src/server.rs: contains disallowed comments)*
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon tests and mount permission errors)*
- `cargo test --all-features` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68b64b9f24888323b0a36e6c8e79a5e2