### PR TITLE
feat: add out-format and logging placeholders

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -90,10 +90,13 @@ where
 }
 
 pub fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFlag>) {
-    let info = matches
+    let mut info: Vec<InfoFlag> = matches
         .get_many::<InfoFlag>("info")
         .map(|v| v.copied().collect())
         .unwrap_or_default();
+    if matches.contains_id("out_format") && !info.contains(&InfoFlag::Name) {
+        info.push(InfoFlag::Name);
+    }
     let debug = matches
         .get_many::<DebugFlag>("debug")
         .map(|v| v.copied().collect())

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -210,8 +210,9 @@ fn log_name(rel: &Path, link: Option<&Path>, opts: &SyncOptions, default: String
     if opts.quiet {
         return;
     }
+    let itemized = default.split_once(' ').map(|(i, _)| i.to_string());
     if let Some(fmt) = &opts.out_format {
-        let msg = logging::render_out_format(fmt, rel, link);
+        let msg = logging::render_out_format(fmt, rel, link, itemized.as_deref());
         tracing::info!(target: InfoFlag::Name.target(), "{}", msg);
     } else if opts.itemize_changes {
         println!("{}", default);

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -280,7 +280,12 @@ pub fn progress_formatter(bytes: u64, human_readable: bool) -> String {
     }
 }
 
-pub fn render_out_format(format: &str, name: &Path, link: Option<&Path>) -> String {
+pub fn render_out_format(
+    format: &str,
+    name: &Path,
+    link: Option<&Path>,
+    itemized: Option<&str>,
+) -> String {
     let mut out = String::new();
     let mut chars = format.chars();
     while let Some(c) = chars.next() {
@@ -292,6 +297,22 @@ pub fn render_out_format(format: &str, name: &Path, link: Option<&Path>) -> Stri
                         if let Some(l) = link {
                             out.push_str(" -> ");
                             out.push_str(&l.to_string_lossy());
+                        }
+                    }
+                    'i' => {
+                        if let Some(i) = itemized {
+                            out.push_str(i);
+                        }
+                    }
+                    'o' => {
+                        if let Some(i) = itemized {
+                            let op = match i.chars().next().unwrap_or(' ') {
+                                '>' => "send",
+                                '<' => "recv",
+                                '*' => "del.",
+                                _ => "",
+                            };
+                            out.push_str(op);
                         }
                     }
                     '%' => out.push('%'),

--- a/tests/out_format.rs
+++ b/tests/out_format.rs
@@ -1,0 +1,109 @@
+use assert_cmd::Command as TestCommand;
+use std::{fs, process::Command};
+use tempfile::tempdir;
+
+#[test]
+fn out_format_file_matches_rsync() {
+    let tmp = tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(src_dir.join("a"), b"hi").unwrap();
+    let dst_oc = tmp.path().join("dst_oc");
+    let dst_rsync = tmp.path().join("dst_rsync");
+    fs::create_dir_all(&dst_oc).unwrap();
+    fs::create_dir_all(&dst_rsync).unwrap();
+    let log = tmp.path().join("log.txt");
+    let src_arg = format!("{}/", src_dir.display());
+
+    TestCommand::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--log-file",
+            log.to_str().unwrap(),
+            "--out-format=%o:%n",
+            &src_arg,
+            dst_oc.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let ours = fs::read_to_string(&log).unwrap();
+    let ours_line = ours
+        .lines()
+        .find(|l| l.contains("info::name") && l.contains("send:a"))
+        .unwrap();
+    let ours_msg = ours_line.split("info::name: ").nth(1).unwrap().trim();
+
+    let output = Command::new("rsync")
+        .args([
+            "-r",
+            "--out-format=%o:%n",
+            &src_arg,
+            dst_rsync.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let binding = String::from_utf8_lossy(&output.stdout);
+    let theirs_msg = binding
+        .lines()
+        .find(|l| l.trim() == "send:a")
+        .unwrap()
+        .trim();
+
+    assert_eq!(ours_msg, theirs_msg);
+}
+
+#[cfg(unix)]
+#[test]
+fn out_format_symlink_matches_rsync() {
+    let tmp = tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(src_dir.join("f"), b"hi").unwrap();
+    std::os::unix::fs::symlink("f", src_dir.join("link")).unwrap();
+    let dst_oc = tmp.path().join("dst_oc");
+    let dst_rsync = tmp.path().join("dst_rsync");
+    fs::create_dir_all(&dst_oc).unwrap();
+    fs::create_dir_all(&dst_rsync).unwrap();
+    let log = tmp.path().join("log.txt");
+    let src_arg = format!("{}/", src_dir.display());
+
+    TestCommand::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "-l",
+            "--recursive",
+            "--log-file",
+            log.to_str().unwrap(),
+            "--out-format=%i:%n%L",
+            &src_arg,
+            dst_oc.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    let ours = fs::read_to_string(&log).unwrap();
+    let ours_line = ours
+        .lines()
+        .find(|l| l.contains("info::name") && l.contains("link"))
+        .unwrap();
+    let ours_msg = ours_line.split("info::name: ").nth(1).unwrap().trim();
+
+    let output = Command::new("rsync")
+        .args([
+            "-r",
+            "-l",
+            "--out-format=%i:%n%L",
+            &src_arg,
+            dst_rsync.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let binding = String::from_utf8_lossy(&output.stdout);
+    let theirs_msg = binding.lines().find(|l| l.contains("link")).unwrap().trim();
+
+    assert_eq!(ours_msg, theirs_msg);
+}


### PR DESCRIPTION
## Summary
- support --out-format flag implying info-level logging
- expand logging placeholders for --out-format strings
- test out-format against upstream rsync

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f95839388323b9653ce3f3678bf7