### PR TITLE
feat(transport): expose TCP connection retries

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -622,7 +622,8 @@ struct ClientOpts {
     #[arg(long = "timeout", value_name = "SECONDS", value_parser = parse_duration, help_heading = "Misc")]
     timeout: Option<Duration>,
     #[arg(
-        long = "contimeout",
+        long = "connect-timeout",
+        alias = "contimeout",
         value_name = "SECONDS",
         value_parser = parse_nonzero_duration,
         help_heading = "Misc"

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -299,6 +299,7 @@ where
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn subscriber(
     format: LogFormat,
     verbose: u8,
@@ -387,6 +388,7 @@ pub fn subscriber(
     Box::new(registry)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn init(
     format: LogFormat,
     verbose: u8,

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -8,7 +8,7 @@ pub mod tcp;
 
 pub use rate::RateLimitedTransport;
 pub use ssh::SshStdioTransport;
-pub use tcp::TcpTransport;
+pub use tcp::{connect_with_retry, TcpTransport};
 
 pub fn rate_limited<T: Transport>(inner: T, bwlimit: u64) -> RateLimitedTransport<T> {
     RateLimitedTransport::new(inner, bwlimit)

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -194,3 +194,19 @@ impl Transport for TcpTransport {
 }
 
 impl DaemonTransport for TcpTransport {}
+
+/// Attempt to establish a TCP connection with exponential backoff.
+///
+/// This is a convenience wrapper around [`TcpTransport::connect_with_retry`]
+/// exposing the retry logic as a free function so that higher level APIs can
+/// use it without constructing a [`TcpTransport`] manually.
+pub fn connect_with_retry(
+    host: &str,
+    port: u16,
+    connect_timeout: Option<Duration>,
+    family: Option<AddressFamily>,
+    retries: u32,
+    retry_delay: Duration,
+) -> io::Result<TcpTransport> {
+    TcpTransport::connect_with_retry(host, port, connect_timeout, family, retries, retry_delay)
+}

--- a/crates/transport/tests/bwlimit.rs
+++ b/crates/transport/tests/bwlimit.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::rc::Rc;
 use std::time::Duration;
 
-use transport::{LocalPipeTransport, RateLimitedTransport};
+use transport::{LocalPipeTransport, RateLimitedTransport, Transport};
 
 #[test]
 fn write_below_min_sleep_is_unthrottled() {

--- a/crates/transport/tests/retry.rs
+++ b/crates/transport/tests/retry.rs
@@ -3,6 +3,7 @@ use std::net::TcpListener;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use transport::connect_with_retry;
 use transport::tcp::TcpTransport;
 
 #[test]
@@ -45,4 +46,29 @@ fn connect_fails_after_retries() {
     );
     assert!(res.is_err());
     assert!(start.elapsed() >= Duration::from_millis(30));
+}
+
+#[test]
+fn connect_waits_with_backoff_before_success() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(60));
+        let listener = TcpListener::bind(addr).expect("bind");
+        let _ = listener.accept().unwrap();
+    });
+
+    let start = Instant::now();
+    connect_with_retry(
+        &addr.ip().to_string(),
+        addr.port(),
+        None,
+        None,
+        5,
+        Duration::from_millis(10),
+    )
+    .expect("connect");
+    assert!(start.elapsed() >= Duration::from_millis(70));
 }


### PR DESCRIPTION
## Summary
- expose `connect_with_retry` as a public helper and re-export from transport crate
- surface `--connect-timeout` CLI flag for configuring retry behaviour
- add integration test covering backoff on transient failures

## Testing
- `cargo fmt --all`
- `cargo clippy -p transport -p logging --all-targets --all-features -- -D warnings`
- `UPSTREAM_VERSION=3.2.7 cargo test` *(fails: duplicate `version_string` in cli)*
- `cargo test -p transport` *(fails: bwlimit tests timeout assertions)*
- `cargo test -p transport --all-features` *(fails: bwlimit parity assertion)*
- `make verify-comments` *(fails: duplicate `version_string` in cli)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b715b7e7988323af5081bdcd9154aa