### PR TITLE
Treat bare drive letters as local

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -110,6 +110,8 @@ fn parse_bool(s: &str) -> std::result::Result<bool, String> {
         "0" | "false" | "no" => Ok(false),
         "1" | "true" | "yes" => Ok(true),
         _ => Err("invalid boolean".to_string()),
+    }
+}
 
 pub fn version_string() -> String {
     if let Ok(out) = Command::new("rsync").arg("--version").output() {
@@ -873,13 +875,13 @@ pub fn cli_command() -> clap::Command {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct PathSpec {
+pub struct PathSpec {
     path: PathBuf,
     trailing_slash: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-enum RemoteSpec {
+pub enum RemoteSpec {
     Local(PathSpec),
     Remote {
         host: String,
@@ -888,7 +890,7 @@ enum RemoteSpec {
     },
 }
 
-fn parse_remote_spec(input: &str) -> Result<RemoteSpec> {
+pub fn parse_remote_spec(input: &str) -> Result<RemoteSpec> {
     let (trailing_slash, s) = if input != "/" && input.ends_with('/') {
         (true, &input[..input.len() - 1])
     } else {
@@ -947,10 +949,11 @@ fn parse_remote_spec(input: &str) -> Result<RemoteSpec> {
         if idx == 1 {
             let bytes = s.as_bytes();
             if bytes[0].is_ascii_alphabetic()
-                && bytes
-                    .get(2)
-                    .map(|c| *c == b'/' || *c == b'\\')
-                    .unwrap_or(false)
+                && (bytes.len() == 2
+                    || bytes
+                        .get(2)
+                        .map(|c| *c == b'/' || *c == b'\\')
+                        .unwrap_or(false))
             {
                 return Ok(RemoteSpec::Local(PathSpec {
                     path: PathBuf::from(s),

--- a/crates/cli/tests/drive_letters.rs
+++ b/crates/cli/tests/drive_letters.rs
@@ -1,0 +1,18 @@
+// crates/cli/tests/drive_letters.rs
+#![cfg(windows)]
+
+use oc_rsync_cli::{parse_remote_spec, RemoteSpec};
+
+#[test]
+fn drive_letter_without_separator_is_local() {
+    let spec = parse_remote_spec("C:").unwrap();
+    assert!(matches!(spec, RemoteSpec::Local(_)));
+}
+
+#[test]
+fn drive_letter_with_separator_is_local() {
+    for path in ["C:/", r"C:\"] {
+        let spec = parse_remote_spec(path).unwrap();
+        assert!(matches!(spec, RemoteSpec::Local(_)));
+    }
+}


### PR DESCRIPTION
## Summary
- expose path parsing types and treat bare drive letters like `C:` as local paths
- add Windows tests for drive letters with and without trailing separators

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b703dcf9648323a041e53d4d96dd90