### PR TITLE
docs: record protocol and ACL gaps

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,6 +1,9 @@
 # Differences from rsync
 
-oc-rsync currently has no known behavioral differences from upstream rsync 3.4.x.
+oc-rsync diverges from upstream rsync 3.4.x in the following areas:
+
+- Protocol feature negotiation covers only a subset of rsync capabilities; some message types are unimplemented. [crates/protocol/src/lib.rs](../crates/protocol/src/lib.rs) · [crates/protocol/tests/protocol.rs](../crates/protocol/tests/protocol.rs)
+- POSIX ACL handling requires the optional `acl` feature and does not yet match upstream semantics. [crates/meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) · [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs)
 
 Parity gaps and unsupported options are tracked in [gaps.md](gaps.md) and [feature_matrix.md](feature_matrix.md).
 

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -1,7 +1,7 @@
 # Feature Matrix
 
 This table tracks the implementation status of rsync 3.4.x command-line options.
-Behavioral differences from upstream rsync are tracked in [differences.md](differences.md) (currently none) and outstanding parity gaps appear in [gaps.md](gaps.md).
+Behavioral differences from upstream rsync are tracked in [differences.md](differences.md) and outstanding parity gaps appear in [gaps.md](gaps.md).
 
 Classic `rsync` protocol versions 31–32 are supported.
 
@@ -14,11 +14,11 @@ Classic `rsync` protocol versions 31–32 are supported.
 | Option | Supported | Parity (Y/N) | Tests | Source | Notes |
 | --- | --- | --- | --- | --- | --- |
 | `--8-bit-output` | ✅ | N | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--acls` | ✅ | Y | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires `acl` feature |
+| `--acls` | ✅ | N | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires `acl` feature; lacks parity |
 | `--address` | ✅ | Y | [tests/daemon.rs](../tests/daemon.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--append` | ✅ | Y | [tests/resume.rs](../tests/resume.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--append-verify` | ✅ | Y | [tests/resume.rs](../tests/resume.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--archive` | ✅ | Y | [tests/archive.rs](../tests/archive.rs)<br>[tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `--archive` | ✅ | N | [tests/archive.rs](../tests/archive.rs)<br>[tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | composite flag; underlying gaps |
 | `--atimes` | ✅ | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--backup` | ✅ | Y | [crates/engine/tests/backup.rs](../crates/engine/tests/backup.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | uses `~` suffix without `--backup-dir` |
 | `--backup-dir` | ✅ | Y | [crates/engine/tests/backup.rs](../crates/engine/tests/backup.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | implies `--backup` |
@@ -164,4 +164,4 @@ Classic `rsync` protocol versions 31–32 are supported.
 | `--whole-file` | ✅ | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--write-batch` | ✅ | Y | [tests/write_batch.rs](../tests/write_batch.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--write-devices` | ✅ | Y | [tests/write_devices.rs](../tests/write_devices.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | writes to existing devices |
-| `--xattrs` | ✅ | Y | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires `xattr` feature |
+| `--xattrs` | ✅ | N | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires `xattr` feature; lacks parity |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -5,7 +5,7 @@ This page enumerates known gaps between **oc-rsync** and upstream
 coverage so progress can be tracked as features land.
 
 ## Protocol
-No known gaps.
+- Feature negotiation covers only a subset of rsync protocol capabilities; ACL and other optional bits are not yet exchanged. [crates/protocol/src/lib.rs](../crates/protocol/src/lib.rs) · [crates/protocol/tests/protocol.rs](../crates/protocol/tests/protocol.rs)
 
 ## Compression
 No known gaps.
@@ -18,7 +18,7 @@ No known gaps. Exit codes map to upstream values. [protocol/src/lib.rs](../crate
 
 ## Metadata
 - `--archive` — composite flag; underlying `--owner`, `--group`, and `--perms` gaps apply. [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) · [tests/archive.rs](../tests/archive.rs)
-- `--acls` — ACL support requires optional feature and lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs)
+- `--acls` — ACL support requires optional feature and lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) · [tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs)
 - `--hard-links` — hard link tracking incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)
 - `--owner` — ownership restoration lacks parity. [meta/src/unix.rs](../crates/meta/src/unix.rs) · [tests/cli.rs](../tests/cli.rs)
 - `--perms` — permission preservation incomplete. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)


### PR DESCRIPTION
## Summary
- document outstanding protocol negotiation gap and ACL limitations
- mark --acls, --archive, and --xattrs as not yet matching rsync
- track protocol and ACL differences from upstream until parity

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `cargo test --all-features` *(fails: super_overrides_fake_super)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b699333f688323a3bc739e9321c6db