### PR TITLE
Support external filter lists and per-dir merges

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1940,13 +1940,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
 
 fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
     fn load_patterns(path: &Path, from0: bool) -> io::Result<Vec<String>> {
-        if path == Path::new("-") {
-            let mut buf = Vec::new();
-            io::stdin().read_to_end(&mut buf)?;
-            Ok(filters::parse_list(&buf, from0))
-        } else {
-            filters::parse_list_file(path, from0).map_err(|e| io::Error::other(format!("{:?}", e)))
-        }
+        filters::parse_list_file(path, from0).map_err(|e| io::Error::other(format!("{:?}", e)))
     }
 
     let mut entries: Vec<(usize, usize, Rule)> = Vec::new();
@@ -1975,13 +1969,7 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
             .indices_of("filter_file")
             .map_or_else(Vec::new, |v| v.collect());
         for (idx, file) in idxs.into_iter().zip(values) {
-            let mut data = Vec::new();
-            if file == Path::new("-") {
-                io::stdin().read_to_end(&mut data)?;
-            } else {
-                data = fs::read(file)?;
-            }
-            let rs = filters::parse_from_bytes(&data, opts.from0, &mut HashSet::new(), 0)
+            let rs = filters::parse_file(file, opts.from0, &mut HashSet::new(), 0)
                 .map_err(|e| EngineError::Other(format!("{:?}", e)))?;
             add_rules(idx + 1, rs);
         }
@@ -2016,15 +2004,8 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
             .map_or_else(Vec::new, |v| v.collect());
         for (idx, file) in idxs.into_iter().zip(values) {
             let mut vset = HashSet::new();
-            let rs = if file == Path::new("-") {
-                let mut buf = Vec::new();
-                io::stdin().read_to_end(&mut buf)?;
-                filters::parse_rule_list_from_bytes(&buf, opts.from0, '+', &mut vset, 0)
-                    .map_err(|e| EngineError::Other(format!("{:?}", e)))?
-            } else {
-                filters::parse_rule_list_file(file, opts.from0, '+', &mut vset, 0)
-                    .map_err(|e| EngineError::Other(format!("{:?}", e)))?
-            };
+            let rs = filters::parse_rule_list_file(file, opts.from0, '+', &mut vset, 0)
+                .map_err(|e| EngineError::Other(format!("{:?}", e)))?;
             add_rules(idx + 1, rs);
         }
     }
