### PR TITLE
feat(protocol): handle remaining rsync messages

### DIFF
--- a/crates/protocol/src/mux.rs
+++ b/crates/protocol/src/mux.rs
@@ -84,6 +84,34 @@ impl Mux {
         self.send(id, Message::Xattrs(data))
     }
 
+    pub fn send_success(&self, id: u16, idx: u32) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::Success(idx))
+    }
+
+    pub fn send_deleted(&self, id: u16, idx: u32) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::Deleted(idx))
+    }
+
+    pub fn send_no_send(&self, id: u16, idx: u32) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::NoSend(idx))
+    }
+
+    pub fn send_redo(&self, id: u16, idx: u32) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::Redo(idx))
+    }
+
+    pub fn send_stats(&self, id: u16, data: Vec<u8>) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::Stats(data))
+    }
+
+    pub fn send_io_error(&self, id: u16, val: u32) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::IoError(val))
+    }
+
+    pub fn send_io_timeout(&self, id: u16, val: u32) -> Result<(), mpsc::SendError<Message>> {
+        self.send(id, Message::IoTimeout(val))
+    }
+
     pub fn poll(&mut self) -> Option<Frame> {
         let now = Instant::now();
 

--- a/crates/protocol/tests/messages.rs
+++ b/crates/protocol/tests/messages.rs
@@ -21,3 +21,26 @@ fn roundtrip_additional_messages() {
         assert_eq!(decoded, msg);
     }
 }
+
+#[test]
+fn roundtrip_remaining_messages() {
+    let msgs = [
+        Message::Success(1),
+        Message::Deleted(2),
+        Message::NoSend(3),
+        Message::Redo(4),
+        Message::Stats(vec![1, 2, 3]),
+        Message::Progress(5),
+        Message::Attributes(vec![6, 7]),
+        Message::FileListEntry(vec![8, 9]),
+        Message::Codecs(vec![10, 11]),
+        Message::ErrorExit(12),
+        Message::Done,
+        Message::KeepAlive,
+    ];
+    for msg in msgs.into_iter() {
+        let frame = msg.clone().to_frame(1, None);
+        let decoded = Message::from_frame(frame, None).unwrap();
+        assert_eq!(decoded, msg);
+    }
+}


### PR DESCRIPTION
## Summary
- add mux helpers for file result and diagnostics messages
- track success, delete, and nosend events in demux
- expand message round-trip tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: delete_policy tests)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6dbc70d908323abb82d5605f10609