### PR TITLE
Add MD4 strong hash support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "criterion",
  "hex",
  "md-5",
+ "md4",
  "sha1",
 ]
 
@@ -792,6 +793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
+ "digest",
+]
+
+[[package]]
+name = "md4"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
+dependencies = [
  "digest",
 ]
 

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+md4 = "0.10"
 md-5 = "0.10"
 sha1 = "0.10"
 

--- a/crates/checksums/tests/golden.rs
+++ b/crates/checksums/tests/golden.rs
@@ -32,11 +32,19 @@ fn rolling_golden_windows() {
 
 #[test]
 fn builder_strong_digests() {
+    let cfg_md4 = ChecksumConfigBuilder::new().build();
     let cfg_md5 = ChecksumConfigBuilder::new().strong(StrongHash::Md5).build();
     let cfg_sha1 = ChecksumConfigBuilder::new()
         .strong(StrongHash::Sha1)
         .build();
     let data = b"hello world";
+
+    let cs_md4 = cfg_md4.checksum(data);
+    assert_eq!(cs_md4.weak, rolling_checksum(data));
+    assert_eq!(
+        hex::encode(cs_md4.strong),
+        "ea91f391e02b5e19f432b43bd87a531d"
+    );
 
     let cs_md5 = cfg_md5.checksum(data);
     assert_eq!(cs_md5.weak, rolling_checksum(data));

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1109,6 +1109,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
 
     let strong = if let Some(choice) = opts.checksum_choice.as_deref() {
         match choice {
+            "md4" => StrongHash::Md4,
             "md5" => StrongHash::Md5,
             "sha1" => StrongHash::Sha1,
             other => {
@@ -1116,7 +1117,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
             }
         }
     } else if let Ok(list) = env::var("RSYNC_CHECKSUM_LIST") {
-        let mut chosen = StrongHash::Md5;
+        let mut chosen = StrongHash::Md4;
         for name in list.split(',') {
             match name {
                 "sha1" => {
@@ -1127,12 +1128,16 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     chosen = StrongHash::Md5;
                     break;
                 }
+                "md4" => {
+                    chosen = StrongHash::Md4;
+                    break;
+                }
                 _ => {}
             }
         }
         chosen
     } else {
-        StrongHash::Md5
+        StrongHash::Md4
     };
 
     let src_trailing = match &src {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1719,7 +1719,7 @@ impl Default for SyncOptions {
             ignore_existing: false,
             size_only: false,
             ignore_times: false,
-            strong: StrongHash::Md5,
+            strong: StrongHash::Md4,
             checksum_seed: 0,
             compress_level: None,
             compress_choice: None,

--- a/crates/protocol/src/demux.rs
+++ b/crates/protocol/src/demux.rs
@@ -26,7 +26,7 @@ impl Demux {
         Demux {
             timeout,
             channels: IndexMap::new(),
-            strong_hash: StrongHash::Md5,
+            strong_hash: StrongHash::Md4,
             compressor: Codec::Zlib,
             exit_code: None,
             remote_error: None,

--- a/crates/protocol/src/mux.rs
+++ b/crates/protocol/src/mux.rs
@@ -27,7 +27,7 @@ impl Mux {
             keepalive,
             channels: IndexMap::new(),
             next: 0,
-            strong_hash: StrongHash::Md5,
+            strong_hash: StrongHash::Md4,
             compressor: Codec::Zlib,
         }
     }

--- a/tests/checksum_seed.rs
+++ b/tests/checksum_seed.rs
@@ -22,7 +22,7 @@ fn checksum_seed_changes_strong_checksum() {
     let strong1 = cfg1.checksum(data).strong;
     let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
     let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
-    assert_eq!(hex0, "be4b47980f89d075f8f7e7a9fab84e29");
-    assert_eq!(hex1, "157438ee5881306a9af554cc9b3e5974");
+    assert_eq!(hex0, "ea91f391e02b5e19f432b43bd87a531d");
+    assert_eq!(hex1, "92e5994e0babddace03f0ff88f767181");
     assert_ne!(hex0, hex1);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -18,7 +18,7 @@ use logging::progress_formatter;
 use nix::unistd::{chown, mkfifo, Gid, Uid};
 use oc_rsync_cli::{parse_iconv, spawn_daemon_session};
 use predicates::prelude::PredicateBooleanExt;
-use protocol::{ExitCode, SUPPORTED_PROTOCOLS};
+use protocol::SUPPORTED_PROTOCOLS;
 use serial_test::serial;
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};


### PR DESCRIPTION
## Summary
- add `Md4` strong hash option and make it default
- compute MD4 digests in strong checksum routine
- test MD4 digests and update defaults across CLI, engine, and protocol

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(hangs: `sparse_files_preserved` >60s, aborting)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6957534b88323b0e165aaa5f0be6a