### PR TITLE
Refactor version rendering to return Vec lines

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,10 +1,9 @@
 // bin/oc-rsync/src/main.rs
 mod version;
 
-use logging::LogFormat;
-use std::{io::ErrorKind, path::PathBuf};
-use oc_rsync_cli::{cli_command, parse_logging_flags, EngineError};
+use oc_rsync_cli::{cli_command, EngineError};
 use protocol::ExitCode;
+use std::io::ErrorKind;
 
 fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
     use clap::error::ErrorKind::*;
@@ -32,7 +31,7 @@ fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
 fn main() {
     if std::env::args().any(|a| a == "--version" || a == "-V") {
         if !std::env::args().any(|a| a == "--quiet" || a == "-q") {
-            print!("{}", version::render_version_lines());
+            println!("{}", version::render_version_lines().join("\n"));
         }
         return;
     }

--- a/bin/oc-rsync/src/version.rs
+++ b/bin/oc-rsync/src/version.rs
@@ -4,18 +4,32 @@ use protocol::SUPPORTED_PROTOCOLS;
 /// Latest rsync protocol version supported by oc-rsync.
 pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOLS[0];
 
-/// Render a three-line version string.
+/// Render a three-line version banner as separate lines.
 ///
 /// Line 1: "oc-rsync <pkg-version> (protocol <RSYNC_PROTOCOL>)"
 /// Line 2: "rsync <upstream-version>"
 /// Line 3: "<git-hash> <official-flag>"
-pub fn render_version_lines() -> String {
-    format!(
-        "oc-rsync {} (protocol {})\nrsync {}\n{} {}\n",
-        env!("CARGO_PKG_VERSION"),
-        RSYNC_PROTOCOL,
-        env!("OC_RSYNC_UPSTREAM"),
-        env!("OC_RSYNC_GIT"),
-        env!("OC_RSYNC_OFFICIAL"),
-    )
+pub fn render_version_lines() -> Vec<String> {
+    vec![
+        format!(
+            "oc-rsync {} (protocol {})",
+            env!("CARGO_PKG_VERSION"),
+            RSYNC_PROTOCOL
+        ),
+        format!(
+            "rsync {}",
+            option_env!("OC_RSYNC_UPSTREAM").unwrap_or("unknown")
+        ),
+        format!(
+            "{} {}",
+            option_env!("OC_RSYNC_GIT").unwrap_or("unknown"),
+            option_env!("OC_RSYNC_OFFICIAL").unwrap_or("unofficial")
+        ),
+    ]
+}
+
+/// Render the version banner as a single string ending with a newline.
+#[allow(dead_code)]
+pub fn version_banner() -> String {
+    format!("{}\n", render_version_lines().join("\n"))
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -42,34 +42,6 @@ pub mod version {
     include!("../../../bin/oc-rsync/src/version.rs");
 }
 
-#[allow(clippy::vec_init_then_push)]
-pub fn version_banner() -> String {
-    #[allow(unused_mut)]
-    let mut features: Vec<&str> = Vec::new();
-    #[cfg(feature = "xattr")]
-    features.push("xattr");
-    #[cfg(feature = "acl")]
-    features.push("acl");
-    let features = if features.is_empty() {
-        "none".to_string()
-    } else {
-        features.join(", ")
-    };
-    let protocols = SUPPORTED_PROTOCOLS
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
-    let upstream = option_env!("UPSTREAM_VERSION").unwrap_or("unknown");
-    format!(
-        "oc-rsync {} (rsync {})\nProtocols: {}\nFeatures: {}\n",
-        env!("CARGO_PKG_VERSION"),
-        upstream,
-        protocols,
-        features,
-    )
-}
-
 fn parse_filters(s: &str, from0: bool) -> std::result::Result<Vec<Rule>, filters::ParseError> {
     let mut v = HashSet::new();
     parse_with_options(s, from0, &mut v, 0)
@@ -143,40 +115,6 @@ fn parse_bool(s: &str) -> std::result::Result<bool, String> {
         "1" | "true" | "yes" => Ok(true),
         _ => Err("invalid boolean".to_string()),
     }
-}
-
-pub fn version_string() -> String {
-    format!(
-        "oc-rsync {} (rsync {})",
-        env!("CARGO_PKG_VERSION"),
-        option_env!("UPSTREAM_VERSION").unwrap_or("unknown"),
-    )
-}
-
-#[allow(clippy::vec_init_then_push)]
-pub fn version_banner() -> String {
-    #[allow(unused_mut)]
-    let mut features: Vec<&str> = Vec::new();
-    #[cfg(feature = "xattr")]
-    features.push("xattr");
-    #[cfg(feature = "acl")]
-    features.push("acl");
-    let features = if features.is_empty() {
-        "none".to_string()
-    } else {
-        features.join(", ")
-    };
-    let protocols = SUPPORTED_PROTOCOLS
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
-    format!(
-        "{}\nProtocols: {}\nFeatures: {}\n",
-        version_string(),
-        protocols,
-        features,
-    )
 }
 
 pub fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFlag>) {

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -4,29 +4,21 @@ use protocol::SUPPORTED_PROTOCOLS;
 
 #[test]
 fn banner_is_static() {
-    let mut features = Vec::new();
-    #[cfg(feature = "xattr")]
-    features.push("xattr");
-    #[cfg(feature = "acl")]
-    features.push("acl");
-    let features = if features.is_empty() {
-        "none".to_string()
-    } else {
-        features.join(", ")
-    };
-    let protocols = SUPPORTED_PROTOCOLS
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
     let expected = vec![
         format!(
-            "oc-rsync {} (rsync {})",
+            "oc-rsync {} (protocol {})",
             env!("CARGO_PKG_VERSION"),
-            env!("UPSTREAM_VERSION"),
+            SUPPORTED_PROTOCOLS[0],
         ),
-        format!("Protocols: {protocols}"),
-        format!("Features: {features}"),
+        format!(
+            "rsync {}",
+            option_env!("OC_RSYNC_UPSTREAM").unwrap_or("unknown")
+        ),
+        format!(
+            "{} {}",
+            option_env!("OC_RSYNC_GIT").unwrap_or("unknown"),
+            option_env!("OC_RSYNC_OFFICIAL").unwrap_or("unofficial"),
+        ),
     ];
     assert_eq!(version::render_version_lines(), expected);
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -361,28 +361,13 @@ impl Drop for Tmpfs {
 #[allow(clippy::vec_init_then_push)]
 #[test]
 fn prints_version() {
-    #[allow(unused_mut)]
-    let mut features: Vec<&str> = Vec::new();
-    #[cfg(feature = "xattr")]
-    features.push("xattr");
-    #[cfg(feature = "acl")]
-    features.push("acl");
-    let features = if features.is_empty() {
-        "none".to_string()
-    } else {
-        features.join(", ")
-    };
-    let protocols = SUPPORTED_PROTOCOLS
-        .iter()
-        .map(|p| p.to_string())
-        .collect::<Vec<_>>()
-        .join(", ");
     let expected = format!(
-        "oc-rsync {} (rsync {})\nProtocols: {}\nFeatures: {}\n",
+        "oc-rsync {} (protocol {})\nrsync {}\n{} {}\n",
         env!("CARGO_PKG_VERSION"),
-        env!("UPSTREAM_VERSION"),
-        protocols,
-        features,
+        SUPPORTED_PROTOCOLS[0],
+        option_env!("OC_RSYNC_UPSTREAM").unwrap_or("unknown"),
+        option_env!("OC_RSYNC_GIT").unwrap_or("unknown"),
+        option_env!("OC_RSYNC_OFFICIAL").unwrap_or("unofficial"),
     );
     Command::cargo_bin("oc-rsync")
         .unwrap()


### PR DESCRIPTION
## Summary
- Refactor render_version_lines to return `Vec<String>` and add helper `version_banner`
- Join version lines before printing
- Update tests and remove duplicate version banner logic

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(failed: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*
- `make verify-comments` *(failed: crates/meta/tests/acl_codec.rs contains disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b720aeefd48323864cb7422dda37e2