### PR TITLE
Add rsync-style logging formatter

### DIFF
--- a/crates/logging/src/formatter.rs
+++ b/crates/logging/src/formatter.rs
@@ -1,0 +1,113 @@
+// crates/logging/src/formatter.rs
+use std::fmt;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::fmt::{format::Writer, FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::registry::LookupSpan;
+
+pub struct RsyncFormatter;
+
+impl RsyncFormatter {
+    fn columns() -> usize {
+        std::env::var("COLUMNS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|&c| c > 0)
+            .unwrap_or(80)
+    }
+
+    fn wrap(msg: &str, width: usize) -> String {
+        let mut out = String::new();
+        let mut line_len = 0usize;
+        for word in msg.split_whitespace() {
+            let wlen = word.len();
+            if line_len == 0 {
+                out.push_str(word);
+                line_len = wlen;
+            } else if line_len + 1 + wlen > width {
+                out.push('\n');
+                out.push_str(word);
+                line_len = wlen;
+            } else {
+                out.push(' ');
+                out.push_str(word);
+                line_len += 1 + wlen;
+            }
+        }
+        out
+    }
+}
+
+struct MsgVisitor {
+    msg: String,
+}
+
+impl MsgVisitor {
+    fn new() -> Self {
+        Self { msg: String::new() }
+    }
+}
+
+impl Visit for MsgVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "message" {
+            if !self.msg.is_empty() {
+                self.msg.push(' ');
+            }
+            self.msg.push_str(value);
+        } else {
+            if !self.msg.is_empty() {
+                self.msg.push(' ');
+            }
+            self.msg.push_str(field.name());
+            self.msg.push('=');
+            self.msg.push_str(value);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if field.name() == "message" {
+            if !self.msg.is_empty() {
+                self.msg.push(' ');
+            }
+            self.msg.push_str(&format!("{value:?}"));
+        } else {
+            if !self.msg.is_empty() {
+                self.msg.push(' ');
+            }
+            self.msg.push_str(field.name());
+            self.msg.push('=');
+            self.msg.push_str(&format!("{value:?}"));
+        }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for RsyncFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        _ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let mut visitor = MsgVisitor::new();
+        event.record(&mut visitor);
+        let msg = if visitor.msg.is_empty() {
+            event.metadata().target()
+        } else {
+            &visitor.msg
+        };
+        let width = Self::columns();
+        let wrapped = Self::wrap(msg, width);
+        for (i, line) in wrapped.lines().enumerate() {
+            if i > 0 {
+                writer.write_char('\n')?;
+            }
+            writer.write_str(line)?;
+        }
+        writer.write_char('\n')
+    }
+}

--- a/crates/logging/tests/formatter.rs
+++ b/crates/logging/tests/formatter.rs
@@ -1,0 +1,49 @@
+// crates/logging/tests/formatter.rs
+use logging::RsyncFormatter;
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+use tracing::info;
+use tracing_subscriber::{fmt, layer::SubscriberExt, registry};
+
+#[derive(Clone, Default)]
+struct VecWriter(Arc<Mutex<Vec<u8>>>);
+
+struct VecWriterGuard(Arc<Mutex<Vec<u8>>>);
+
+impl Write for VecWriterGuard {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> fmt::writer::MakeWriter<'a> for VecWriter {
+    type Writer = VecWriterGuard;
+    fn make_writer(&'a self) -> Self::Writer {
+        VecWriterGuard(self.0.clone())
+    }
+}
+
+#[test]
+fn respects_columns_env_var() {
+    std::env::set_var("COLUMNS", "40");
+    let writer = VecWriter::default();
+    let layer = fmt::layer()
+        .with_target(false)
+        .with_level(false)
+        .without_time()
+        .event_format(RsyncFormatter)
+        .with_ansi(false)
+        .with_writer(writer.clone());
+    let subscriber = registry().with(layer);
+    tracing::subscriber::with_default(subscriber, || {
+        info!(target: "test", "this is a very long line that should wrap around to the next line when the terminal width is small");
+    });
+    let out = String::from_utf8(writer.0.lock().unwrap().clone()).unwrap();
+    let expected = include_str!("../../../tests/golden/logging/wrap_40.txt");
+    assert_eq!(out, expected);
+    std::env::remove_var("COLUMNS");
+}

--- a/crates/logging/tests/journald.rs
+++ b/crates/logging/tests/journald.rs
@@ -11,7 +11,7 @@ fn journald_emits_message() {
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
     std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path);
-    let sub = subscriber(LogFormat::Text, 0, &[], &[], false, None, false, true);
+    let sub = subscriber(LogFormat::Text, 1, &[], &[], false, None, false, true);
     with_default(sub, || {
         info!(target: "test", "hi");
     });

--- a/crates/logging/tests/syslog.rs
+++ b/crates/logging/tests/syslog.rs
@@ -11,7 +11,7 @@ fn syslog_emits_message() {
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
     std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path);
-    let sub = subscriber(LogFormat::Text, 0, &[], &[], false, None, true, false);
+    let sub = subscriber(LogFormat::Text, 1, &[], &[], false, None, true, false);
     with_default(sub, || {
         info!(target: "test", "hello");
     });

--- a/tests/golden/logging/wrap_40.txt
+++ b/tests/golden/logging/wrap_40.txt
@@ -1,0 +1,3 @@
+this is a very long line that should
+wrap around to the next line when the
+terminal width is small


### PR DESCRIPTION
## Summary
- implement custom `RsyncFormatter` for text logs that wraps lines according to the `COLUMNS` env var
- snapshot rsync-formatted output under `tests/golden/` and add a test validating wrapping
- adjust log tests to emit info-level events through syslog and journald

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: version_string defined multiple times in crates/cli)*
- `UPSTREAM_VERSION=3.2.7 cargo clippy -p logging --tests -- -D warnings`
- `cargo test` *(fails: version_string defined multiple times in crates/cli)*
- `UPSTREAM_VERSION=3.2.7 cargo test -p logging`
- `make verify-comments` *(fails: version_string defined multiple times in crates/cli)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b715a7c9888323b1e2e2f3357f440d