@@ -2034,15 +2015,8 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
             .map_or_else(Vec::new, |v| v.collect());
         for (idx, file) in idxs.into_iter().zip(values) {
             let mut vset = HashSet::new();
-            let rs = if file == Path::new("-") {
-                let mut buf = Vec::new();
-                io::stdin().read_to_end(&mut buf)?;
-                filters::parse_rule_list_from_bytes(&buf, opts.from0, '-', &mut vset, 0)
-                    .map_err(|e| EngineError::Other(format!("{:?}", e)))?
-            } else {
-                filters::parse_rule_list_file(file, opts.from0, '-', &mut vset, 0)
-                    .map_err(|e| EngineError::Other(format!("{:?}", e)))?
-            };
+            let rs = filters::parse_rule_list_file(file, opts.from0, '-', &mut vset, 0)
+                .map_err(|e| EngineError::Other(format!("{:?}", e)))?;
             add_rules(idx + 1, rs);
         }
     }

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 const MAX_PARSE_DEPTH: usize = 64;
@@ -885,7 +886,7 @@ pub fn parse_with_options(
                 rules.push(Rule::DirMerge(PerDir {
                     file: ".rsync-filter".to_string(),
                     anchored: true,
-                    root_only: true,
+                    root_only: false,
                     inherit: true,
                     cvs: false,
                     word_split: false,
@@ -1430,7 +1431,13 @@ pub fn parse_list(input: &[u8], from0: bool) -> Vec<String> {
 }
 
 pub fn parse_list_file(path: &Path, from0: bool) -> Result<Vec<String>, ParseError> {
-    let data = fs::read(path)?;
+    let data = if path == Path::new("-") {
+        let mut buf = Vec::new();
+        std::io::stdin().read_to_end(&mut buf)?;
+        buf
+    } else {
+        fs::read(path)?
+    };
     Ok(parse_list(&data, from0))
 }
 
@@ -1468,7 +1475,13 @@ pub fn parse_file(
     visited: &mut HashSet<PathBuf>,
     depth: usize,
 ) -> Result<Vec<Rule>, ParseError> {
-    let data = fs::read(path)?;
+    let data = if path == Path::new("-") {
+        let mut buf = Vec::new();
+        std::io::stdin().read_to_end(&mut buf)?;
+        buf
+    } else {
+        fs::read(path)?
+    };
     parse_from_bytes(&data, from0, visited, depth)
 }
 
@@ -1499,6 +1512,12 @@ pub fn parse_rule_list_file(
     visited: &mut HashSet<PathBuf>,
     depth: usize,
 ) -> Result<Vec<Rule>, ParseError> {
-    let data = fs::read(path)?;
+    let data = if path == Path::new("-") {
+        let mut buf = Vec::new();
+        std::io::stdin().read_to_end(&mut buf)?;
+        buf
+    } else {
+        fs::read(path)?
+    };
     parse_rule_list_from_bytes(&data, from0, sign, visited, depth)
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -243,6 +243,112 @@ fn exclude_from_from0_matches_rsync() {
     assert!(diff.success(), "directory trees differ");
 }
 
+#[test]
+fn filter_file_from0_matches_rsync() {
+    use std::process::Command as StdCommand;
+
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let rsync_dst = tmp.path().join("rsync");
+    let ours_dst = tmp.path().join("ours");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&rsync_dst).unwrap();
+    fs::create_dir_all(&ours_dst).unwrap();
+
+    fs::write(src.join("a.txt"), "hi").unwrap();
+    fs::write(src.join("b.log"), "no").unwrap();
+    fs::write(src.join("c.txt"), "hi").unwrap();
+
+    let filter = tmp.path().join("filters");
+    fs::write(&filter, b"+ *.txt\0- *\0").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+
+    StdCommand::new("rsync")
+        .args([
+            "-r",
+            "--from0",
+            "--filter",
+            &format!("merge {}", filter.display()),
+            &src_arg,
+            rsync_dst.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "--from0",
+            "--filter-file",
+            filter.to_str().unwrap(),
+            &src_arg,
+            ours_dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let diff = StdCommand::new("diff")
+        .arg("-r")
+        .arg(&rsync_dst)
+        .arg(&ours_dst)
+        .status()
+        .unwrap();
+    assert!(diff.success(), "directory trees differ");
+}
+
+#[test]
+fn per_dir_merge_matches_rsync() {
+    use std::process::Command as StdCommand;
+
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let rsync_dst = tmp.path().join("rsync");
+    let ours_dst = tmp.path().join("ours");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::create_dir_all(&rsync_dst).unwrap();
+    fs::create_dir_all(&ours_dst).unwrap();
+
+    fs::write(src.join("keep.txt"), "hi").unwrap();
+    fs::write(src.join("omit.log"), "no").unwrap();
+    fs::write(src.join("sub").join("keep2.txt"), "hi").unwrap();
+    fs::write(src.join("sub").join("omit2.txt"), "no").unwrap();
+
+    fs::write(src.join(".rsync-filter"), b"- *.log\n").unwrap();
+    fs::write(src.join("sub").join(".rsync-filter"), b"- omit2.txt\n").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+
+    StdCommand::new("rsync")
+        .args(["-r", "-F", "-F", &src_arg, rsync_dst.to_str().unwrap()])
+        .status()
+        .unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--recursive",
+            "-F",
+            "-F",
+            &src_arg,
+            ours_dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    let diff = StdCommand::new("diff")
+        .arg("-r")
+        .arg(&rsync_dst)
+        .arg(&ours_dst)
+        .status()
+        .unwrap();
+    assert!(diff.success(), "directory trees differ");
+}
+
 #[cfg(unix)]
 impl Drop for Tmpfs {
     fn drop(&mut self) {


### PR DESCRIPTION
## Summary
- allow filter parsing to load list files from stdin and handle null-separated entries
- plumb external list and from0 options through CLI into filter matcher
- add integration tests for filter file input and per-directory merge behavior

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test` *(fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f969d74883238d6393889858a4de