### PR TITLE
feat: add out-format logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "protocol",
  "tempfile",
  "thiserror",
+ "tracing",
  "walk",
  "xattr",
 ]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -193,6 +193,8 @@ struct ClientOpts {
         id = "client-log-file-format"
     )]
     log_file_format: Option<String>,
+    #[arg(long = "out-format", value_name = "FORMAT", help_heading = "Output")]
+    out_format: Option<String>,
     #[arg(
         long,
         value_name = "FLAGS",
@@ -1351,6 +1353,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         progress: opts.progress || opts.partial_progress,
         human_readable: opts.human_readable,
         itemize_changes: opts.itemize_changes,
+        out_format: opts.out_format.clone(),
         partial_dir: opts.partial_dir.clone(),
         temp_dir: opts.temp_dir.clone(),
         append: opts.append,

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -17,6 +17,7 @@ logging = { path = "../logging" }
 libc = "0.2"
 memmap2 = "0.9"
 tempfile = "3"
+tracing = "0.1"
 
 [dev-dependencies]
 compress = { path = "../compress" }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -24,7 +24,7 @@ pub use checksums::StrongHash;
 use checksums::{ChecksumConfig, ChecksumConfigBuilder};
 use compress::{should_compress, Codec, Compressor, Decompressor, Zlib, Zlibx, Zstd};
 use filters::Matcher;
-use logging::progress_formatter;
+use logging::{progress_formatter, InfoFlag};
 use protocol::ExitCode;
 use thiserror::Error;
 pub mod flist;
@@ -204,6 +204,18 @@ fn outside_size_bounds(len: u64, opts: &SyncOptions) -> bool {
         }
     }
     false
+}
+
+fn log_name(rel: &Path, link: Option<&Path>, opts: &SyncOptions, default: String) {
+    if opts.quiet {
+        return;
+    }
+    if let Some(fmt) = &opts.out_format {
+        let msg = logging::render_out_format(fmt, rel, link);
+        tracing::info!(target: InfoFlag::Name.target(), "{}", msg);
+    } else if opts.itemize_changes {
+        println!("{}", default);
+    }
 }
 
 #[cfg(unix)]
@@ -1706,6 +1718,7 @@ pub struct SyncOptions {
     pub progress: bool,
     pub human_readable: bool,
     pub itemize_changes: bool,
+    pub out_format: Option<String>,
     pub partial_dir: Option<PathBuf>,
     pub temp_dir: Option<PathBuf>,
     pub append: bool,
@@ -1800,6 +1813,7 @@ impl Default for SyncOptions {
             progress: false,
             human_readable: false,
             itemize_changes: false,
+            out_format: None,
             partial_dir: None,
             temp_dir: None,
             append: false,
@@ -2263,8 +2277,8 @@ pub fn sync(
                         if let Some(f) = batch_file.as_mut() {
                             let _ = writeln!(f, "{}", rel.display());
                         }
-                        if opts.itemize_changes && !opts.quiet {
-                            println!(">f+++++++++ {}", rel.display());
+                        if (opts.out_format.is_some() || opts.itemize_changes) && !opts.quiet {
+                            log_name(rel, None, opts, format!(">f+++++++++ {}", rel.display()));
                         }
                     }
                     if opts.remove_source_files {
@@ -2336,8 +2350,8 @@ pub fn sync(
                             chown(&dest_path, Some(Uid::from_raw(uid)), gid)
                                 .map_err(|e| io_context(&dest_path, std::io::Error::from(e)))?;
                         }
-                        if opts.itemize_changes && !opts.quiet {
-                            println!("cd+++++++++ {}/", rel.display());
+                        if (opts.out_format.is_some() || opts.itemize_changes) && !opts.quiet {
+                            log_name(rel, None, opts, format!("cd+++++++++ {}/", rel.display()));
                         }
                     }
                     dir_meta.push((path.clone(), dest_path.clone()));
@@ -2423,8 +2437,17 @@ pub fn sync(
                         receiver.copy_metadata(&path, &dest_path)?;
                         if created {
                             stats.files_transferred += 1;
-                            if opts.itemize_changes && !opts.quiet {
-                                println!("cL+++++++++ {} -> {}", rel.display(), target.display());
+                            if (opts.out_format.is_some() || opts.itemize_changes) && !opts.quiet {
+                                log_name(
+                                    rel,
+                                    Some(&target),
+                                    opts,
+                                    format!(
+                                        "cL+++++++++ {} -> {}",
+                                        rel.display(),
+                                        target.display()
+                                    ),
+                                );
                             }
                         }
                         if opts.remove_source_files {
@@ -2460,8 +2483,15 @@ pub fn sync(
                             receiver.copy_metadata_now(&path, &dest_path)?;
                             if created {
                                 stats.files_transferred += 1;
-                                if opts.itemize_changes && !opts.quiet {
-                                    println!("cD+++++++++ {}", rel.display());
+                                if (opts.out_format.is_some() || opts.itemize_changes)
+                                    && !opts.quiet
+                                {
+                                    log_name(
+                                        rel,
+                                        None,
+                                        opts,
+                                        format!("cD+++++++++ {}", rel.display()),
+                                    );
                                 }
                             }
                         } else if file_type.is_fifo() && opts.specials {

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -1,6 +1,6 @@
 // crates/logging/src/lib.rs
 use std::fs::OpenOptions;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     fmt,
@@ -278,4 +278,34 @@ pub fn progress_formatter(bytes: u64, human_readable: bool) -> String {
         }
         out.chars().rev().collect()
     }
+}
+
+pub fn render_out_format(format: &str, name: &Path, link: Option<&Path>) -> String {
+    let mut out = String::new();
+    let mut chars = format.chars();
+    while let Some(c) = chars.next() {
+        if c == '%' {
+            if let Some(n) = chars.next() {
+                match n {
+                    'n' => out.push_str(&name.to_string_lossy()),
+                    'L' => {
+                        if let Some(l) = link {
+                            out.push_str(" -> ");
+                            out.push_str(&l.to_string_lossy());
+                        }
+                    }
+                    '%' => out.push('%'),
+                    other => {
+                        out.push('%');
+                        out.push(other);
+                    }
+                }
+            } else {
+                out.push('%');
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }

--- a/tests/log_file.rs
+++ b/tests/log_file.rs
@@ -25,6 +25,7 @@ fn log_file_writes_messages() {
         .success();
     let contents = fs::read_to_string(&log).unwrap();
     assert!(contents.contains("verbose level set to 1"), "{}", contents);
+    assert!(!contents.contains("src"), "{}", contents);
 }
 
 #[test]
@@ -50,4 +51,28 @@ fn log_file_format_json_writes_json() {
         .success();
     let contents = fs::read_to_string(&log).unwrap();
     assert!(contents.contains("\"message\""), "{}", contents);
+}
+
+#[test]
+fn out_format_writes_custom_message() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(&src, b"hi").unwrap();
+    let log = tmp.path().join("log.txt");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--log-file",
+            log.to_str().unwrap(),
+            "--out-format=custom:%n",
+            src.to_str().unwrap(),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let contents = fs::read_to_string(&log).unwrap();
+    assert!(contents.contains("custom:src"), "{}", contents);
 }


### PR DESCRIPTION
## Summary
- add `--out-format` flag and plumb through engine
- support custom update formatting in logging
- test custom log formatting

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments`
- `cargo test --test delete_policy` *(failed: assertion failed: !dst.exists())*


------
https://chatgpt.com/codex/tasks/task_e_68b6e64e82e88323b7478d3567a9b9d8