### PR TITLE
protocol: add additional message types

### DIFF
--- a/crates/protocol/src/demux.rs
+++ b/crates/protocol/src/demux.rs
@@ -63,8 +63,8 @@ impl Demux {
         }
 
         if id == 0 {
-            if let Message::Data(payload) = &msg {
-                if payload.len() == 1 {
+            match &msg {
+                Message::Data(payload) if payload.len() == 1 => {
                     let code = payload[0];
                     self.exit_code = Some(code);
                     if code != 0 {
@@ -73,6 +73,11 @@ impl Demux {
                         return Ok(());
                     }
                 }
+                Message::ErrorExit(code) => {
+                    self.exit_code = Some(*code);
+                    return Err(std::io::Error::other(format!("remote exit code {}", code)));
+                }
+                _ => {}
             }
         }
 

--- a/crates/protocol/src/mux.rs
+++ b/crates/protocol/src/mux.rs
@@ -52,7 +52,12 @@ impl Mux {
     }
 
     pub fn send_exit_code(&self, code: ExitCode) -> Result<(), mpsc::SendError<Message>> {
-        self.send(0, Message::Data(vec![code.into()]))
+        let byte: u8 = code.into();
+        if code == ExitCode::Ok {
+            self.send(0, Message::Data(vec![byte]))
+        } else {
+            self.send(0, Message::ErrorExit(byte))
+        }
     }
 
     pub fn send_error<S: Into<String>>(

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -125,6 +125,63 @@ fn captured_frames_roundtrip() {
 }
 
 #[test]
+fn extra_messages_roundtrip() {
+    let msg = Message::Redo(0x01020304);
+    let frame = msg.to_frame(0, None);
+    let mut buf = Vec::new();
+    frame.encode(&mut buf).unwrap();
+    let decoded = Frame::decode(&buf[..]).unwrap();
+    assert_eq!(decoded.header.msg, Msg::Redo);
+    let msg2 = Message::from_frame(decoded, None).unwrap();
+    assert_eq!(msg2, msg);
+
+    let msg = Message::Stats(vec![1, 2, 3]);
+    let frame = msg.to_frame(0, None);
+    let mut buf = Vec::new();
+    frame.encode(&mut buf).unwrap();
+    let decoded = Frame::decode(&buf[..]).unwrap();
+    assert_eq!(decoded.header.msg, Msg::Stats);
+    let msg2 = Message::from_frame(decoded, None).unwrap();
+    assert_eq!(msg2, msg);
+
+    let msg = Message::Success(7);
+    let frame = msg.to_frame(0, None);
+    let mut buf = Vec::new();
+    frame.encode(&mut buf).unwrap();
+    let decoded = Frame::decode(&buf[..]).unwrap();
+    assert_eq!(decoded.header.msg, Msg::Success);
+    let msg2 = Message::from_frame(decoded, None).unwrap();
+    assert_eq!(msg2, msg);
+
+    let msg = Message::Deleted(9);
+    let frame = msg.to_frame(0, None);
+    let mut buf = Vec::new();
+    frame.encode(&mut buf).unwrap();
+    let decoded = Frame::decode(&buf[..]).unwrap();
+    assert_eq!(decoded.header.msg, Msg::Deleted);
+    let msg2 = Message::from_frame(decoded, None).unwrap();
+    assert_eq!(msg2, msg);
+
+    let msg = Message::NoSend(11);
+    let frame = msg.to_frame(0, None);
+    let mut buf = Vec::new();
+    frame.encode(&mut buf).unwrap();
+    let decoded = Frame::decode(&buf[..]).unwrap();
+    assert_eq!(decoded.header.msg, Msg::NoSend);
+    let msg2 = Message::from_frame(decoded, None).unwrap();
+    assert_eq!(msg2, msg);
+
+    let msg = Message::ErrorExit(2);
+    let frame = msg.to_frame(0, None);
+    let mut buf = Vec::new();
+    frame.encode(&mut buf).unwrap();
+    let decoded = Frame::decode(&buf[..]).unwrap();
+    assert_eq!(decoded.header.msg, Msg::ErrorExit);
+    let msg2 = Message::from_frame(decoded, None).unwrap();
+    assert_eq!(msg2, msg);
+}
+
+#[test]
 fn error_message_iconv_roundtrip() {
     let cv = CharsetConv::new(Encoding::for_label(b"latin1").unwrap());
     let msg = Message::Error("Grüße".into());


### PR DESCRIPTION
## Summary
- extend protocol message enums to include upstream codes like redo, stats, success, deleted, nosend, and error_exit
- handle error_exit codes in mux and demux
- add round-trip tests for new messages

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b690df4b008323a2ba57b706c9163d