### PR TITLE
Expose build metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.exe
 *.so
 *.dylib
+/docs/build_info.md
 
 # Upstream rsync sources
 /rsync-*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 # If user passes UPSTREAM/OFFICIAL, map them to RSYNC_UPSTREAM_VER/OFFICIAL_BUILD unless already set.
 RSYNC_UPSTREAM_VER ?= $(UPSTREAM)
 OFFICIAL_BUILD     ?= $(OFFICIAL)
+BUILD_REVISION     ?= $(shell git rev-parse HEAD)
 
 VERIFY_COMMENT_FILES := $(shell git ls-files '*.rs')
 
@@ -54,15 +55,15 @@ test-golden:
 # or legacy:
 #   make build UPSTREAM=3.4.1 OFFICIAL=1
 build:
-	@echo "RSYNC_UPSTREAM_VER=$(RSYNC_UPSTREAM_VER) OFFICIAL_BUILD=$(OFFICIAL_BUILD)"
-	@env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" \
-		cargo build -p oc-rsync-bin --bin oc-rsync --release
+	@echo "RSYNC_UPSTREAM_VER=$(RSYNC_UPSTREAM_VER) BUILD_REVISION=$(BUILD_REVISION) OFFICIAL_BUILD=$(OFFICIAL_BUILD)"
+	@env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" BUILD_REVISION="$(BUILD_REVISION)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" \
+	cargo build -p oc-rsync-bin --bin oc-rsync --release
 
 # Max performance build (uses your [profile.maxspeed])
 build-maxspeed:
-	@echo "RSYNC_UPSTREAM_VER=$(RSYNC_UPSTREAM_VER) OFFICIAL_BUILD=$(OFFICIAL_BUILD) [maxspeed]"
-	@env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" \
-		cargo build -p oc-rsync-bin --bin oc-rsync --profile maxspeed --release
+	@echo "RSYNC_UPSTREAM_VER=$(RSYNC_UPSTREAM_VER) BUILD_REVISION=$(BUILD_REVISION) OFFICIAL_BUILD=$(OFFICIAL_BUILD) [maxspeed]"
+	@env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" BUILD_REVISION="$(BUILD_REVISION)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" \
+	cargo build -p oc-rsync-bin --bin oc-rsync --profile maxspeed --release
 
 # Show version from the release artifact built above
 version: build

--- a/bin/oc-rsync/build.rs
+++ b/bin/oc-rsync/build.rs
@@ -1,22 +1,24 @@
-use std::process::Command;
+use std::{env, fs, path::Path};
 
 fn main() {
-    let upstream = std::env::var("OC_RSYNC_UPSTREAM")
-        .or_else(|_| std::env::var("UPSTREAM_VERSION"))
-        .unwrap_or_else(|_| "unknown".to_string());
-    println!("cargo:rustc-env=OC_RSYNC_UPSTREAM={upstream}");
+    let upstream = env::var("RSYNC_UPSTREAM_VER").unwrap_or_else(|_| "unknown".to_string());
+    let revision = env::var("BUILD_REVISION").unwrap_or_else(|_| "unknown".to_string());
+    let official = env::var("OFFICIAL_BUILD").unwrap_or_else(|_| "unofficial".to_string());
 
-    let git = Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "unknown".to_string());
-    println!("cargo:rustc-env=OC_RSYNC_GIT={git}");
+    println!("cargo:rustc-env=RSYNC_UPSTREAM_VER={upstream}");
+    println!("cargo:rustc-env=BUILD_REVISION={revision}");
+    println!("cargo:rustc-env=OFFICIAL_BUILD={official}");
 
-    let official = std::env::var("OC_RSYNC_OFFICIAL").unwrap_or_else(|_| "unofficial".to_string());
-    println!("cargo:rustc-env=OC_RSYNC_OFFICIAL={official}");
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("missing manifest dir");
+    let docs_dir = Path::new(&manifest_dir).join("../../docs");
+    let _ = fs::create_dir_all(&docs_dir);
+    let info_path = docs_dir.join("build_info.md");
+    let contents = format!(
+        "rsync upstream version: {upstream}\nbuild revision: {revision}\nofficial build: {official}\n"
+    );
+    fs::write(info_path, contents).expect("failed to write build_info.md");
 
-    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-env-changed=RSYNC_UPSTREAM_VER");
+    println!("cargo:rerun-if-env-changed=BUILD_REVISION");
+    println!("cargo:rerun-if-env-changed=OFFICIAL_BUILD");
 }

