### PR TITLE
refactor: move version module to cli crate

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,10 +1,8 @@
 // bin/oc-rsync/src/main.rs
-mod version;
-
-use logging::LogFormat;
-use oc_rsync_cli::{cli_command, parse_logging_flags, EngineError};
+use oc_rsync_cli::version;
+use oc_rsync_cli::{cli_command, EngineError};
 use protocol::ExitCode;
-use std::{io::ErrorKind, path::PathBuf};
+use std::io::ErrorKind;
 
 fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
     use clap::error::ErrorKind::*;

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -38,9 +38,8 @@ use transport::{
 #[cfg(unix)]
 use users::get_user_by_uid;
 
-pub mod version {
-    include!("../../../bin/oc-rsync/src/version.rs");
-}
+pub mod version;
+pub use version::version_banner;
 
 fn parse_filters(s: &str, from0: bool) -> std::result::Result<Vec<Rule>, filters::ParseError> {
     let mut v = HashSet::new();

--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -1,4 +1,4 @@
-// bin/oc-rsync/src/version.rs
+// crates/cli/src/version.rs
 use protocol::SUPPORTED_PROTOCOLS;
 
 /// Latest rsync protocol version supported by oc-rsync.


### PR DESCRIPTION
## Summary
- move version helper into cli crate
- import cli version module from bin

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: `test sparse_files_preserved` hung over 60s)*
- `make verify-comments` *(fails: Os { code: 2, kind: NotFound, message: "No such file or directory" })*
- `make lint`
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68b72477e6b88323abc0ef21ddb0f484