### PR TITLE
Refactor version handling into reusable module

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,8 +1,9 @@
 // bin/oc-rsync/src/main.rs
+mod version;
 use logging::LogFormat;
 use std::{io::ErrorKind, path::PathBuf};
 
-use oc_rsync_cli::{cli_command, parse_logging_flags, version_banner, EngineError};
+use oc_rsync_cli::{cli_command, parse_logging_flags, EngineError};
 use protocol::ExitCode;
 
 fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
@@ -16,7 +17,7 @@ fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
 fn main() {
     if std::env::args().any(|a| a == "--version" || a == "-V") {
         if !std::env::args().any(|a| a == "--quiet" || a == "-q") {
-            print!("{}", version_banner());
+            print!("{}", version::version_banner());
         }
         return;
     }

--- a/bin/oc-rsync/src/version.rs
+++ b/bin/oc-rsync/src/version.rs
@@ -1,0 +1,38 @@
+// bin/oc-rsync/src/version.rs
+use protocol::SUPPORTED_PROTOCOLS;
+
+#[allow(clippy::vec_init_then_push)]
+pub fn render_version_lines() -> Vec<String> {
+    let mut lines = Vec::new();
+    let upstream = option_env!("UPSTREAM_VERSION").unwrap_or("unknown");
+    lines.push(format!(
+        "oc-rsync {} (rsync {})",
+        env!("CARGO_PKG_VERSION"),
+        upstream,
+    ));
+    let protocols = SUPPORTED_PROTOCOLS
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    lines.push(format!("Protocols: {protocols}"));
+    #[allow(unused_mut)]
+    let mut features: Vec<&str> = Vec::new();
+    #[cfg(feature = "xattr")]
+    features.push("xattr");
+    #[cfg(feature = "acl")]
+    features.push("acl");
+    let features = if features.is_empty() {
+        "none".to_string()
+    } else {
+        features.join(", ")
+    };
+    lines.push(format!("Features: {features}"));
+    lines
+}
+
+pub fn version_banner() -> String {
+    let mut lines = render_version_lines();
+    lines.push(String::new());
+    lines.join("\n")
+}

--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -42,7 +42,7 @@ pub fn render_help(cmd: &Command) -> String {
     let wrap_opts = WrapOptions::new(desc_width).break_words(false);
 
     let mut out = String::new();
-    out.push_str(&crate::version_string());
+    out.push_str(&crate::version::version_banner());
     out.push_str(HELP_PREFIX);
 
     for arg in cmd.get_arguments() {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -38,9 +38,8 @@ use transport::{
 #[cfg(unix)]
 use users::get_user_by_uid;
 
-pub fn version_string() -> String {
-    let ver = option_env!("UPSTREAM_VERSION").unwrap_or("unknown");
-    format!("rsync {ver}")
+pub mod version {
+    include!("../../../bin/oc-rsync/src/version.rs");
 }
 
 fn parse_filters(s: &str, from0: bool) -> std::result::Result<Vec<Rule>, filters::ParseError> {
@@ -116,47 +115,6 @@ fn parse_bool(s: &str) -> std::result::Result<bool, String> {
         "1" | "true" | "yes" => Ok(true),
         _ => Err("invalid boolean".to_string()),
     }
-}
-
-pub fn version_string() -> String {
-    format!(
-        "oc-rsync {} (rsync {})\n",
-        env!("CARGO_PKG_VERSION"),
-        env!("UPSTREAM_VERSION"),
-    )
-}
-
-#[allow(clippy::vec_init_then_push)]
-pub fn version_banner() -> String {
-    #[allow(unused_mut)]
-    let mut features: Vec<&str> = Vec::new();
-    #[cfg(feature = "xattr")]
-    features.push("xattr");
-    #[cfg(feature = "acl")]
-    features.push("acl");
-    let features = if features.is_empty() {
-        "none".to_string()
-    } else {
-        features.join(", ")
-    };
-    let protocols = SUPPORTED_PROTOCOLS
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
-    let upstream = option_env!("UPSTREAM_VERSION").unwrap_or("unknown");
-    format!(
-        version_string(),
-        "oc-rsync {} (rsync {})\nProtocols: {}\nFeatures: {}\n",
-        env!("CARGO_PKG_VERSION"),
-        upstream,
-        protocols,
-        features,
-    )
-}
-
-pub fn version_string() -> String {
-    version_banner()
 }
 
 pub fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFlag>) {

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -1,5 +1,5 @@
 // crates/cli/tests/version.rs
-use oc_rsync_cli::version_banner;
+use oc_rsync_cli::version;
 use protocol::SUPPORTED_PROTOCOLS;
 
 #[test]
@@ -19,12 +19,14 @@ fn banner_is_static() {
         .map(|p| p.to_string())
         .collect::<Vec<_>>()
         .join(", ");
-    let expected = format!(
-        "oc-rsync {} (rsync {})\nProtocols: {}\nFeatures: {}\n",
-        env!("CARGO_PKG_VERSION"),
-        env!("UPSTREAM_VERSION"),
-        protocols,
-        features,
-    );
-    assert_eq!(version_banner(), expected);
+    let expected = vec![
+        format!(
+            "oc-rsync {} (rsync {})",
+            env!("CARGO_PKG_VERSION"),
+            env!("UPSTREAM_VERSION"),
+        ),
+        format!("Protocols: {protocols}"),
+        format!("Features: {features}"),
+    ];
+    assert_eq!(version::render_version_lines(), expected);
 }

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -299,6 +299,7 @@ where
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn subscriber(
     format: LogFormat,
     verbose: u8,
@@ -387,6 +388,7 @@ pub fn subscriber(
     Box::new(registry)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn init(
     format: LogFormat,
     verbose: u8,

--- a/src/bin/version/mod.rs
+++ b/src/bin/version/mod.rs
@@ -1,0 +1,2 @@
+// src/bin/version/mod.rs
+include!(concat!(env!("CARGO_MANIFEST_DIR"), "/bin/oc-rsync/src/version.rs"));


### PR DESCRIPTION
## Summary
- centralize version information in `bin/oc-rsync/src/version.rs`
- expose version helpers via `oc_rsync_cli::version` and update consumers
- refresh version test to use `render_version_lines`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `UPSTREAM_VERSION=3.2.7 cargo test` *(hangs: `sparse_files_preserved` runs over 60s)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b714c3c47c83238c71ac6db6381e0d