### PR TITLE
Support legacy protocol versions

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -49,9 +49,11 @@ pub use server::Server;
 
 pub const V32: u32 = 32;
 pub const V31: u32 = 31;
-pub const SUPPORTED_PROTOCOLS: &[u32] = &[V32, V31];
+pub const V30: u32 = 30;
+pub const V29: u32 = 29;
+pub const SUPPORTED_PROTOCOLS: &[u32] = &[V32, V31, V30, V29];
 pub const LATEST_VERSION: u32 = V32;
-pub const MIN_VERSION: u32 = V31;
+pub const MIN_VERSION: u32 = V29;
 
 pub const CAP_CODECS: u32 = 1 << 0;
 pub const CAP_ZSTD: u32 = 1 << 1;

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -2,7 +2,7 @@
 use compress::{available_codecs, encode_codecs, Codec};
 use protocol::{
     ExitCode, Server, CAP_ACLS, CAP_CODECS, CAP_XATTRS, CAP_ZSTD, SUPPORTED_CAPS,
-    SUPPORTED_PROTOCOLS, V31, V32,
+    SUPPORTED_PROTOCOLS, V29,
 };
 use std::io::Cursor;
 use std::time::Duration;
@@ -41,7 +41,7 @@ fn server_negotiates_version() {
 
 #[test]
 fn server_accepts_legacy_version() {
-    let legacy = V32;
+    let legacy = V29;
     let payload = encode_codecs(&available_codecs());
     let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0, None);
     let mut codecs_buf = Vec::new();
@@ -81,7 +81,7 @@ fn server_classic_versions() {
     let mut codecs_buf = Vec::new();
     codecs_frame.encode(&mut codecs_buf).unwrap();
 
-    for ver in [V31, V32] {
+    for &ver in SUPPORTED_PROTOCOLS {
         let mut input = Cursor::new({
             let mut v = vec![0, 0];
             v.extend_from_slice(&ver.to_be_bytes());

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -1,0 +1,11 @@
+# Upstream Compatibility
+
+`oc-rsync` interoperates with classic `rsync` by negotiating a common protocol version during the handshake.
+The following upstream protocol versions are recognized:
+
+- 32
+- 31
+- 30
+- 29
+
+When connecting to a peer, the highest shared version from this list is selected. Versions earlier than 29 are not supported.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,7 +7,7 @@ into CI, and their results populate the detailed matrix in
 
 ## Protocol versions
 
-`oc-rsync` interoperates with classic `rsync` using protocol versions 27
+`oc-rsync` interoperates with classic `rsync` using protocol versions 29
 through 32.
 
 ## Tested platforms
@@ -31,8 +31,6 @@ kept up to date from their results.
 
 | Version | Tests/Fixtures |
 |---------|----------------|
-| 27 | [proto-27 wire log](../tests/interop/wire/proto-27.log) |
-| 28 | [proto-28 wire log](../tests/interop/wire/proto-28.log) |
 | 29 | [version negotiation test](../crates/protocol/tests/protocol.rs#L40-L45) |
 | 30 | [protocol override test](../crates/cli/src/lib.rs#L1958-L2030) |
 | 31 | [server handshake test](../crates/protocol/tests/server.rs#L1-L80) |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -3,7 +3,7 @@
 This table tracks the implementation status of rsync 3.4.x command-line options.
 Behavioral differences from upstream rsync are tracked in [differences.md](differences.md) and outstanding parity gaps appear in [gaps.md](gaps.md).
 
-Classic `rsync` protocol versions 31–32 are supported.
+Classic `rsync` protocol versions 29–32 are supported.
 
 ## Internal features
 


### PR DESCRIPTION
## Summary
- add constants for rsync protocol versions 29 and 30
- negotiate with older peers and test all supported versions
- document upstream protocol compatibility

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6f7c46248832384da50b267c1b6e7