### PR TITLE
Add MD4 checksum and expose negotiation

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -71,12 +71,7 @@ impl ChecksumConfig {
 #[allow(clippy::needless_borrows_for_generic_args)]
 pub fn strong_digest(data: &[u8], alg: StrongHash, seed: u32) -> Vec<u8> {
     match alg {
-        StrongHash::Md4 => {
-            let mut hasher = Md4::new();
-            hasher.update(&seed.to_le_bytes());
-            hasher.update(data);
-            hasher.finalize().to_vec()
-        }
+        StrongHash::Md4 => md4_digest(data, seed),
         StrongHash::Md5 => {
             let mut hasher = Md5::new();
             hasher.update(&seed.to_le_bytes());
@@ -90,6 +85,14 @@ pub fn strong_digest(data: &[u8], alg: StrongHash, seed: u32) -> Vec<u8> {
             hasher.finalize().to_vec()
         }
     }
+}
+
+#[inline]
+fn md4_digest(data: &[u8], seed: u32) -> Vec<u8> {
+    let mut hasher = Md4::new();
+    hasher.update(seed.to_le_bytes());
+    hasher.update(data);
+    hasher.finalize().to_vec()
 }
 
 pub fn rolling_checksum(data: &[u8]) -> u32 {

--- a/crates/checksums/tests/md4.rs
+++ b/crates/checksums/tests/md4.rs
@@ -1,0 +1,8 @@
+// crates/checksums/tests/md4.rs
+use checksums::{strong_digest, StrongHash};
+
+#[test]
+fn md4_seeded_digest() {
+    let digest = strong_digest(b"hello world", StrongHash::Md4, 1);
+    assert_eq!(hex::encode(digest), "92e5994e0babddace03f0ff88f767181");
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -140,6 +140,10 @@ pub fn version_banner() -> String {
     )
 }
 
+pub fn version_string() -> String {
+    version_banner()
+}
+
 pub fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFlag>) {
     let mut info: Vec<InfoFlag> = matches
         .get_many::<InfoFlag>("info")
@@ -1286,7 +1290,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     }
 
     if !rsync_env.iter().any(|(k, _)| k == "RSYNC_CHECKSUM_LIST") {
-        let list = ["md5", "sha1"];
+        let list = ["md4", "md5", "sha1"];
         rsync_env.push(("RSYNC_CHECKSUM_LIST".into(), list.join(",")));
     }
 

--- a/docs/spec/rsync.1
+++ b/docs/spec/rsync.1
@@ -2414,6 +2414,7 @@ various flavors of MD4 based on protocol age).
 The default order can be customized by setting the environment variable
 \f[V]RSYNC_CHECKSUM_LIST\f[R] to a space-separated list of acceptable
 checksum names.
+The default list is \f[V]md4\f[R], \f[V]md5\f[R], and \f[V]sha1\f[R].
 If the string contains a \[lq]\f[V]&\f[R]\[rq] character, it is
 separated into the \[lq]client string & server string\[rq], otherwise
 the same string applies to both.


### PR DESCRIPTION
## Summary
- add MD4 digest helper and expose selection through checksum negotiation
- document default checksum list and support
- test seeded MD4 digest

## Testing
- `UPSTREAM_VERSION=3.2.7 cargo clippy --all-targets --all-features -- -D warnings`
- `UPSTREAM_VERSION=3.2.7 cargo test -p checksums`
- `UPSTREAM_VERSION=3.2.7 make verify-comments`
- `UPSTREAM_VERSION=3.2.7 make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b70a71e038832398ebc13652197fc0