--- a/bin/oc-rsync/tests/version.rs
+++ b/bin/oc-rsync/tests/version.rs
@@ -18,9 +18,9 @@ fn prints_three_lines() {
     assert_eq!(lines.len(), 3);
     assert!(lines[0].contains(env!("CARGO_PKG_VERSION")));
     assert!(lines[0].contains(&SUPPORTED_PROTOCOLS[0].to_string()));
-    assert!(lines[1].contains(env!("OC_RSYNC_UPSTREAM")));
-    assert!(lines[2].contains(env!("OC_RSYNC_GIT")));
-    assert!(lines[2].contains(env!("OC_RSYNC_OFFICIAL")));
+    assert!(lines[1].contains(env!("RSYNC_UPSTREAM_VER")));
+    assert!(lines[2].contains(env!("BUILD_REVISION")));
+    assert!(lines[2].contains(env!("OFFICIAL_BUILD")));
 }
 
 #[test]
@@ -37,4 +37,12 @@ fn exit_code_is_zero() {
         .arg("--version")
         .assert()
         .success();
+}
+
+#[test]
+fn build_info_file_has_expected_values() {
+    let info = std::fs::read_to_string("../../docs/build_info.md").unwrap();
+    assert!(info.contains(env!("RSYNC_UPSTREAM_VER")));
+    assert!(info.contains(env!("BUILD_REVISION")));
+    assert!(info.contains(env!("OFFICIAL_BUILD")));
 }

--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -7,7 +7,7 @@ pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOLS[0];
 ///
 /// Line 1: "oc-rsync <pkg-version> (protocol <RSYNC_PROTOCOL>)"
 /// Line 2: "rsync <upstream-version>"
-/// Line 3: "<git-hash> <official-flag>"
+/// Line 3: "<build-revision> <official-flag>"
 pub fn render_version_lines() -> Vec<String> {
     vec![
         format!(
@@ -17,12 +17,12 @@ pub fn render_version_lines() -> Vec<String> {
         ),
         format!(
             "rsync {}",
-            option_env!("OC_RSYNC_UPSTREAM").unwrap_or("unknown")
+            option_env!("RSYNC_UPSTREAM_VER").unwrap_or("unknown")
         ),
         format!(
             "{} {}",
-            option_env!("OC_RSYNC_GIT").unwrap_or("unknown"),
-            option_env!("OC_RSYNC_OFFICIAL").unwrap_or("unofficial")
+            option_env!("BUILD_REVISION").unwrap_or("unknown"),
+            option_env!("OFFICIAL_BUILD").unwrap_or("unofficial")
         ),
     ]
 }

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -12,12 +12,12 @@ fn banner_is_static() {
         ),
         format!(
             "rsync {}",
-            option_env!("OC_RSYNC_UPSTREAM").unwrap_or("unknown")
+            option_env!("RSYNC_UPSTREAM_VER").unwrap_or("unknown")
         ),
         format!(
             "{} {}",
-            option_env!("OC_RSYNC_GIT").unwrap_or("unknown"),
-            option_env!("OC_RSYNC_OFFICIAL").unwrap_or("unofficial"),
+            option_env!("BUILD_REVISION").unwrap_or("unknown"),
+            option_env!("OFFICIAL_BUILD").unwrap_or("unofficial"),
         ),
     ];
     assert_eq!(version::render_version_lines(), expected);

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,6 +72,13 @@ oc-rsync [OPTIONS] "<SRC>" "<DEST>"
   ```sh
   oc-rsync --version
   ```
+  which prints three lines:
+
+  ```text
+  oc-rsync <pkg-version> (protocol <protocol>)
+  rsync <upstream-version>
+  <build-revision> <official|unofficial>
+  ```
 
 ### Trailing slash semantics
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -365,9 +365,9 @@ fn prints_version() {
         "oc-rsync {} (protocol {})\nrsync {}\n{} {}\n",
         env!("CARGO_PKG_VERSION"),
         SUPPORTED_PROTOCOLS[0],
-        option_env!("OC_RSYNC_UPSTREAM").unwrap_or("unknown"),
-        option_env!("OC_RSYNC_GIT").unwrap_or("unknown"),
-        option_env!("OC_RSYNC_OFFICIAL").unwrap_or("unofficial"),
+        option_env!("RSYNC_UPSTREAM_VER").unwrap_or("unknown"),
+        option_env!("BUILD_REVISION").unwrap_or("unknown"),
+        option_env!("OFFICIAL_BUILD").unwrap_or("unofficial"),
     );
     Command::cargo_bin("oc-rsync")
         .unwrap()

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -30,6 +30,11 @@ fn packaging_includes_service_unit() {
         "systemd example config missing from package list:\n{}",
         listing
     );
+    assert!(
+        listing.lines().any(|l| l.trim() == "docs/build_info.md"),
+        "build info missing from package list:\n{}",
+        listing
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- surface rsync upstream version, build revision, and official flag via env vars
- document version output and package build info
- test build metadata output

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*
- `cargo test --all-features`
- `make verify-comments` *(fails: crates/meta/tests/acl_codec.rs: contains disallowed comments)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b745eece9c8323b9724e3e9aa00e47