### PR TITLE
cli: add alias for no-owner and no-group

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -472,7 +472,8 @@ struct ClientOpts {
     #[arg(
         long = "no-owner",
         help_heading = "Attributes",
-        overrides_with = "owner"
+        overrides_with = "owner",
+        alias = "no-o"
     )]
     no_owner: bool,
     #[arg(
@@ -485,7 +486,8 @@ struct ClientOpts {
     #[arg(
         long = "no-group",
         help_heading = "Attributes",
-        overrides_with = "group"
+        overrides_with = "group",
+        alias = "no-g"
     )]
     no_group: bool,
     #[arg(


### PR DESCRIPTION
## Summary
- add shorthand aliases `no-o` and `no-g` to ownership flags

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments` *(fails: crates/cli/src/version.rs: contains doc comments; crates/meta/tests/acl_codec.rs: contains disallowed comments; crates/transport/src/tcp.rs: contains doc comments)*
- `cargo test` *(fails: test archive_matches_combination_and_rsync - called `Result::unwrap()` on an `Err` value: CargoError { cause: Some(NotFoundError { path: "/workspace/oc-rsync/target/debug/oc-rsync" }) }*)


------
https://chatgpt.com/codex/tasks/task_e_68b72efc61c08323b15b5ae53f19fa27