### PR TITLE
Add ACL and xattr capabilities with extended message handling

### DIFF
--- a/crates/protocol/src/mux.rs
+++ b/crates/protocol/src/mux.rs
@@ -76,6 +76,14 @@ impl Mux {
         self.send(id, Message::ErrorXfer(text.into()))
     }
 
+    pub fn send_progress(&self, id: u16, val: u64) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::Progress(val))
+    }
+
+    pub fn send_xattrs(&self, id: u16, data: Vec<u8>) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::Xattrs(data))
+    }
+
     pub fn poll(&mut self) -> Option<Frame> {
         let now = Instant::now();
 

--- a/crates/protocol/tests/golden_frames.rs
+++ b/crates/protocol/tests/golden_frames.rs
@@ -29,6 +29,17 @@ fn decode_progress_golden() {
 }
 
 #[test]
+fn decode_xattrs_golden() {
+    const XATTRS: [u8; 14] = [
+        0, 0, 0, 0xF7, 0, 0, 0, 6, b'u', b's', b'e', b'r', b'=', b'1',
+    ];
+    let frame = Frame::decode(&XATTRS[..]).unwrap();
+    assert_eq!(frame.header.msg, Msg::Xattrs);
+    let msg = Message::from_frame(frame, None).unwrap();
+    assert_eq!(msg, Message::Xattrs(b"user=1".to_vec()));
+}
+
+#[test]
 fn decode_error_golden() {
     const ERR: [u8; 12] = [0, 0, 0, 3, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
     let frame = Frame::decode(&ERR[..]).unwrap();

--- a/crates/protocol/tests/messages.rs
+++ b/crates/protocol/tests/messages.rs
@@ -1,23 +1,21 @@
 // crates/protocol/tests/messages.rs
-use protocol::{Message, Msg};
+use protocol::Message;
 
 #[test]
 fn roundtrip_additional_messages() {
     let msgs = [
-        Msg::ErrorXfer,
-        Msg::Info,
-        Msg::Warning,
-        Msg::ErrorSocket,
-        Msg::ErrorUtf8,
-        Msg::Log,
-        Msg::Client,
-        Msg::IoError,
-        Msg::IoTimeout,
-        Msg::Noop,
+        Message::ErrorXfer("test".into()),
+        Message::Info("test".into()),
+        Message::Warning("test".into()),
+        Message::ErrorSocket("test".into()),
+        Message::ErrorUtf8("test".into()),
+        Message::Log("test".into()),
+        Message::Client("test".into()),
+        Message::IoError(7),
+        Message::IoTimeout(9),
+        Message::Noop,
     ];
-    for m in msgs {
-        let payload = b"test".to_vec();
-        let msg = Message::Other(m, payload.clone());
+    for msg in msgs.into_iter() {
         let frame = msg.clone().to_frame(9, None);
         let decoded = Message::from_frame(frame, None).unwrap();
         assert_eq!(decoded, msg);

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -122,6 +122,20 @@ fn captured_frames_roundtrip() {
         .encode(&mut buf)
         .unwrap();
     assert_eq!(buf, PROG);
+
+    const XATTRS: [u8; 14] = [
+        0, 0, 0, 0xF7, 0, 0, 0, 6, b'u', b's', b'e', b'r', b'=', b'1',
+    ];
+    let frame = Frame::decode(&XATTRS[..]).unwrap();
+    assert_eq!(frame.header.msg, Msg::Xattrs);
+    let msg = Message::from_frame(frame.clone(), None).unwrap();
+    assert_eq!(msg, Message::Xattrs(b"user=1".to_vec()));
+    let mut buf = Vec::new();
+    Message::Xattrs(b"user=1".to_vec())
+        .into_frame(0, None)
+        .encode(&mut buf)
+        .unwrap();
+    assert_eq!(buf, XATTRS);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add capability bits for ACL and xattr negotiation
- extend protocol messages and mux helpers to cover xattrs and progress
- validate new capabilities and message types against upstream frame captures

## Testing
- `cargo test` *(fails: daemon_* integration tests)*
- `cargo test -p protocol`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6b73d989c83238e48bd1ca44420ea