### PR TITLE
Map clap argument errors to exit codes

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -110,6 +110,8 @@ fn parse_bool(s: &str) -> std::result::Result<bool, String> {
         "0" | "false" | "no" => Ok(false),
         "1" | "true" | "yes" => Ok(true),
         _ => Err("invalid boolean".to_string()),
+    }
+}
 
 pub fn version_string() -> String {
     if let Ok(out) = Command::new("rsync").arg("--version").output() {

--- a/tests/clap_error_codes.rs
+++ b/tests/clap_error_codes.rs
@@ -1,0 +1,42 @@
+// tests/clap_error_codes.rs
+use assert_cmd::Command;
+use predicates::str::contains;
+use protocol::ExitCode;
+use tempfile::tempdir;
+
+#[test]
+fn unsupported_option_returns_exit_code_unsupported() {
+    let src = tempdir().unwrap();
+    let dst = tempdir().unwrap();
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--bad-option",
+            src.path().to_str().unwrap(),
+            dst.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .code(u8::from(ExitCode::Unsupported) as i32)
+        .stderr(contains("rsync: --bad-option: unknown option"))
+        .stderr(contains(
+            "rsync error: requested action not supported (code 4)",
+        ));
+}
+
+#[test]
+fn invalid_numeric_value_is_usage_error() {
+    let src = tempdir().unwrap();
+    let dst = tempdir().unwrap();
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--timeout=abc",
+            src.path().to_str().unwrap(),
+            dst.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .code(u8::from(ExitCode::SyntaxOrUsage) as i32)
+        .stderr(contains("rsync error: syntax or usage error (code 1)"));
+}


### PR DESCRIPTION
## Summary
- map clap::ErrorKind variants to protocol exit codes
- print rsync-style error messages
- test clap error exit codes

## Testing
- `cargo test` *(fails: delete_policy::delete_missing_args_removes_destination, delete_policy::ignore_errors_allows_deletion_failure)*
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b703e372808323bc708ef7a368ad43