### PR TITLE
Enforce privileges for ownership options

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -982,10 +982,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
 
     #[cfg(unix)]
     {
-        let owner_req = matches.value_source("owner") == Some(ValueSource::CommandLine);
-        let group_req = matches.value_source("group") == Some(ValueSource::CommandLine);
-        let chown_req = matches.value_source("chown") == Some(ValueSource::CommandLine);
-        if owner_req || group_req || chown_req {
+        if opts.owner || opts.group || opts.chown.is_some() {
             use nix::unistd::Uid;
             if !Uid::effective().is_root() {
                 #[cfg(target_os = "linux")]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,5 @@
 // tests/cli.rs
 
-
 use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use encoding_rs::Encoding;
@@ -990,11 +989,12 @@ fn owner_requires_privileges() {
         .unwrap()
         .args(["--local", "--owner", &src_arg, dst_dir.to_str().unwrap()])
         .assert()
-        .success();
+        .failure()
+        .code(u8::from(protocol::ExitCode::Protocol) as i32)
+        .stderr(predicates::str::contains("changing ownership"));
 
     let dst_file = dst_dir.join("id.txt");
-    let metadata = std::fs::metadata(&dst_file).unwrap();
-    assert_eq!(metadata.uid(), current_uid);
+    assert!(!dst_file.exists());
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- require root or `CAP_CHOWN` when `--owner`, `--group`, or `--chown` are used
- add CLI test for ownership flag privilege errors

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(failed: client_respects_no_motd, daemon_allows_path_traversal_without_chroot, daemon_displays_motd, daemon_honors_bwlimit, daemon_parses_secrets_file_with_comments, daemon_rejects_unlisted_auth_user)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b69faa4bc48323b642c077552108e4