### PR TITLE
cli: remove duplicate version banner

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -2,9 +2,9 @@
 mod version;
 
 use logging::LogFormat;
-use std::{io::ErrorKind, path::PathBuf};
 use oc_rsync_cli::{cli_command, parse_logging_flags, EngineError};
 use protocol::ExitCode;
+use std::{io::ErrorKind, path::PathBuf};
 
 fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
     use clap::error::ErrorKind::*;

--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -42,7 +42,7 @@ pub fn render_help(cmd: &Command) -> String {
     let wrap_opts = WrapOptions::new(desc_width).break_words(false);
 
     let mut out = String::new();
-    out.push_str(&crate::version::version_banner());
+    out.push_str(&crate::version_banner());
     out.push_str(HELP_PREFIX);
 
     for arg in cmd.get_arguments() {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -42,34 +42,6 @@ pub mod version {
     include!("../../../bin/oc-rsync/src/version.rs");
 }
 
-#[allow(clippy::vec_init_then_push)]
-pub fn version_banner() -> String {
-    #[allow(unused_mut)]
-    let mut features: Vec<&str> = Vec::new();
-    #[cfg(feature = "xattr")]
-    features.push("xattr");
-    #[cfg(feature = "acl")]
-    features.push("acl");
-    let features = if features.is_empty() {
-        "none".to_string()
-    } else {
-        features.join(", ")
-    };
-    let protocols = SUPPORTED_PROTOCOLS
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
-    let upstream = option_env!("UPSTREAM_VERSION").unwrap_or("unknown");
-    format!(
-        "oc-rsync {} (rsync {})\nProtocols: {}\nFeatures: {}\n",
-        env!("CARGO_PKG_VERSION"),
-        upstream,
-        protocols,
-        features,
-    )
-}
-
 fn parse_filters(s: &str, from0: bool) -> std::result::Result<Vec<Rule>, filters::ParseError> {
     let mut v = HashSet::new();
     parse_with_options(s, from0, &mut v, 0)


### PR DESCRIPTION
## Summary
- remove duplicate `version_banner` implementation
- call `version_banner` directly from CLI formatter

## Testing
- `OC_RSYNC_UPSTREAM=0 OC_RSYNC_GIT=0 OC_RSYNC_OFFICIAL=0 make verify-comments` (failed: crates/meta/tests/acl_codec.rs: contains disallowed comments)
- `OC_RSYNC_UPSTREAM=0 OC_RSYNC_GIT=0 OC_RSYNC_OFFICIAL=0 make lint`
- `OC_RSYNC_UPSTREAM=0 OC_RSYNC_GIT=0 OC_RSYNC_OFFICIAL=0 UPSTREAM_VERSION=0 cargo test` (failed: prints_version)


------
https://chatgpt.com/codex/tasks/task_e_68b7207bdbe08323a2bbbe6e5db45688