### PR TITLE
Ensure help and version exit codes are zero

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,6 +942,7 @@ name = "oc-rsync-bin"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "clap",
  "engine",
  "logging",
  "oc-rsync-cli",

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -13,6 +13,7 @@ oc-rsync-cli = { path = "../../crates/cli" }
 engine = { path = "../../crates/engine" }
 logging = { path = "../../crates/logging" }
 protocol = { path = "../../crates/protocol" }
+clap = { version = "4" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -19,9 +19,8 @@ fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
         | MissingRequiredArgument
         | MissingSubcommand
         | InvalidUtf8
-        | DisplayHelp
-        | DisplayHelpOnMissingArgumentOrSubcommand
-        | DisplayVersion => ExitCode::SyntaxOrUsage,
+        | DisplayHelpOnMissingArgumentOrSubcommand => ExitCode::SyntaxOrUsage,
+        DisplayHelp | DisplayVersion => ExitCode::Ok,
         Io | Format => ExitCode::FileIo,
         _ => ExitCode::SyntaxOrUsage,
     }
@@ -39,32 +38,29 @@ fn main() {
         .try_get_matches_from_mut(std::env::args_os())
         .unwrap_or_else(|e| {
             use clap::error::ErrorKind;
-            match e.kind() {
-                ErrorKind::DisplayHelp => {
-                    println!("{}", oc_rsync_cli::render_help(&cmd));
-                    std::process::exit(0);
-                }
-                kind => {
-                    let first = e.to_string();
-                    let first = first.lines().next().unwrap_or("");
-                    let msg = match kind {
-                        ErrorKind::UnknownArgument => {
-                            let arg = first.split('\'').nth(1).unwrap_or("");
-                            format!("{arg}: unknown option")
-                        }
-                        _ => first.strip_prefix("error: ").unwrap_or(first).to_string(),
-                    };
-                    let code = exit_code_from_error_kind(kind);
-                    let desc = match code {
-                        ExitCode::Unsupported => "requested action not supported",
-                        _ => "syntax or usage error",
-                    };
-                    let code_num = u8::from(code);
-                    eprintln!("rsync: {msg}");
-                    eprintln!("rsync error: {desc} (code {code_num})");
-                    std::process::exit(code_num as i32);
-                }
+            let kind = e.kind();
+            let code = exit_code_from_error_kind(kind);
+            if kind == ErrorKind::DisplayHelp {
+                println!("{}", oc_rsync_cli::render_help(&cmd));
+            } else {
+                let first = e.to_string();
+                let first = first.lines().next().unwrap_or("");
+                let msg = match kind {
+                    ErrorKind::UnknownArgument => {
+                        let arg = first.split('\'').nth(1).unwrap_or("");
+                        format!("{arg}: unknown option")
+                    }
+                    _ => first.strip_prefix("error: ").unwrap_or(first).to_string(),
+                };
+                let desc = match code {
+                    ExitCode::Unsupported => "requested action not supported",
+                    _ => "syntax or usage error",
+                };
+                let code_num = u8::from(code);
+                eprintln!("rsync: {msg}");
+                eprintln!("rsync error: {desc} (code {code_num})");
             }
+            std::process::exit(u8::from(code) as i32);
         });
     if let Err(e) = oc_rsync_cli::run(&matches) {
         eprintln!("{e}");

--- a/bin/oc-rsync/tests/help.rs
+++ b/bin/oc-rsync/tests/help.rs
@@ -1,0 +1,11 @@
+// bin/oc-rsync/tests/help.rs
+use assert_cmd::Command;
+
+#[test]
+fn exit_code_is_zero() {
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success();
+}

--- a/bin/oc-rsync/tests/version.rs
+++ b/bin/oc-rsync/tests/version.rs
@@ -29,3 +29,12 @@ fn output_is_immutable() {
     let second = version_output();
     assert_eq!(first, second);
 }
+
+#[test]
+fn exit_code_is_zero() {
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .arg("--version")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary
- Map DisplayHelp and DisplayVersion errors to `ExitCode::Ok`
- Simplify CLI error handling to use the new exit code mapping
- Add tests verifying `--help` and `--version` exit successfully

## Testing
- `cargo clippy -p oc-rsync-bin --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: archive_matches_combination_and_rsync missing oc-rsync binary)*
- `cargo test -p oc-rsync-bin` *(fails: prints_three_lines missing `OC_RSYNC_GIT` env var)*
- `make lint`
- `make verify-comments` *(fails: contains disallowed comments in other crates)*
- `cargo test --all-features` *(fails: unresolved crate `oc_rsync_cli` for gen-completions)*

------
https://chatgpt.com/codex/tasks/task_e_68b736e0b0b883238427c455303e3e6a