### PR TITLE
Track remote log and error messages

### DIFF
--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -164,6 +164,22 @@ impl<R: Read, W: Write> Server<R, W> {
         self.demux.take_remote_error()
     }
 
+    pub fn take_error_xfers(&mut self) -> Vec<String> {
+        self.demux.take_error_xfers()
+    }
+
+    pub fn take_errors(&mut self) -> Vec<String> {
+        self.demux.take_errors()
+    }
+
+    pub fn take_error_sockets(&mut self) -> Vec<String> {
+        self.demux.take_error_sockets()
+    }
+
+    pub fn take_error_utf8s(&mut self) -> Vec<String> {
+        self.demux.take_error_utf8s()
+    }
+
     pub fn take_successes(&mut self) -> Vec<u32> {
         self.demux.take_successes()
     }

--- a/crates/protocol/tests/exit_codes.rs
+++ b/crates/protocol/tests/exit_codes.rs
@@ -131,8 +131,7 @@ fn demux_remote_error_propagates() {
     let mut demux = Demux::new(Duration::from_millis(50));
     let rx = demux.register_channel(5);
     let frame = Message::Error("oops".into()).to_frame(5, None);
-    let err = demux.ingest(frame).unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::Other);
-    assert_eq!(demux.take_remote_error().as_deref(), Some("oops"));
+    demux.ingest(frame).unwrap();
+    assert_eq!(demux.take_errors(), vec!["oops".to_string()]);
     assert!(matches!(rx.try_recv(), Ok(Message::Error(ref s)) if s == "oops"));
 }

--- a/crates/protocol/tests/mux_demux.rs
+++ b/crates/protocol/tests/mux_demux.rs
@@ -96,11 +96,12 @@ fn error_xfer_sets_remote_error() {
     let mut demux = Demux::new(Duration::from_millis(50));
 
     mux.register_channel(0);
-    demux.register_channel(0);
+    let _rx = demux.register_channel(0);
 
     mux.send_error_xfer(0, "oops").unwrap();
     let frame = mux.poll().expect("frame");
-    assert!(demux.ingest(frame).is_err());
+    demux.ingest(frame).unwrap();
+    assert_eq!(demux.take_error_xfers(), vec!["oops".to_string()]);
     assert_eq!(demux.take_remote_error(), Some("oops".into()));
 }
 
@@ -136,7 +137,7 @@ fn collect_log_messages() {
     let mut demux = Demux::new(Duration::from_millis(50));
 
     mux.register_channel(0);
-    demux.register_channel(0);
+    let _rx = demux.register_channel(0);
 
     mux.send_info(0, "info").unwrap();
     mux.send_warning(0, "warn").unwrap();
@@ -166,7 +167,7 @@ fn collect_progress_and_stats_messages() {
     let mut demux = Demux::new(Duration::from_millis(50));
 
     mux.register_channel(0);
-    demux.register_channel(0);
+    let _rx = demux.register_channel(0);
 
     mux.send_progress(0, 123).unwrap();
     mux.send_stats(0, vec![1, 2, 3]).unwrap();

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -147,7 +147,7 @@ fn server_propagates_handshake_error() {
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
     let err = srv.handshake(latest, SUPPORTED_CAPS, &[]).unwrap_err();
-    assert_eq!(err.kind(), std::io::ErrorKind::Other);
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert_eq!(srv.demux.take_remote_error().as_deref(), Some("fail"));
 }
 
@@ -302,7 +302,7 @@ fn server_surfaces_progress_and_stats() {
     let mut output = Vec::new();
     let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
 
-    srv.demux.register_channel(0);
+    let _rx = srv.demux.register_channel(0);
 
     let prog = protocol::Message::Progress(42).to_frame(0, None);
     let stats = protocol::Message::Stats(vec![1, 2, 3]).to_frame(0, None);


### PR DESCRIPTION
## Summary
- track error and log messages in protocol Demux and expose retrieval helpers
- forward recorded messages via Server and test coverage

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p protocol`
- `cargo test` *(fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b6f83d682c832392d8b8934bcf86f8