### PR TITLE
feat(logging): add syslog and journald outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ name = "logging"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -68,6 +68,8 @@ fn main() {
         .unwrap_or(&LogFormat::Text);
     let log_file = matches.get_one::<PathBuf>("client-log-file").cloned();
     let log_file_fmt = matches.get_one::<String>("client-log-file-format").cloned();
+    let log_syslog = matches.get_flag("syslog");
+    let log_journald = matches.get_flag("journald");
     logging::init(
         log_format,
         verbose,
@@ -75,6 +77,8 @@ fn main() {
         &debug,
         quiet,
         log_file.map(|p| (p, log_file_fmt)),
+        log_syslog,
+        log_journald,
     );
     if let Err(e) = oc_rsync_cli::run(&matches) {
         eprintln!("{e}");

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -251,6 +251,10 @@ struct ClientOpts {
         id = "client-log-file-format"
     )]
     log_file_format: Option<String>,
+    #[arg(long, help_heading = "Output", env = "OC_RSYNC_SYSLOG")]
+    syslog: bool,
+    #[arg(long, help_heading = "Output", env = "OC_RSYNC_JOURNALD")]
+    journald: bool,
     #[arg(long = "out-format", value_name = "FORMAT", help_heading = "Output")]
     out_format: Option<String>,
     #[arg(

--- a/crates/cli/tests/logging_flags.rs
+++ b/crates/cli/tests/logging_flags.rs
@@ -40,7 +40,9 @@ fn verbose_and_log_format_json_parity() {
     let log_format = *matches
         .get_one::<logging::LogFormat>("log_format")
         .unwrap_or(&logging::LogFormat::Text);
-    logging::init(log_format, verbose, &info, &debug, false, None);
+    logging::init(
+        log_format, verbose, &info, &debug, false, None, false, false,
+    );
     oc_rsync_cli::run(&matches).unwrap();
 }
 
@@ -50,7 +52,16 @@ fn info_flag_enables_progress() {
         .try_get_matches_from(["oc-rsync", "--info=progress", "src", "dst"])
         .unwrap();
     let (info, _) = parse_logging_flags(&matches);
-    let sub = logging::subscriber(logging::LogFormat::Text, 0, &info, &[], false, None);
+    let sub = logging::subscriber(
+        logging::LogFormat::Text,
+        0,
+        &info,
+        &[],
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(!tracing::enabled!(Level::INFO));
         assert!(!tracing::enabled!(Level::DEBUG));
@@ -72,7 +83,16 @@ fn info_flag_enables_progress2() {
         .unwrap();
     let (info, _) = parse_logging_flags(&matches);
     assert!(info.contains(&logging::InfoFlag::Progress2));
-    let sub = logging::subscriber(logging::LogFormat::Text, 0, &info, &[], false, None);
+    let sub = logging::subscriber(
+        logging::LogFormat::Text,
+        0,
+        &info,
+        &[],
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(tracing::enabled!(
             target: logging::InfoFlag::Progress.target(),
@@ -88,7 +108,16 @@ fn info_flag_enables_stats3() {
         .unwrap();
     let (info, _) = parse_logging_flags(&matches);
     assert!(info.contains(&logging::InfoFlag::Stats3));
-    let sub = logging::subscriber(logging::LogFormat::Text, 0, &info, &[], false, None);
+    let sub = logging::subscriber(
+        logging::LogFormat::Text,
+        0,
+        &info,
+        &[],
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(tracing::enabled!(
             target: logging::InfoFlag::Stats.target(),
@@ -103,7 +132,16 @@ fn debug_flag_enables_flist() {
         .try_get_matches_from(["oc-rsync", "--debug=flist", "src", "dst"])
         .unwrap();
     let (_, debug) = parse_logging_flags(&matches);
-    let sub = logging::subscriber(logging::LogFormat::Text, 0, &[], &debug, false, None);
+    let sub = logging::subscriber(
+        logging::LogFormat::Text,
+        0,
+        &[],
+        &debug,
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(!tracing::enabled!(Level::TRACE));
         assert!(tracing::enabled!(
@@ -147,17 +185,44 @@ fn all_info_flags_parse() {
 
 #[test]
 fn verbose_levels_map_to_tracing() {
-    let sub = logging::subscriber(logging::LogFormat::Text, 1, &[], &[], false, None);
+    let sub = logging::subscriber(
+        logging::LogFormat::Text,
+        1,
+        &[],
+        &[],
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
         assert!(!tracing::enabled!(Level::DEBUG));
     });
-    let sub = logging::subscriber(logging::LogFormat::Text, 2, &[], &[], false, None);
+    let sub = logging::subscriber(
+        logging::LogFormat::Text,
+        2,
+        &[],
+        &[],
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
         assert!(!tracing::enabled!(Level::TRACE));
     });
-    let sub = logging::subscriber(logging::LogFormat::Text, 3, &[], &[], false, None);
+    let sub = logging::subscriber(
+        logging::LogFormat::Text,
+        3,
+        &[],
+        &[],
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(tracing::enabled!(Level::TRACE));
     });
@@ -176,7 +241,16 @@ fn quiet_overrides_logging_flags() {
         ])
         .unwrap();
     let (info, debug) = parse_logging_flags(&matches);
-    let sub = logging::subscriber(logging::LogFormat::Text, 0, &info, &debug, true, None);
+    let sub = logging::subscriber(
+        logging::LogFormat::Text,
+        0,
+        &info,
+        &debug,
+        true,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(!tracing::enabled!(Level::INFO));
         assert!(!tracing::enabled!(Level::DEBUG));

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 clap = { version = "4", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3"
+

--- a/crates/logging/tests/journald.rs
+++ b/crates/logging/tests/journald.rs
@@ -1,0 +1,23 @@
+// crates/logging/tests/journald.rs
+use logging::{subscriber, LogFormat};
+use std::os::unix::net::UnixDatagram;
+use tempfile::tempdir;
+use tracing::info;
+use tracing::subscriber::with_default;
+
+#[test]
+fn journald_emits_message() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("sock");
+    let server = UnixDatagram::bind(&path).unwrap();
+    std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path);
+    let sub = subscriber(LogFormat::Text, 0, &[], &[], false, None, false, true);
+    with_default(sub, || {
+        info!(target: "test", "hi");
+    });
+    let mut buf = [0u8; 256];
+    let (n, _) = server.recv_from(&mut buf).unwrap();
+    let msg = std::str::from_utf8(&buf[..n]).unwrap();
+    assert!(msg.contains("MESSAGE=hi"));
+    std::env::remove_var("OC_RSYNC_JOURNALD_PATH");
+}

--- a/crates/logging/tests/levels.rs
+++ b/crates/logging/tests/levels.rs
@@ -5,7 +5,7 @@ use tracing::Level;
 
 #[test]
 fn info_not_emitted_by_default() {
-    let sub = subscriber(LogFormat::Text, 0, &[], &[], false, None);
+    let sub = subscriber(LogFormat::Text, 0, &[], &[], false, None, false, false);
     with_default(sub, || {
         assert!(!tracing::enabled!(Level::INFO));
     });
@@ -13,7 +13,7 @@ fn info_not_emitted_by_default() {
 
 #[test]
 fn verbose_enables_info() {
-    let sub = subscriber(LogFormat::Text, 1, &[], &[], false, None);
+    let sub = subscriber(LogFormat::Text, 1, &[], &[], false, None, false, false);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -21,7 +21,16 @@ fn verbose_enables_info() {
 
 #[test]
 fn debug_enables_debug() {
-    let sub = subscriber(LogFormat::Text, 0, &[], &[DebugFlag::Flist], false, None);
+    let sub = subscriber(
+        LogFormat::Text,
+        0,
+        &[],
+        &[DebugFlag::Flist],
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -29,7 +38,7 @@ fn debug_enables_debug() {
 
 #[test]
 fn debug_with_two_v() {
-    let sub = subscriber(LogFormat::Text, 2, &[], &[], false, None);
+    let sub = subscriber(LogFormat::Text, 2, &[], &[], false, None, false, false);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -37,7 +46,16 @@ fn debug_with_two_v() {
 
 #[test]
 fn info_flag_enables_info() {
-    let sub = subscriber(LogFormat::Text, 0, &[InfoFlag::Progress], &[], false, None);
+    let sub = subscriber(
+        LogFormat::Text,
+        0,
+        &[InfoFlag::Progress],
+        &[],
+        false,
+        None,
+        false,
+        false,
+    );
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -45,7 +63,7 @@ fn info_flag_enables_info() {
 
 #[test]
 fn json_verbose_enables_info() {
-    let sub = subscriber(LogFormat::Json, 1, &[], &[], false, None);
+    let sub = subscriber(LogFormat::Json, 1, &[], &[], false, None, false, false);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });

--- a/crates/logging/tests/syslog.rs
+++ b/crates/logging/tests/syslog.rs
@@ -1,0 +1,23 @@
+// crates/logging/tests/syslog.rs
+use logging::{subscriber, LogFormat};
+use std::os::unix::net::UnixDatagram;
+use tempfile::tempdir;
+use tracing::info;
+use tracing::subscriber::with_default;
+
+#[test]
+fn syslog_emits_message() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("sock");
+    let server = UnixDatagram::bind(&path).unwrap();
+    std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path);
+    let sub = subscriber(LogFormat::Text, 0, &[], &[], false, None, true, false);
+    with_default(sub, || {
+        info!(target: "test", "hello");
+    });
+    let mut buf = [0u8; 256];
+    let (n, _) = server.recv_from(&mut buf).unwrap();
+    let msg = std::str::from_utf8(&buf[..n]).unwrap();
+    assert!(msg.contains("hello"));
+    std::env::remove_var("OC_RSYNC_SYSLOG_PATH");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,8 @@ pub fn synchronize_with_config(src: &Path, dst: &Path, cfg: &SyncConfig) -> Resu
         &cfg.debug,
         false,
         None,
+        false,
+        false,
     );
     with_default(sub, || -> Result<()> {
         let opts = SyncOptions {


### PR DESCRIPTION
## Summary
- support optional syslog and journald logging sinks
- expose `--syslog` and `--journald` flags (also via env vars)
- test syslog and journald emission via unix sockets

## Testing
- `UPSTREAM_VERSION=3.2.7 cargo test` *(fails: delete_policy tests)*
- `UPSTREAM_VERSION=3.2.7 make verify-comments`
- `UPSTREAM_VERSION=3.2.7 make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b70aa727288323a20d14e26b4d32e9