### PR TITLE
docs: document cross-platform CI

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,7 +2,8 @@
 
 This page summarizes the operating systems and interoperability scenarios that
 have been exercised with `oc-rsync`. For a detailed status matrix see
-[compat_matrix.md](compat_matrix.md).
+[compat_matrix.md](compat_matrix.md). Cross-platform CI runs targeted tests on
+Linux, macOS, and Windows.
 
 ## Protocol versions
 
@@ -16,9 +17,9 @@ through 32.
 | Linux | primary development and CI platform |
 | Linux (arm64) | native CI runner |
 | Linux (armv7) | cross-compiled in CI |
-| FreeBSD | cross-compiled in CI |
-| macOS | builds and basic local sync verified |
-| Windows | under active development; path and permission handling incomplete |
+| FreeBSD | cross-compiled in CI (no tests) |
+| macOS | CI runner executes targeted tests |
+| Windows | CI runner executes targeted tests; path and permission handling incomplete |
 
 ## Supported Protocol Versions
 

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -52,7 +52,7 @@ No known gaps.
 - `--temp-dir` — cross-filesystem behavior differs. [engine/src/lib.rs](../crates/engine/src/lib.rs) · [tests/cli.rs](../tests/cli.rs)
 
 ## CI
-- CI runs only on Linux; other platforms are cross-compiled without tests. [compatibility.md](compatibility.md) · [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh)
+- CI runs tests on Linux, macOS, and Windows; other platforms are cross-compiled without tests. [compatibility.md](compatibility.md) · [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh)
 - Interop matrix lacks scenarios for resume and progress flags. [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh)
 
 ## Testing


### PR DESCRIPTION
## Summary
- note that CI runs cross-platform tests on Linux, macOS, and Windows
- update gap analysis CI section to reflect cross-platform coverage

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(hangs after many tests; interrupted)*
- `cargo test --lib`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6c7cc2090832387ba10c8a7aa04db