### PR TITLE
test: compare iconv and usage against fixture

### DIFF
--- a/crates/cli/tests/cli_parity.rs
+++ b/crates/cli/tests/cli_parity.rs
@@ -1,5 +1,6 @@
 // crates/cli/tests/cli_parity.rs
 use oc_rsync_cli::cli_command;
+use std::path::Path;
 use std::process::{Command, Stdio};
 use tempfile::tempdir;
 
@@ -218,13 +219,13 @@ fn no_option_alias_matches_upstream() {
     assert!(matches.get_flag("no-perms"));
 }
 
+#[test]
 fn help_usage_matches_upstream() {
-    require_rsync!();
-    let upstream = std::process::Command::new("rsync")
-        .arg("--help")
-        .output()
-        .unwrap();
-    let upstream_usage = String::from_utf8_lossy(&upstream.stdout)
+    let help = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/rsync-help.txt"),
+    )
+    .unwrap();
+    let upstream_usage = help
         .lines()
         .find(|l| l.starts_with("Usage:"))
         .unwrap()

--- a/crates/cli/tests/iconv.rs
+++ b/crates/cli/tests/iconv.rs
@@ -1,32 +1,18 @@
 // crates/cli/tests/iconv.rs
 use assert_cmd::Command;
 use oc_rsync_cli::{cli_command, parse_iconv};
-use std::process::Command as StdCommand;
+use std::path::Path;
 use tempfile::tempdir;
-
-macro_rules! require_rsync {
-    () => {
-        let rsync = StdCommand::new("rsync")
-            .arg("--version")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status()
-            .ok();
-        if rsync.is_none() {
-            eprintln!("skipping test: rsync not installed");
-            return;
-        }
-    };
-}
 
 #[test]
 fn iconv_help_matches_upstream() {
-    require_rsync!();
     let ours = cli_command().render_help().to_string();
     let our_line = ours.lines().find(|l| l.contains("--iconv")).unwrap().trim();
 
-    let output = StdCommand::new("rsync").arg("--help").output().unwrap();
-    let help = String::from_utf8(output.stdout).unwrap();
+    let help = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/rsync-help.txt"),
+    )
+    .unwrap();
     let upstream_line = help.lines().find(|l| l.contains("--iconv")).unwrap().trim();
 
     assert_eq!(our_line, upstream_line);


### PR DESCRIPTION
## Summary
- read rsync help fixture to test `--iconv` parity
- verify CLI usage line from fixture and enable test
- drop `require_rsync!` guards where rsync is no longer used

## Testing
- `cargo fmt --all`
- `make lint` *(fails: Diff in bin/oc-rsync/src/main.rs)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: duplicate `version_banner` and missing env vars)*
- `OC_RSYNC_UPSTREAM=1 OC_RSYNC_GIT=1 OC_RSYNC_OFFICIAL=1 cargo test` *(fails: duplicate `version_banner`)*
- `make verify-comments` *(fails: duplicate `version_banner` and missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68b71fafd9ac8323b7b65055ab26d1bb