### PR TITLE
feat(cli): add --no-o alias

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -471,6 +471,7 @@ struct ClientOpts {
     owner: bool,
     #[arg(
         long = "no-owner",
+        alias = "no-o",
         help_heading = "Attributes",
         overrides_with = "owner"
     )]

--- a/docs/spec/rsync.1
+++ b/docs/spec/rsync.1
@@ -2048,7 +2048,8 @@ This option causes rsync to set the owner of the destination file to be
 the same as the source file, but only if the receiving rsync is being
 run as the super-user (see also the \f[V]--super\f[R] and
 \f[V]--fake-super\f[R] options).
-Without this option, the owner of new and/or transferred files are set
+The negative form \f[V]--no-owner\f[R] (alias \f[V]--no-o\f[R]) disables
+owner preservation. Without this option, the owner of new and/or transferred files are set
 to the invoking user on the receiving side.
 .PP
 The preservation of ownership will associate matching names by default,


### PR DESCRIPTION
## Summary
- allow `--no-o` as an alias for `--no-owner`
- document `--no-o` as the negative form of `--owner`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: use of unresolved module or unlinked crate `oc_rsync_cli`)*
- `cargo clippy -p oc-rsync-cli --all-features --lib --bins -- -D warnings`
- `cargo test` *(fails: called `Result::unwrap()` on an `Err` value: NotFoundError { path: "/workspace/oc-rsync/target/debug/oc-rsync"})*
- `cargo test --test cli archive_implies_recursive` *(fails: called `Result::unwrap()` on an `Err` value: NotFoundError { path: "/workspace/oc-rsync/target/debug/oc-rsync"})*
- `make verify-comments` *(fails: crates/meta/tests/acl_codec.rs: contains disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b72f10f4788323b7e5150cd2db6bc5