### PR TITLE
Handle missing UPSTREAM_VERSION

### DIFF
--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -23,7 +23,7 @@ fn banner_is_static() {
         format!(
             "oc-rsync {} (rsync {})",
             env!("CARGO_PKG_VERSION"),
-            env!("UPSTREAM_VERSION"),
+            option_env!("UPSTREAM_VERSION").unwrap_or("unknown"),
         ),
         format!("Protocols: {protocols}"),
         format!("Features: {features}"),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -380,7 +380,7 @@ fn prints_version() {
     let expected = format!(
         "oc-rsync {} (rsync {})\nProtocols: {}\nFeatures: {}\n",
         env!("CARGO_PKG_VERSION"),
-        env!("UPSTREAM_VERSION"),
+        option_env!("UPSTREAM_VERSION").unwrap_or("unknown"),
         protocols,
         features,
     );


### PR DESCRIPTION
## Summary
- Use `option_env!` with a fallback to "unknown" when `UPSTREAM_VERSION` isn't set
- Update version-related tests to tolerate missing `UPSTREAM_VERSION`

## Testing
- `cargo fmt --all`
- `OC_RSYNC_UPSTREAM=unknown OC_RSYNC_GIT=unknown OC_RSYNC_OFFICIAL=unofficial cargo clippy --all-targets --all-features -- -D warnings` *(fails: the name `version_banner` is defined multiple times)*
- `OC_RSYNC_UPSTREAM=unknown OC_RSYNC_GIT=unknown OC_RSYNC_OFFICIAL=unofficial cargo test` *(fails: the name `version_banner` is defined multiple times)*
- `make verify-comments` *(fails: the name `version_banner` is defined multiple times)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b720a44acc8323b0820290d0ea7f83