### PR TITLE
feat: track filter rule statistics

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -42,7 +42,7 @@ pub mod version;
 
 fn parse_filters(s: &str, from0: bool) -> std::result::Result<Vec<Rule>, filters::ParseError> {
     let mut v = HashSet::new();
-    parse_with_options(s, from0, &mut v, 0)
+    parse_with_options(s, from0, &mut v, 0, None)
 }
 
 fn parse_duration(s: &str) -> std::result::Result<Duration, std::num::ParseIntError> {

--- a/crates/filters/tests/from0_merges.rs
+++ b/crates/filters/tests/from0_merges.rs
@@ -32,7 +32,7 @@ fn merge_word_split_from0() {
     fs::write(&list, b"-foo\0+bar\0").unwrap();
     let spec = format!(": merge,w {}\n", list.display());
     let mut v: HashSet<PathBuf> = HashSet::new();
-    let rules = parse_with_options(&spec, true, &mut v, 0).unwrap();
+    let rules = parse_with_options(&spec, true, &mut v, 0, None).unwrap();
     let matcher = Matcher::new(rules);
     assert!(!matcher.is_included("foo").unwrap());
     assert!(matcher.is_included("bar").unwrap());

--- a/crates/filters/tests/list_files.rs
+++ b/crates/filters/tests/list_files.rs
@@ -17,6 +17,7 @@ fn include_from_newline_vs_null() {
         false,
         &mut v1,
         0,
+        None,
     )
     .unwrap();
     let m_nl = Matcher::new(rules_nl);
@@ -30,6 +31,7 @@ fn include_from_newline_vs_null() {
         true,
         &mut v2,
         0,
+        None,
     )
     .unwrap();
     let m_nul = Matcher::new(rules_nul);
@@ -45,7 +47,7 @@ fn include_exclude_precedence() {
     fs::write(&list, "a\nb\n").unwrap();
     let filter = format!("+ c\nexclude-from {}\n+ a\n- *\n", list.display());
     let mut v = HashSet::new();
-    let rules = parse_with_options(&filter, false, &mut v, 0).unwrap();
+    let rules = parse_with_options(&filter, false, &mut v, 0, None).unwrap();
     let m = Matcher::new(rules);
     assert!(m.is_included("c").unwrap());
     assert!(m.is_included("a").unwrap());

--- a/crates/filters/tests/rule_stats.rs
+++ b/crates/filters/tests/rule_stats.rs
@@ -1,0 +1,18 @@
+// crates/filters/tests/rule_stats.rs
+use filters::{parse_file, Matcher};
+use std::collections::HashSet;
+use tempfile::NamedTempFile;
+
+#[test]
+fn counts_matches_and_misses() {
+    let tmp = NamedTempFile::new().unwrap();
+    std::fs::write(tmp.path(), "+ foo\n- *\n").unwrap();
+    let mut v = HashSet::new();
+    let rules = parse_file(tmp.path(), false, &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("foo").unwrap());
+    assert!(!matcher.is_included("bar").unwrap());
+    let stats = matcher.stats();
+    assert_eq!(stats.matches, 2);
+    assert_eq!(stats.misses, 1);
+}

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -15,3 +15,15 @@ their relative order is preserved with global rules.
 
 The parser is fuzzed and property tested against rsync to ensure identical
 semantics.
+
+## Reporting
+
+`Matcher` instances keep running statistics of rule evaluations. Each rule
+records whether it matched or missed and the source file that defined it. After
+filter checks, call `Matcher::stats()` or `Matcher::report()` to retrieve or log
+these counters. `LoggingAgent` consumes this data on the `info::filter` target
+to produce lines such as:
+
+```
+matches=1 misses=0 source=/tmp/rules
+```

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -31,7 +31,7 @@ when available.
 | --- | --- | --- | --- |
 | Include/Exclude parser | ✅ | [crates/filters/tests/include_exclude.rs](../crates/filters/tests/include_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | `.rsync-filter` merge semantics | ✅ | [crates/filters/tests/merge.rs](../crates/filters/tests/merge.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
-| Rule logging and statistics | ❌ | — | — |
+| Rule logging and statistics | ✅ | [crates/filters/tests/rule_stats.rs](../crates/filters/tests/rule_stats.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 
 ## File List
 | Feature | Status | Tests | Source |


### PR DESCRIPTION
## Summary
- track rule matches and misses with source file
- expose `Matcher::stats` and `Matcher::report` for logging
- document filter statistics and mark gap as complete

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make SHELL=/bin/bash lint`
- `make SHELL=/bin/bash verify-comments` (fails: contains doc comments)
- `cargo test` (fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)


------
https://chatgpt.com/codex/tasks/task_e_68b746870e7c8323b9830a957f570685