### PR TITLE
docs: sync links parity

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -93,7 +93,7 @@ Classic `rsync` protocol versions 31–32 are supported.
 | `--itemize-changes` | ✅ | Y | [tests/golden/cli_parity/itemize-changes.sh](../tests/golden/cli_parity/itemize-changes.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--keep-dirlinks` | ✅ | Y | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--link-dest` | ✅ | Y | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--links` | ✅ | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | preserves relative/absolute targets; supports dangling links |
+| `--links` | ✅ | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/engine/src/lib.rs](../crates/engine/src/lib.rs) | preserves relative/absolute targets; supports dangling links |
 | `--list-only` | ✅ | Y | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--log-file` | ✅ | N | [tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | limited format support |
 | `--log-file-format` | ✅ | N | [tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | limited format support |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -19,7 +19,6 @@ No known gaps. Exit codes map to upstream values. [protocol/src/lib.rs](../crate
 ## Metadata
 - `--archive` — composite flag; underlying `--owner`, `--group`, and `--perms` gaps apply. [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) · [tests/archive.rs](../tests/archive.rs)
 - `--acls` — ACL support requires optional feature and lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs)
-- `--links` — symlink handling lacks parity. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--hard-links` — hard link tracking incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)
 - `--owner` — ownership restoration lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--perms` — permission preservation incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)


### PR DESCRIPTION
## Summary
- sync docs on `--links` parity with source/tests
- include engine source reference in feature matrix

## Testing
- `cargo fmt --all`
- `cargo test --package oc-rsync`
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b69287d070832398ed34a0f0b6cfe5