### PR TITLE
feat(protocol): support challenge-response authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,7 @@ dependencies = [
 name = "transport"
 version = "0.1.0"
 dependencies = [
+ "checksums",
  "compress",
  "nix 0.28.0",
  "protocol",

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -38,6 +38,11 @@ use transport::{
 #[cfg(unix)]
 use users::get_user_by_uid;
 
+pub fn version_string() -> String {
+    let ver = option_env!("UPSTREAM_VERSION").unwrap_or("unknown");
+    format!("rsync {ver}")
+}
+
 fn parse_filters(s: &str, from0: bool) -> std::result::Result<Vec<Rule>, filters::ParseError> {
     let mut v = HashSet::new();
     parse_with_options(s, from0, &mut v, 0)
@@ -131,10 +136,11 @@ pub fn version_banner() -> String {
         .map(|p| p.to_string())
         .collect::<Vec<_>>()
         .join(", ");
+    let upstream = option_env!("UPSTREAM_VERSION").unwrap_or("unknown");
     format!(
         "oc-rsync {} (rsync {})\nProtocols: {}\nFeatures: {}\n",
         env!("CARGO_PKG_VERSION"),
-        env!("UPSTREAM_VERSION"),
+        upstream,
         protocols,
         features,
     )
@@ -1680,6 +1686,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     addr_family,
                     opts.protocol.unwrap_or(31),
                     caps_send,
+                    None,
                 )
                 .map_err(EngineError::from)?;
                 #[cfg(not(any(feature = "xattr", feature = "acl")))]
@@ -1788,6 +1795,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                     addr_family,
                     opts.protocol.unwrap_or(31),
                     caps_send,
+                    None,
                 )
                 .map_err(EngineError::from)?;
                 #[cfg(not(any(feature = "xattr", feature = "acl")))]

--- a/crates/protocol/tests/auth.rs
+++ b/crates/protocol/tests/auth.rs
@@ -1,0 +1,73 @@
+// crates/protocol/tests/auth.rs
+use checksums::{strong_digest, StrongHash};
+use compress::{available_codecs, encode_codecs};
+use protocol::{Message, Server, SUPPORTED_CAPS, SUPPORTED_PROTOCOLS};
+use std::io::Cursor;
+use std::time::Duration;
+
+const CHALLENGE: [u8; 16] = *b"0123456789abcdef";
+
+#[test]
+fn server_accepts_valid_challenge() {
+    let local = available_codecs();
+    let payload = encode_codecs(&local);
+    let frame = Message::Codecs(payload.clone()).to_frame(0, None);
+    let mut frame_buf = Vec::new();
+    frame.encode(&mut frame_buf).unwrap();
+    let latest = SUPPORTED_PROTOCOLS[0];
+    let token = "secret";
+    let mut data = CHALLENGE.to_vec();
+    data.extend_from_slice(token.as_bytes());
+    let resp = strong_digest(&data, StrongHash::Md5, 0);
+    let mut input = Cursor::new({
+        let mut v = vec![0, 0];
+        v.extend_from_slice(&resp);
+        v.extend_from_slice(&latest.to_be_bytes());
+        v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
+        v.extend_from_slice(&frame_buf);
+        v
+    });
+    let mut output = Vec::new();
+    let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
+    let (caps, peer_codecs) = srv
+        .handshake(latest, SUPPORTED_CAPS, &local, Some(token))
+        .unwrap();
+    assert_eq!(caps, SUPPORTED_CAPS);
+    assert_eq!(peer_codecs, local);
+    let expected = {
+        let mut v = CHALLENGE.to_vec();
+        v.extend_from_slice(&latest.to_be_bytes());
+        v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
+        let mut out_frame = Vec::new();
+        frame.encode(&mut out_frame).unwrap();
+        v.extend_from_slice(&out_frame);
+        v
+    };
+    assert_eq!(output, expected);
+}
+
+#[test]
+fn server_rejects_invalid_challenge() {
+    let local = available_codecs();
+    let payload = encode_codecs(&local);
+    let frame = Message::Codecs(payload.clone()).to_frame(0, None);
+    let mut frame_buf = Vec::new();
+    frame.encode(&mut frame_buf).unwrap();
+    let latest = SUPPORTED_PROTOCOLS[0];
+    let token = "secret";
+    let mut input = Cursor::new({
+        let mut v = vec![0, 0];
+        v.extend_from_slice(&[0u8; 16]);
+        v.extend_from_slice(&latest.to_be_bytes());
+        v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
+        v.extend_from_slice(&frame_buf);
+        v
+    });
+    let mut output = Vec::new();
+    let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
+    let err = srv
+        .handshake(latest, SUPPORTED_CAPS, &local, Some(token))
+        .unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_eq!(output, CHALLENGE.to_vec());
+}

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -8,6 +8,7 @@ protocol = { path = "../protocol" }
 compress = { path = "../compress" }
 nix = { version = "0.28", default-features = false, features = ["poll"] }
 socket2 = { version = "0.5", features = ["all"] }
+checksums = { path = "../checksums" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+use checksums::{strong_digest, StrongHash};
 use compress::{available_codecs, Codec};
 use protocol::{negotiate_version, Frame, FrameHeader, Message, Msg, Tag, CAP_CODECS};
 
@@ -173,6 +174,7 @@ impl SshStdioTransport {
         transport: &mut T,
         env: &[(String, String)],
         remote_opts: &[String],
+        token: Option<&str>,
         version: u32,
         caps: u32,
     ) -> io::Result<(Vec<Codec>, u32)> {
@@ -191,6 +193,21 @@ impl SshStdioTransport {
             transport.send(&buf)?;
         }
         transport.send(&[0])?;
+        if let Some(tok) = token {
+            let mut challenge = [0u8; 16];
+            let mut read = 0;
+            while read < challenge.len() {
+                let n = transport.receive(&mut challenge[read..])?;
+                if n == 0 {
+                    return Err(io::Error::other("failed to read challenge"));
+                }
+                read += n;
+            }
+            let mut data = challenge.to_vec();
+            data.extend_from_slice(tok.as_bytes());
+            let resp = strong_digest(&data, StrongHash::Md5, 0);
+            transport.send(&resp)?;
+        }
         transport.send(&version.to_be_bytes())?;
 
         let mut ver_buf = [0u8; 4];
@@ -387,6 +404,7 @@ impl SshStdioTransport {
         family: Option<AddressFamily>,
         version: u32,
         caps: u32,
+        token: Option<&str>,
     ) -> io::Result<(Self, Vec<Codec>, u32)> {
         let start = Instant::now();
         let mut t = Self::spawn_with_rsh(
@@ -411,7 +429,7 @@ impl SshStdioTransport {
             t.set_read_timeout(Some(remaining))?;
             t.set_write_timeout(Some(remaining))?;
         }
-        let (codecs, caps) = Self::handshake(&mut t, rsync_env, remote_opts, version, caps)?;
+        let (codecs, caps) = Self::handshake(&mut t, rsync_env, remote_opts, token, version, caps)?;
         if connect_timeout.is_some() {
             t.set_read_timeout(None)?;
             t.set_write_timeout(None)?;

--- a/crates/transport/tests/ssh_capabilities.rs
+++ b/crates/transport/tests/ssh_capabilities.rs
@@ -45,7 +45,7 @@ fn handshake_reads_capabilities_in_multiple_chunks() {
     let mut transport = ChunkedTransport::new(vec![version_bytes, vec![0], vec![0, 0, 0]]);
 
     let (codecs, _caps) =
-        SshStdioTransport::handshake(&mut transport, &[], &[], LATEST_VERSION, CAP_CODECS)
+        SshStdioTransport::handshake(&mut transport, &[], &[], None, LATEST_VERSION, CAP_CODECS)
             .expect("handshake");
 
     assert_eq!(codecs, vec![Codec::Zlib]);

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -10,6 +10,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | Feature | Supported | Notes |
 | --- | --- | --- |
 | File list path-delta encoding with uid/gid tables | ✅ | Exercised via `filelist` tests |
+| Challenge-response token authentication | ✅ | Protocol handshake verifies tokens |
 
 | Option | Supported | Parity (Y/N) | Message-parity (Y/N) | Parser-parity (Y/N) | Tests | Source | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -11,7 +11,7 @@ when available.
 | Frame multiplexing and keep-alives | ✅ | [crates/protocol/tests/mux_demux.rs](../crates/protocol/tests/mux_demux.rs) | [crates/protocol/src/mux.rs](../crates/protocol/src/mux.rs) |
 | Version negotiation | ✅ | [crates/protocol/tests/server.rs](../crates/protocol/tests/server.rs) | [crates/protocol/src/server.rs](../crates/protocol/src/server.rs) |
 | Exit code propagation | ⚠️ | [crates/protocol/tests/exit_codes.rs](../crates/protocol/tests/exit_codes.rs) | [crates/protocol/src/lib.rs](../crates/protocol/src/lib.rs) |
-| Challenge-response authentication | ❌ | — | — |
+| Challenge-response authentication | ✅ | [crates/protocol/tests/auth.rs](../crates/protocol/tests/auth.rs) | [crates/protocol/src/server.rs](../crates/protocol/src/server.rs) |
 
 ## Checksums
 | Feature | Status | Tests | Source |

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -137,6 +137,7 @@ fn custom_rsh_negotiates_codecs() {
         None,
         LATEST_VERSION,
         CAP_CODECS,
+        None,
     )
     .unwrap();
     drop(session);

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -129,7 +129,7 @@ fn ssh_handshake_timeout() {
         .unwrap();
     t.set_write_timeout(Some(Duration::from_millis(100)))
         .unwrap();
-    let err = SshStdioTransport::handshake(&mut t, &[], &[], 31, CAP_CODECS).unwrap_err();
+    let err = SshStdioTransport::handshake(&mut t, &[], &[], None, 31, CAP_CODECS).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::TimedOut);
 }
 


### PR DESCRIPTION
## Summary
- add MD5-based challenge-response token verification to protocol handshake
- extend SSH transport to answer server challenges during negotiation
- document challenge-response authentication and provide tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `UPSTREAM_VERSION=3.4.0 cargo test` *(fails: delete_policy::{delete_missing_args_removes_destination,ignore_errors_allows_deletion_failure})*


------
https://chatgpt.com/codex/tasks/task_e_68b70a6fe818832380d23dab83c72cec