### PR TITLE
Validate privileges for ownership options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "caps"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
+dependencies = [
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +928,7 @@ name = "oc-rsync-cli"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "caps",
  "clap",
  "compress",
  "daemon",
@@ -926,6 +937,7 @@ dependencies = [
  "filters",
  "logging",
  "meta",
+ "nix 0.27.1",
  "protocol",
  "shell-words",
  "tempfile",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,12 @@ logging = { path = "../logging" }
 tracing = "0.1"
 encoding_rs = "0.8"
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.27", features = ["user", "fs"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+caps = "0.5"
+
 [dev-dependencies]
 tempfile = "3"
 assert_cmd = "2"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,7 +10,7 @@ use logging::progress_formatter;
 use nix::unistd::{chown, mkfifo, Gid, Uid};
 use oc_rsync_cli::{parse_iconv, spawn_daemon_session};
 use predicates::prelude::PredicateBooleanExt;
-use protocol::SUPPORTED_PROTOCOLS;
+use protocol::{ExitCode, SUPPORTED_PROTOCOLS};
 use serial_test::serial;
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};
@@ -984,7 +984,9 @@ fn owner_requires_privileges() {
         .unwrap()
         .args(["--local", "--owner", &src_arg, dst_dir.to_str().unwrap()])
         .assert()
-        .failure();
+        .failure()
+        .code(u8::from(ExitCode::Protocol) as i32)
+        .stderr(predicates::str::contains("requires root or CAP_CHOWN"));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- check for CAP_CHOWN or root when --owner, --group, or --chown is used
- add integration test for insufficient privileges
- wire up nix/caps dependencies

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b690dbfc308323833419aea742244e