### PR TITLE
docs: document feature gaps per domain

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -1,7 +1,7 @@
 # Feature Matrix
 
 This table tracks the implementation status of rsync 3.4.x command-line options.
-Behavioral differences from upstream rsync are tracked in [differences.md](differences.md) and outstanding parity gaps appear in [gaps.md](gaps.md).
+Behavioral differences from upstream rsync are tracked in [differences.md](differences.md) and detailed per-domain coverage appears in [gaps.md](gaps.md).
 
 Classic `rsync` protocol versions 29–32 are supported.
 

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -1,0 +1,93 @@
+# Feature Gaps
+
+This document summarizes parity status across major domains of `oc-rsync`.  Each
+table lists notable features that are either implemented, only partially
+completed, or still missing.  Entries link to the source and corresponding tests
+when available.
+
+## Protocol
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Frame multiplexing and keep-alives | ✅ | [crates/protocol/tests/mux_demux.rs](../crates/protocol/tests/mux_demux.rs) | [crates/protocol/src/mux.rs](../crates/protocol/src/mux.rs) |
+| Version negotiation | ✅ | [crates/protocol/tests/server.rs](../crates/protocol/tests/server.rs) | [crates/protocol/src/server.rs](../crates/protocol/src/server.rs) |
+| Exit code propagation | ⚠️ | [crates/protocol/tests/exit_codes.rs](../crates/protocol/tests/exit_codes.rs) | [crates/protocol/src/lib.rs](../crates/protocol/src/lib.rs) |
+| Challenge-response authentication | ❌ | — | — |
+
+## Checksums
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Rolling and strong MD5/SHA-1 hashes | ✅ | [crates/checksums/tests/golden.rs](../crates/checksums/tests/golden.rs) | [crates/checksums/src/lib.rs](../crates/checksums/src/lib.rs) |
+| Legacy MD4 algorithm | ❌ | — | — |
+
+## Compression
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| zstd, zlibx and zlib codecs | ✅ | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/lib.rs](../crates/compress/src/lib.rs) |
+| `--skip-compress` suffix handling | ✅ | [tests/skip_compress.rs](../tests/skip_compress.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
+| Additional codecs (e.g. lzo, lz4) | ❌ | — | — |
+
+## Filters
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Include/Exclude parser | ✅ | [crates/filters/tests/include_exclude.rs](../crates/filters/tests/include_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| `.rsync-filter` merge semantics | ✅ | [crates/filters/tests/merge.rs](../crates/filters/tests/merge.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| Rule logging and statistics | ❌ | — | — |
+
+## File List
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Path-delta encoding with uid/gid tables | ✅ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
+| Group ID preservation | ⚠️ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
+| Extended attributes and ACL entries | ❌ | — | — |
+
+## Walk
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Batched filesystem traversal | ✅ | [crates/walk/tests/walk.rs](../crates/walk/tests/walk.rs) | [crates/walk/src/lib.rs](../crates/walk/src/lib.rs) |
+| Maximum file-size filtering | ✅ | [crates/walk/tests/walk.rs](../crates/walk/tests/walk.rs) | [crates/walk/src/lib.rs](../crates/walk/src/lib.rs) |
+| `--one-file-system` device boundary | ❌ | — | — |
+
+## Metadata
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Permissions and ownership restoration | ✅ | [crates/meta/tests/chmod.rs](../crates/meta/tests/chmod.rs) | [crates/meta/src/unix.rs](../crates/meta/src/unix.rs) |
+| `--fake-super` xattr fallback | ✅ | [crates/meta/tests/fake_super.rs](../crates/meta/tests/fake_super.rs) | [crates/meta/src/unix.rs](../crates/meta/src/unix.rs) |
+| POSIX ACL preservation | ❌ | — | — |
+
+## Transport
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| SSH stdio transport | ✅ | [crates/transport/tests/ssh_stdio.rs](../crates/transport/tests/ssh_stdio.rs) | [crates/transport/src/ssh.rs](../crates/transport/src/ssh.rs) |
+| TCP transport with bandwidth limiting | ✅ | [crates/transport/tests/bwlimit.rs](../crates/transport/tests/bwlimit.rs) | [crates/transport/src/rate.rs](../crates/transport/src/rate.rs) |
+| Extended socket options | ⚠️ | [crates/transport/tests/sockopts.rs](../crates/transport/tests/sockopts.rs) | [crates/transport/src/tcp.rs](../crates/transport/src/tcp.rs) |
+| Connection retry/backoff | ❌ | — | — |
+
+## Engine
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| In-place updates and resume | ✅ | [crates/engine/tests/resume.rs](../crates/engine/tests/resume.rs) | [crates/engine/src/lib.rs](../crates/engine/src/lib.rs) |
+| Delete policies | ✅ | [crates/engine/tests/delete.rs](../crates/engine/tests/delete.rs) | [crates/engine/src/lib.rs](../crates/engine/src/lib.rs) |
+| `--read-batch` replay | ❌ | — | — |
+
+## Daemon
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Module parsing and secrets auth | ✅ | [tests/daemon_config.rs](../tests/daemon_config.rs)<br>[tests/daemon_auth.sh](../tests/daemon_auth.sh) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
+| IPv6 listener and rate limiting | ✅ | [tests/daemon.rs](../tests/daemon.rs) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
+| Chroot and uid/gid dropping | ⚠️ | [tests/daemon_features.sh](../tests/daemon_features.sh) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
+| `rsyncd.conf` file parsing | ❌ | — | — |
+
+## CLI
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Comprehensive flag parsing via `clap` | ✅ | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
+| `--log-file-format` (limited subset) | ⚠️ | [tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
+| `--munge-links` option | ❌ | — | — |
+
+## Logging
+| Feature | Status | Tests | Source |
+| --- | --- | --- | --- |
+| Info and debug flag routing | ✅ | [crates/logging/tests/info_flags.rs](../crates/logging/tests/info_flags.rs) | [crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |
+| JSON and text formatters | ✅ | [crates/logging/tests/levels.rs](../crates/logging/tests/levels.rs) | [crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |
+| System log integration | ❌ | — | — |
+


### PR DESCRIPTION
## Summary
- add docs/gaps.md detailing implemented, partial, and missing features for each major domain
- reference the new gaps file from feature_matrix.md

## Testing
- `cargo fmt --all` *(fails: unclosed delimiter crates/cli/src/lib.rs:2788)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unclosed delimiter crates/cli/src/lib.rs:2788)*
- `cargo test` *(fails: unclosed delimiter crates/cli/src/lib.rs:2788)*
- `make verify-comments` *(fails: unclosed delimiter crates/cli/src/lib.rs:2788)*
- `make lint` *(fails: unclosed delimiter crates/cli/src/lib.rs:2788)*


------
https://chatgpt.com/codex/tasks/task_e_68b70382b34c832380cb8a16b526db60