### PR TITLE
Remove unused io import

### DIFF
--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -6,8 +6,6 @@ use assert_cmd::{cargo::CommandCargoExt, Command};
 use serial_test::serial;
 #[cfg(unix)]
 use std::fs;
-#[cfg(all(unix, feature = "xattr"))]
-use std::io;
 #[cfg(unix)]
 use std::net::{TcpListener, TcpStream};
 #[cfg(unix)]
@@ -87,7 +85,7 @@ fn wait_for_daemon(port: u16) {
 fn try_set_xattr(path: &std::path::Path, name: &str, value: &[u8]) -> bool {
     match xattr::set(path, name, value) {
         Ok(()) => true,
-        Err(e) if e.kind() == io::ErrorKind::PermissionDenied => false,
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => false,
         Err(e) => panic!("setting {name}: {e}"),
     }
 }
@@ -160,7 +158,7 @@ fn daemon_preserves_xattrs() {
         match xattr::get(srv.join("file"), "security.test") {
             Ok(None) => {}
             Ok(Some(_)) => panic!("security.test should be absent"),
-            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {}
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {}
             Err(e) => panic!("get security.test: {e}"),
         }
     }
@@ -214,7 +212,7 @@ fn daemon_preserves_xattrs_rr_client() {
         match xattr::get(srv.join("file"), "security.test") {
             Ok(None) => {}
             Ok(Some(_)) => panic!("security.test should be absent"),
-            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {}
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {}
             Err(e) => panic!("get security.test: {e}"),
         }
     }
@@ -269,7 +267,7 @@ fn daemon_preserves_xattrs_rr_daemon() {
         match xattr::get(srv.join("file"), "security.test") {
             Ok(None) => {}
             Ok(Some(_)) => panic!("security.test should be absent"),
-            Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {}
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {}
             Err(e) => panic!("get security.test: {e}"),
         }
     }


### PR DESCRIPTION
## Summary
- drop unused `std::io` import in daemon_sync_attrs test
- use `std::io::ErrorKind` directly

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: permission denied; requires mount privileges)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b690e186b483238ae56d7843eece4b