### PR TITLE
Skip ownership preservation test when not root

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -900,6 +900,10 @@ fn numeric_ids_are_preserved() {
 #[test]
 fn owner_group_and_mode_preserved() {
     use std::os::unix::fs::PermissionsExt;
+    if !Uid::effective().is_root() {
+        eprintln!("skipping owner_group_and_mode_preserved: requires root or CAP_CHOWN",);
+        return;
+    }
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
     let dst_dir = dir.path().join("dst");


### PR DESCRIPTION
## Summary
- skip `owner_group_and_mode_preserved` when running tests without root privileges

## Testing
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon tests)*
- `cargo test owner_group_and_mode_preserved -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b6c0ba68908323a5c3d45d17ff26f4