### PR TITLE
Support xattr and ACL metadata in filelist serialization

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -140,6 +140,14 @@ pub fn version_banner() -> String {
     )
 }
 
+pub fn version_string() -> String {
+    format!(
+        "rsync  version {}  protocol version {}\n",
+        env!("CARGO_PKG_VERSION"),
+        env!("UPSTREAM_VERSION")
+    )
+}
+
 pub fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFlag>) {
     let mut info: Vec<InfoFlag> = matches
         .get_many::<InfoFlag>("info")

--- a/crates/engine/tests/flist.rs
+++ b/crates/engine/tests/flist.rs
@@ -12,18 +12,27 @@ fn roundtrip() {
             uid: 1,
             gid: 2,
             group: None,
+            xattrs: vec![(b"user.test".to_vec(), b"1".to_vec())],
+            acl: vec![1, 0, 0, 0, 0, 7, 0, 0, 0],
+            default_acl: Vec::new(),
         },
         Entry {
             path: b"a/b".to_vec(),
             uid: 1,
             gid: 3,
             group: None,
+            xattrs: Vec::new(),
+            acl: Vec::new(),
+            default_acl: vec![1, 0, 0, 0, 0, 7, 0, 0, 0],
         },
         Entry {
             path: b"c".to_vec(),
             uid: 4,
             gid: 3,
             group: None,
+            xattrs: Vec::new(),
+            acl: Vec::new(),
+            default_acl: Vec::new(),
         },
     ];
     let payloads = flist::encode(&entries, None);
@@ -42,6 +51,9 @@ fn iconv_roundtrip() {
         uid: 0,
         gid: 0,
         group: None,
+        xattrs: Vec::new(),
+        acl: Vec::new(),
+        default_acl: Vec::new(),
     }];
     let payloads = flist::encode(&entries, Some(&cv));
     let decoded = flist::decode(&payloads, Some(&cv)).unwrap();
@@ -59,6 +71,9 @@ fn iconv_non_utf8_local_roundtrip() {
         uid: 0,
         gid: 0,
         group: None,
+        xattrs: Vec::new(),
+        acl: Vec::new(),
+        default_acl: Vec::new(),
     }];
     let payloads = flist::encode(&entries, Some(&cv));
     let decoded = flist::decode(&payloads, Some(&cv)).unwrap();

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -65,6 +65,9 @@ fn captured_frames_roundtrip() {
         uid: 0,
         gid: 0,
         group: None,
+        xattrs: vec![(b"user.test".to_vec(), b"1".to_vec())],
+        acl: vec![1, 0, 0, 0, 0, 7, 0, 0, 0],
+        default_acl: Vec::new(),
     };
     let mut fenc = FEncoder::new();
     let payload = fenc.encode_entry(&entry);
@@ -309,6 +312,9 @@ fn filelist_iconv_roundtrip() {
         uid: 0,
         gid: 0,
         group: None,
+        xattrs: Vec::new(),
+        acl: Vec::new(),
+        default_acl: Vec::new(),
     };
     let mut enc = FEncoder::new();
     let msg = Message::from_file_list(&entry, &mut enc, Some(&cv));

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -10,6 +10,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | Feature | Supported | Notes |
 | --- | --- | --- |
 | File list path-delta encoding with uid/gid tables | ✅ | Exercised via `filelist` tests |
+| File list xattr and ACL metadata | ✅ | Exercised via `filelist` tests |
 
 | Option | Supported | Parity (Y/N) | Message-parity (Y/N) | Parser-parity (Y/N) | Tests | Source | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -38,7 +38,7 @@ when available.
 | --- | --- | --- | --- |
 | Path-delta encoding with uid/gid tables | ✅ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
 | Group ID preservation | ⚠️ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
-| Extended attributes and ACL entries | ❌ | — | — |
+| Extended attributes and ACL entries | ✅ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
 
 ## Walk
 | Feature | Status | Tests | Source |


### PR DESCRIPTION
## Summary
- extend file list entries with xattr and ACL fields and round-trip encoding/decoding support
- cover new metadata in file list unit tests and engine/protocol fixtures
- document xattr/ACL file list support in gaps and feature matrix

## Testing
- `cargo clippy -p filelist --tests -- -D warnings`
- `UPSTREAM_VERSION=3.2.7 make verify-comments`
- `make lint`
- `cargo test -p filelist`
- `cargo test -p engine --test flist`
- `cargo test -p protocol --test protocol`


------
https://chatgpt.com/codex/tasks/task_e_68b70a7d02448323b6daf82204d68bac