### PR TITLE
Disable ownership/group preservation in archive test

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1990,7 +1990,14 @@ fn archive_implies_recursive() {
 
     let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
     let src_arg = format!("{}/", src_root.display());
-    cmd.args(["--local", "-a", &src_arg, dst_dir.to_str().unwrap()]);
+    cmd.args([
+        "--local",
+        "-a",
+        "--no-o",
+        "--no-g",
+        &src_arg,
+        dst_dir.to_str().unwrap(),
+    ]);
     cmd.assert().success();
     assert!(dst_dir.join("a/b/file.txt").exists());
 }


### PR DESCRIPTION
## Summary
- adjust archive flag test to pass `--no-o` and `--no-g`
- keep asserting recursive copy of `a/b/file.txt`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unresolved crate `oc_rsync_cli` in gen-completions)*
- `cargo test --test cli archive_implies_recursive -- --nocapture` *(fails: could not find built binary `oc-rsync`)*
- `make verify-comments` *(fails: disallowed/doc comments in crates/cli/src/version.rs, crates/meta/tests/acl_codec.rs, crates/transport/src/tcp.rs)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b72a3084888323919d65dcb4cfc446