### PR TITLE
build: expose oc-rsync binary in workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ logging = { path = "crates/logging" }
 tracing = "0.1"
 filetime = "0.2"
 clap = { version = "4" }
+oc-rsync-cli = { path = "crates/cli" }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.27", features = ["user", "fs"] }
@@ -55,7 +56,10 @@ meta = { path = "crates/meta" }
 daemon = { path = "crates/daemon" }
 sha2 = "0.10"
 encoding_rs = "0.8"
-oc-rsync-cli = { path = "crates/cli" }
+
+[[bin]]
+name = "oc-rsync"
+path = "bin/oc-rsync/src/main.rs"
 
 [[bin]]
 name = "flag_matrix"


### PR DESCRIPTION
## Summary
- expose oc-rsync binary from workspace root package so tests can build it
- promote oc-rsync-cli to a normal dependency

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*
- `make verify-comments` *(fails: crates/cli/src/version.rs: contains doc comments, crates/meta/tests/acl_codec.rs: contains disallowed comments, crates/transport/src/tcp.rs: contains doc comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b736a7076483239cb6bec6603fafcd