### PR TITLE
Use cross-platform makedev in tests

### DIFF
--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -11,7 +11,7 @@ use engine::{sync, IdMapper, SyncOptions};
 use filetime::{set_file_atime, set_file_mtime, set_symlink_file_times, FileTime};
 use filters::Matcher;
 use meta::{parse_chmod, parse_chown, parse_id_map, IdKind};
-use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+use nix::sys::stat::{mknod, Mode, SFlag};
 use nix::unistd::{chown, mkfifo, Gid, Uid};
 #[cfg(feature = "acl")]
 use posix_acl::{PosixACL, Qualifier, ACL_READ, ACL_WRITE};
@@ -505,7 +505,7 @@ fn devices_roundtrip() {
         &dev,
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o600),
-        makedev(1, 3),
+        meta::makedev(1, 3),
     )
     .unwrap();
     sync(
@@ -521,7 +521,7 @@ fn devices_roundtrip() {
     .unwrap();
     let meta = fs::symlink_metadata(dst.join("null")).unwrap();
     assert!(meta.file_type().is_char_device());
-    assert_eq!(meta.rdev(), makedev(1, 3));
+    assert_eq!(meta.rdev(), meta::makedev(1, 3));
 }
 
 #[test]
@@ -536,7 +536,7 @@ fn copy_devices_creates_regular_files() {
         &dev,
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o600),
-        makedev(1, 3),
+        meta::makedev(1, 3),
     )
     .unwrap();
     sync(
@@ -568,7 +568,7 @@ fn copy_devices_handles_zero() {
         &dev,
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o600),
-        makedev(1, 5),
+        meta::makedev(1, 5),
     )
     .unwrap();
     sync(

--- a/crates/engine/tests/write_devices.rs
+++ b/crates/engine/tests/write_devices.rs
@@ -7,7 +7,7 @@ use std::os::unix::fs::FileTypeExt;
 use compress::available_codecs;
 use engine::{sync, SyncOptions};
 use filters::Matcher;
-use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+use nix::sys::stat::{mknod, Mode, SFlag};
 use tempfile::tempdir;
 
 #[test]
@@ -23,7 +23,7 @@ fn requires_flag_to_write_devices() {
         &dev,
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o600),
-        makedev(1, 3),
+        meta::makedev(1, 3),
     )
     .unwrap();
 

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -4,7 +4,7 @@ use assert_cmd::Command;
 #[cfg(unix)]
 use filetime::{set_file_mtime, FileTime};
 #[cfg(unix)]
-use nix::sys::stat::{makedev, mknod, Mode, SFlag};
+use nix::sys::stat::{mknod, Mode, SFlag};
 #[cfg(unix)]
 use nix::unistd::{chown, mkfifo, Gid, Uid};
 #[cfg(unix)]
@@ -55,7 +55,7 @@ fn archive_matches_combination_and_rsync() {
         &src.join("dev"),
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o644),
-        makedev(1, 7),
+        meta::makedev(1, 7),
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
- replace `nix::sys::stat::makedev` with `meta::makedev` across tests
- prepare device tests for non-Linux targets by using the `meta` crate

## Testing
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: mount permission denied, daemon test)*
- `cargo test --all-features` *(fails: mount permission denied, cli test)*
- `cargo check --tests --target x86_64-apple-darwin` *(fails: macOS cross-compile, missing cc flags)*
- `cargo check --tests --target x86_64-pc-windows-gnu` *(fails: missing x86_64-w64-mingw32-gcc)*

------
https://chatgpt.com/codex/tasks/task_e_68b64cbb9a648323be789316e8370053