### PR TITLE
Add batch replay support

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -140,6 +140,14 @@ pub fn version_banner() -> String {
     )
 }
 
+pub fn version_string() -> String {
+    format!(
+        "rsync  version {}  protocol version {}\n",
+        env!("CARGO_PKG_VERSION"),
+        env!("UPSTREAM_VERSION")
+    )
+}
+
 pub fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFlag>) {
     let mut info: Vec<InfoFlag> = matches
         .get_many::<InfoFlag>("info")
@@ -707,6 +715,8 @@ struct ClientOpts {
     iconv: Option<String>,
     #[arg(long = "write-batch", value_name = "FILE", help_heading = "Misc")]
     write_batch: Option<PathBuf>,
+    #[arg(long = "read-batch", value_name = "FILE", help_heading = "Misc")]
+    read_batch: Option<PathBuf>,
     #[arg(long = "copy-devices", help_heading = "Misc")]
     copy_devices: bool,
     #[arg(
@@ -1568,6 +1578,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         sockopts: opts.sockopts.clone(),
         remote_options: remote_opts.clone(),
         write_batch: opts.write_batch.clone(),
+        read_batch: opts.read_batch.clone(),
         copy_devices: opts.copy_devices,
         write_devices: opts.write_devices,
         fsync: opts.fsync,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1754,6 +1754,7 @@ pub struct SyncOptions {
     pub sockopts: Vec<String>,
     pub remote_options: Vec<String>,
     pub write_batch: Option<PathBuf>,
+    pub read_batch: Option<PathBuf>,
     pub copy_devices: bool,
     pub write_devices: bool,
     pub quiet: bool,
@@ -1851,6 +1852,7 @@ impl Default for SyncOptions {
             sockopts: Vec::new(),
             remote_options: Vec::new(),
             write_batch: None,
+            read_batch: None,
             copy_devices: false,
             write_devices: false,
             quiet: false,
@@ -2155,6 +2157,38 @@ pub fn sync(
     let mut receiver = Receiver::new(codec, opts.clone());
     receiver.matcher = matcher.clone();
     let mut dir_meta: Vec<(PathBuf, PathBuf)> = Vec::new();
+
+    if let Some(batch_path) = &opts.read_batch {
+        sender.start();
+        let content =
+            fs::read_to_string(batch_path).map_err(|e| EngineError::Other(e.to_string()))?;
+        for line in content.lines() {
+            if line.trim().is_empty() || line.contains('=') {
+                continue;
+            }
+            let rel = Path::new(line);
+            let path = src_root.join(rel);
+            if !path.exists() {
+                continue;
+            }
+            let dest_path = dst.join(rel);
+            if sender.process_file(&path, &dest_path, rel, &mut receiver)? {
+                stats.files_transferred += 1;
+                stats.bytes_transferred +=
+                    fs::metadata(&path).map_err(|e| io_context(&path, e))?.len();
+            }
+        }
+        sender.finish();
+        receiver.finalize()?;
+        if let Some(mut f) = batch_file {
+            let _ = writeln!(
+                f,
+                "files_transferred={} bytes_transferred={}",
+                stats.files_transferred, stats.bytes_transferred
+            );
+        }
+        return Ok(stats);
+    }
     if matches!(opts.delete, Some(DeleteMode::Before)) {
         delete_extraneous(&src_root, dst, &matcher, opts, &mut stats)?;
     }

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -166,5 +166,6 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--version` | ✅ | N | N | N | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--whole-file` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--write-batch` | ✅ | Y | Y | Y | [tests/write_batch.rs](../tests/write_batch.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `--read-batch` | ✅ | Y | Y | Y | [tests/write_batch.rs](../tests/write_batch.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--write-devices` | ✅ | Y | Y | Y | [tests/write_devices.rs](../tests/write_devices.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | writes to existing devices |
 | `--xattrs` | ✅ | N | N | N | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs)<br>[tests/daemon_sync_attrs.rs](../tests/daemon_sync_attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires `xattr` feature |

--- a/tests/write_batch.rs
+++ b/tests/write_batch.rs
@@ -28,3 +28,41 @@ fn creates_batch_file() {
     assert!(log.contains("files_transferred=1"));
     assert!(log.contains("bytes_transferred=4"));
 }
+
+#[test]
+fn replays_batch_file() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(src.join("f"), b"data").unwrap();
+    let dst1 = dir.path().join("dst1");
+    let batch = dir.path().join("batch.txt");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--write-batch",
+            batch.to_str().unwrap(),
+            "-r",
+            src.to_str().unwrap(),
+            dst1.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    fs::write(src.join("g"), b"new").unwrap();
+    let dst2 = dir.path().join("dst2");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--local",
+            "--read-batch",
+            batch.to_str().unwrap(),
+            "-r",
+            src.to_str().unwrap(),
+            dst2.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(dst2.join("src/f").exists());
+    assert!(!dst2.join("src/g").exists());
+}


### PR DESCRIPTION
## Summary
- support reading batch file during sync
- allow `--read-batch` flag in CLI
- test writing and replaying batch logs

## Testing
- `UPSTREAM_VERSION=3.2.7 cargo test` *(fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*
- `UPSTREAM_VERSION=3.2.7 make verify-comments`
- `UPSTREAM_VERSION=3.2.7 make lint`
- `UPSTREAM_VERSION=3.2.7 cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b70a8e99208323a4f7df2580700a79