### PR TITLE
fix unused io import in daemon test

### DIFF
--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -6,7 +6,7 @@ use assert_cmd::{cargo::CommandCargoExt, Command};
 use serial_test::serial;
 #[cfg(unix)]
 use std::fs;
-#[cfg(unix)]
+#[cfg(all(unix, feature = "xattr"))]
 use std::io;
 #[cfg(unix)]
 use std::net::{TcpListener, TcpStream};


### PR DESCRIPTION
## Summary
- gate `std::io` import in `daemon_sync_attrs.rs` behind `xattr` feature

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b68d7849cc8323a0ee1257ae56973c