### PR TITLE
Expand protocol message codes and add tests

### DIFF
--- a/crates/protocol/tests/golden_frames.rs
+++ b/crates/protocol/tests/golden_frames.rs
@@ -3,7 +3,7 @@ use protocol::{Frame, Message, Msg, Tag};
 
 #[test]
 fn decode_version_golden() {
-    const VERSION: [u8; 12] = [0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 32];
+    const VERSION: [u8; 12] = [0, 0, 0, 240, 0, 0, 0, 4, 0, 0, 0, 32];
     let frame = Frame::decode(&VERSION[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Version);
     let msg = Message::from_frame(frame, None).unwrap();
@@ -12,7 +12,7 @@ fn decode_version_golden() {
 
 #[test]
 fn decode_keepalive_golden() {
-    const KEEPALIVE: [u8; 8] = [0, 0, 1, 3, 0, 0, 0, 0];
+    const KEEPALIVE: [u8; 8] = [0, 0, 1, 242, 0, 0, 0, 0];
     let frame = Frame::decode(&KEEPALIVE[..]).unwrap();
     assert_eq!(frame.header.tag, Tag::KeepAlive);
     let msg = Message::from_frame(frame, None).unwrap();
@@ -21,7 +21,7 @@ fn decode_keepalive_golden() {
 
 #[test]
 fn decode_progress_golden() {
-    const PROG: [u8; 16] = [0, 0, 0, 7, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0x30, 0x39];
+    const PROG: [u8; 16] = [0, 0, 0, 245, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0x30, 0x39];
     let frame = Frame::decode(&PROG[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Progress);
     let msg = Message::from_frame(frame, None).unwrap();
@@ -30,7 +30,7 @@ fn decode_progress_golden() {
 
 #[test]
 fn decode_error_golden() {
-    const ERR: [u8; 12] = [0, 0, 0, 6, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
+    const ERR: [u8; 12] = [0, 0, 0, 3, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
     let frame = Frame::decode(&ERR[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Error);
     let msg = Message::from_frame(frame, None).unwrap();

--- a/crates/protocol/tests/messages.rs
+++ b/crates/protocol/tests/messages.rs
@@ -1,0 +1,31 @@
+// crates/protocol/tests/messages.rs
+use protocol::{Message, Msg};
+
+#[test]
+fn roundtrip_additional_messages() {
+    let msgs = [
+        Msg::ErrorXfer,
+        Msg::Info,
+        Msg::Warning,
+        Msg::ErrorSocket,
+        Msg::ErrorUtf8,
+        Msg::Log,
+        Msg::Client,
+        Msg::Redo,
+        Msg::Stats,
+        Msg::IoError,
+        Msg::IoTimeout,
+        Msg::Noop,
+        Msg::ErrorExit,
+        Msg::Success,
+        Msg::Deleted,
+        Msg::NoSend,
+    ];
+    for m in msgs {
+        let payload = b"test".to_vec();
+        let msg = Message::Other(m, payload.clone());
+        let frame = msg.clone().to_frame(9, None);
+        let decoded = Message::from_frame(frame, None).unwrap();
+        assert_eq!(decoded, msg);
+    }
+}

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -86,7 +86,7 @@ fn captured_frames_roundtrip() {
     assert_eq!(msg.to_file_list(&mut fdec, None).unwrap(), entry);
 
     const ATTRS: [u8; 16] = [
-        0, 0, 0, 5, 0, 0, 0, 8, b'm', b'o', b'd', b'e', b'=', b'7', b'5', b'5',
+        0, 0, 0, 244, 0, 0, 0, 8, b'm', b'o', b'd', b'e', b'=', b'7', b'5', b'5',
     ];
     let frame = Frame::decode(&ATTRS[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Attributes);
@@ -99,7 +99,7 @@ fn captured_frames_roundtrip() {
         .unwrap();
     assert_eq!(buf, ATTRS);
 
-    const ERR: [u8; 12] = [0, 0, 0, 6, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
+    const ERR: [u8; 12] = [0, 0, 0, 3, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
     let frame = Frame::decode(&ERR[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Error);
     let msg = Message::from_frame(frame.clone(), None).unwrap();
@@ -111,7 +111,7 @@ fn captured_frames_roundtrip() {
         .unwrap();
     assert_eq!(buf, ERR);
 
-    const PROG: [u8; 16] = [0, 0, 0, 7, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0x30, 0x39];
+    const PROG: [u8; 16] = [0, 0, 0, 245, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0x30, 0x39];
     let frame = Frame::decode(&PROG[..]).unwrap();
     assert_eq!(frame.header.msg, Msg::Progress);
     let msg = Message::from_frame(frame.clone(), None).unwrap();


### PR DESCRIPTION
## Summary
- include full set of rsync message codes
- support round-tripping unknown message payloads
- test additional message types and update golden frames

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `cargo test -p protocol`
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b68e350fd0832386505d5624459469