### PR TITLE
Use protocol CharsetConv in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
  "clap_complete",
  "compress",
  "daemon",
+ "encoding_rs",
  "engine",
  "filetime",
  "filters",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ users = "0.11"
 meta = { path = "crates/meta" }
 daemon = { path = "crates/daemon" }
 sha2 = "0.10"
+encoding_rs = "0.8"
 
 [[bin]]
 name = "flag_matrix"


### PR DESCRIPTION
## Summary
- remove redundant CliCharsetConv wrapper in CLI
- rely on protocol::CharsetConv for encoding/decoding
- adjust iconv tests and dev-deps

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*

------
https://chatgpt.com/codex/tasks/task_e_68b64c3f1cf0832384d063609c371e8d