### PR TITLE
Add header comment to help output test

### DIFF
--- a/tests/help_output.rs
+++ b/tests/help_output.rs
@@ -1,3 +1,4 @@
+// tests/help_output.rs
 use assert_cmd::Command;
 use std::fs;
 


### PR DESCRIPTION
## Summary
- add file header comment for help_output test

## Testing
- `cargo fmt --all`
- `UPSTREAM_VERSION=3.2.7 cargo clippy --all-targets --all-features -- -D warnings` *(fails: cannot find function `version_string`)*
- `UPSTREAM_VERSION=3.2.7 cargo test` *(fails: cannot find function `version_string`)*
- `UPSTREAM_VERSION=3.2.7 make verify-comments` *(fails: cannot find function `version_string`)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b70a6c0368832399ae9ee93507d752