### PR TITLE
Add local charset handling to iconv

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -109,10 +109,10 @@ pub fn parse_iconv(spec: &str) -> std::result::Result<CharsetConv, String> {
 
     let remote_enc = remote_enc
         .ok_or_else(|| format!("iconv_open(\"{local_label}\", \"{remote_label}\") failed"))?;
-    let _ = local_enc
+    let local_enc = local_enc
         .ok_or_else(|| format!("iconv_open(\"{local_label}\", \"{remote_label}\") failed"))?;
 
-    Ok(CharsetConv::new(remote_enc))
+    Ok(CharsetConv::new(remote_enc, local_enc))
 }
 
 #[derive(Parser, Debug)]

--- a/crates/engine/src/flist.rs
+++ b/crates/engine/src/flist.rs
@@ -10,8 +10,7 @@ pub fn encode(entries: &[Entry], iconv: Option<&CharsetConv>) -> Vec<Vec<u8>> {
         .map(|e| {
             let mut e = e.clone();
             if let Some(cv) = iconv {
-                let s = String::from_utf8_lossy(&e.path);
-                e.path = cv.encode_remote(&s);
+                e.path = cv.to_remote(&e.path);
             }
             enc.encode_entry(&e)
         })
@@ -28,8 +27,7 @@ pub fn decode(
         .map(|c| {
             let mut e = dec.decode_entry(c)?;
             if let Some(cv) = iconv {
-                let s = cv.decode_remote(&e.path);
-                e.path = s.into_bytes();
+                e.path = cv.to_local(&e.path);
             }
             Ok(e)
         })

--- a/crates/engine/tests/flist.rs
+++ b/crates/engine/tests/flist.rs
@@ -33,11 +33,32 @@ fn roundtrip() {
 
 #[test]
 fn iconv_roundtrip() {
-    let cv = CharsetConv::new(Encoding::for_label(b"latin1").unwrap());
+    let cv = CharsetConv::new(
+        Encoding::for_label(b"latin1").unwrap(),
+        Encoding::for_label(b"utf-8").unwrap(),
+    );
     let entries = vec![Entry {
         path: "Grüße".as_bytes().to_vec(),
         uid: 0,
         gid: 0,
+        group: None,
+    }];
+    let payloads = flist::encode(&entries, Some(&cv));
+    let decoded = flist::decode(&payloads, Some(&cv)).unwrap();
+    assert_eq!(decoded, entries);
+}
+
+#[test]
+fn iconv_non_utf8_local_roundtrip() {
+    let cv = CharsetConv::new(
+        Encoding::for_label(b"utf-8").unwrap(),
+        Encoding::for_label(b"latin1").unwrap(),
+    );
+    let entries = vec![Entry {
+        path: b"f\xF8o".to_vec(),
+        uid: 0,
+        gid: 0,
+        group: None,
     }];
     let payloads = flist::encode(&entries, Some(&cv));
     let decoded = flist::decode(&payloads, Some(&cv)).unwrap();

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -183,7 +183,10 @@ fn extra_messages_roundtrip() {
 
 #[test]
 fn error_message_iconv_roundtrip() {
-    let cv = CharsetConv::new(Encoding::for_label(b"latin1").unwrap());
+    let cv = CharsetConv::new(
+        Encoding::for_label(b"latin1").unwrap(),
+        Encoding::for_label(b"utf-8").unwrap(),
+    );
     let msg = Message::Error("Grüße".into());
     let frame = msg.to_frame(0, Some(&cv));
     let decoded = Message::from_frame(frame, Some(&cv)).unwrap();
@@ -192,7 +195,10 @@ fn error_message_iconv_roundtrip() {
 
 #[test]
 fn filelist_iconv_roundtrip() {
-    let cv = CharsetConv::new(Encoding::for_label(b"latin1").unwrap());
+    let cv = CharsetConv::new(
+        Encoding::for_label(b"latin1").unwrap(),
+        Encoding::for_label(b"utf-8").unwrap(),
+    );
     let entry = FEntry {
         path: "Grüße".as_bytes().to_vec(),
         uid: 0,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,9 +1,7 @@
 // tests/cli.rs
 
-
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
-use encoding_rs::Encoding;
 use engine::SyncOptions;
 use filetime::{set_file_mtime, FileTime};
 use logging::progress_formatter;
@@ -195,12 +193,9 @@ fn iconv_transcodes_filenames() {
     let spec = "utf8,latin1";
     let cv = parse_iconv(spec).unwrap();
     let remote = b"f\xC3\xB8o";
-    let decoded = cv.decode_remote(remote);
-    let local_enc = Encoding::for_label(b"latin1").unwrap();
-    let (local, _, _) = local_enc.encode(&decoded);
-    assert_eq!(local.as_ref(), b"f\xF8o");
-    let (round_dec, _, _) = local_enc.decode(&local);
-    let roundtrip = cv.encode_remote(&round_dec);
+    let local = cv.to_local(remote);
+    assert_eq!(local, b"f\xF8o");
+    let roundtrip = cv.to_remote(&local);
     assert_eq!(roundtrip, remote);
 }
 


### PR DESCRIPTION
## Summary
- support converting between remote and local encodings in `CharsetConv`
- parse `--iconv` into separate remote/local encodings
- exercise non-UTF-8 local charsets in tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*

------
https://chatgpt.com/codex/tasks/task_e_68b69f2947988323bd0515469f8869d0