### PR TITLE
test(meta): add ACL round-trip coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ cargo build -p oc-rsync-bin --bin oc-rsync
 cargo run -p oc-rsync-bin -- "<SRC>" "<DEST>"
 ```
 
+Support for preserving extended attributes and POSIX ACLs is gated behind
+optional Cargo features. Enable them at build time:
+
+```
+cargo build -p oc-rsync-bin --bin oc-rsync --features "xattr acl"
+```
+
 ## Packaging
 
 Release tarballs include sample files under `packaging/` to help run the

--- a/crates/meta/tests/chown_nonroot.rs
+++ b/crates/meta/tests/chown_nonroot.rs
@@ -1,6 +1,6 @@
 // crates/meta/tests/chown_nonroot.rs
 use std::fs::{self, Permissions};
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::process::Command;
 
 use meta::{Metadata, Options};

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -8,6 +8,19 @@ use nix::unistd::{chown, Gid, Uid};
 use std::time::SystemTime;
 use tempfile::tempdir;
 
+#[cfg(feature = "acl")]
+fn acl_to_io(err: posix_acl::ACLError) -> std::io::Error {
+    if let Some(ioe) = err.as_io_error() {
+        if let Some(code) = ioe.raw_os_error() {
+            std::io::Error::from_raw_os_error(code)
+        } else {
+            std::io::Error::new(ioe.kind(), ioe.to_string())
+        }
+    } else {
+        std::io::Error::other(err)
+    }
+}
+
 #[test]
 fn roundtrip_full_metadata() -> std::io::Result<()> {
     let dir = tempdir()?;
@@ -140,29 +153,41 @@ fn roundtrip_acl() -> std::io::Result<()> {
     fs::write(&src, b"hello")?;
     fs::write(&dst, b"world")?;
 
-    let mut acl = PosixACL::read_acl(&src).map_err(|e| {
-        if let Some(ioe) = e.as_io_error() {
-            if let Some(code) = ioe.raw_os_error() {
-                std::io::Error::from_raw_os_error(code)
-            } else {
-                std::io::Error::new(ioe.kind(), ioe.to_string())
-            }
-        } else {
-            std::io::Error::other(e)
-        }
-    })?;
+    let mut acl = PosixACL::read_acl(&src).map_err(acl_to_io)?;
     acl.set(Qualifier::User(12345), ACL_READ);
-    acl.write_acl(&src).map_err(|e| {
-        if let Some(ioe) = e.as_io_error() {
-            if let Some(code) = ioe.raw_os_error() {
-                std::io::Error::from_raw_os_error(code)
-            } else {
-                std::io::Error::new(ioe.kind(), ioe.to_string())
-            }
-        } else {
-            std::io::Error::other(e)
-        }
-    })?;
+    acl.write_acl(&src).map_err(acl_to_io)?;
+
+    let opts = Options {
+        acl: true,
+        ..Default::default()
+    };
+    let meta = Metadata::from_path(&src, opts.clone())?;
+    meta.apply(&dst, opts.clone())?;
+    let applied = Metadata::from_path(&dst, opts)?;
+
+    assert_eq!(meta.acl, applied.acl);
+    assert_eq!(meta.default_acl, applied.default_acl);
+    Ok(())
+}
+
+#[cfg(feature = "acl")]
+#[test]
+fn roundtrip_default_acl() -> std::io::Result<()> {
+    use posix_acl::{PosixACL, Qualifier, ACL_READ};
+
+    let dir = tempdir()?;
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::create_dir(&src)?;
+    fs::create_dir(&dst)?;
+
+    let mut acl = PosixACL::read_acl(&src).map_err(acl_to_io)?;
+    acl.set(Qualifier::User(12345), ACL_READ);
+    acl.write_acl(&src).map_err(acl_to_io)?;
+
+    let mut dacl = PosixACL::new(0o755);
+    dacl.set(Qualifier::Group(54321), ACL_READ);
+    dacl.write_default_acl(&src).map_err(acl_to_io)?;
 
     let opts = Options {
         acl: true,


### PR DESCRIPTION
## Summary
- document enabling optional xattr/ACL features at build time
- exercise ACL preservation including default directory ACLs
- fix chown_nonroot test imports

## Testing
- `cargo test` *(fails: environment variable `UPSTREAM_VERSION` not defined)*
- `cargo test -p meta --test roundtrip --all-features`
- `make verify-comments` *(fails: environment variable `UPSTREAM_VERSION` not defined)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b70a852d908323b43b25eb8047a389