### PR TITLE
Add ACL roundtrip tests and fix GID encoding

### DIFF
--- a/crates/filelist/src/lib.rs
+++ b/crates/filelist/src/lib.rs
@@ -55,7 +55,7 @@ impl Encoder {
         out.extend_from_slice(&encode_id(entry.gid, &mut self.gid_table));
         if let Some(group) = entry.group {
             out.push(1);
-            out.extend_from_slice(&group.to_le_bytes());
+            out.extend_from_slice(&encode_id(group, &mut self.gid_table));
         } else {
             out.push(0);
         }
@@ -105,13 +105,9 @@ impl Decoder {
             let tag = rest[0];
             rest = &rest[1..];
             if tag == 1 {
-                if rest.len() < 4 {
-                    return Err(DecodeError::ShortInput);
-                }
-                let mut buf = [0u8; 4];
-                buf.copy_from_slice(&rest[..4]);
-                rest = &rest[4..];
-                Some(u32::from_le_bytes(buf))
+                let (g, r) = decode_id(rest, &mut self.gid_table, false)?;
+                rest = r;
+                Some(g)
             } else {
                 None
             }
@@ -249,7 +245,7 @@ mod tests {
                 path: b"dir/file2".to_vec(),
                 uid: 1000,
                 gid: 1001,
-                group: None,
+                group: Some(2000),
                 xattrs: Vec::new(),
                 acl: Vec::new(),
                 default_acl: vec![1, 0, 0, 0, 0, 7, 0, 0, 0],
@@ -258,7 +254,7 @@ mod tests {
                 path: b"other".to_vec(),
                 uid: 1002,
                 gid: 1001,
-                group: None,
+                group: Some(2000),
                 xattrs: Vec::new(),
                 acl: Vec::new(),
                 default_acl: Vec::new(),

--- a/crates/meta/tests/acl_gid.rs
+++ b/crates/meta/tests/acl_gid.rs
@@ -1,0 +1,46 @@
+#![cfg(feature = "acl")]
+// crates/meta/tests/acl_gid.rs
+use meta::{Metadata, Options};
+use nix::unistd::{chown, Gid};
+use posix_acl::{PosixACL, Qualifier, ACL_READ};
+use std::fs;
+use tempfile::tempdir;
+
+fn acl_to_io(err: posix_acl::ACLError) -> std::io::Error {
+    if let Some(ioe) = err.as_io_error() {
+        if let Some(code) = ioe.raw_os_error() {
+            std::io::Error::from_raw_os_error(code)
+        } else {
+            std::io::Error::new(ioe.kind(), ioe.to_string())
+        }
+    } else {
+        std::io::Error::other(err)
+    }
+}
+
+#[test]
+fn roundtrip_acl_and_gid() -> std::io::Result<()> {
+    let dir = tempdir()?;
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::write(&src, b"hello")?;
+    fs::write(&dst, b"world")?;
+
+    chown(&src, None, Some(Gid::from_raw(12345)))?;
+    let mut acl = PosixACL::read_acl(&src).map_err(acl_to_io)?;
+    acl.set(Qualifier::User(12345), ACL_READ);
+    acl.write_acl(&src).map_err(acl_to_io)?;
+
+    let opts = Options {
+        acl: true,
+        group: true,
+        ..Default::default()
+    };
+    let meta = Metadata::from_path(&src, opts.clone())?;
+    meta.apply(&dst, opts.clone())?;
+    let applied = Metadata::from_path(&dst, opts)?;
+
+    assert_eq!(meta.gid, applied.gid);
+    assert_eq!(meta.acl, applied.acl);
+    Ok(())
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -44,7 +44,7 @@ kept up to date from their results.
 * Filters, sparse files, and compression work across transports. Hard links are
   not yet supported.
 * Extended attributes and ACLs are available only when built with the `xattr`
-  and `acl` feature gates and have not been widely exercised.
+  and `acl` feature gates and are exercised by round-trip tests.
 * Filesystem differences (case sensitivity, permissions) across platforms may
   lead to subtle inconsistencies.
 

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -6,8 +6,8 @@
   },
   {
     "flag": "--acls",
-    "status": "Ignored",
-    "notes": ""
+    "status": "Supported",
+    "notes": "requires `acl` feature"
   },
   {
     "flag": "--address",

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -1,7 +1,7 @@
 | flag | status | notes |
 | --- | --- | --- |
 | --8-bit-output | Supported |  |
-| --acls | Ignored |  |
+| --acls | Supported | requires `acl` feature |
 | --address | Supported |  |
 | --append | Supported |  |
 | --append-verify | Supported |  |


### PR DESCRIPTION
## Summary
- encode and decode group IDs via the ID table for consistent cross-platform behavior
- document ACL support and mark `--acls` flag as supported
- add ACL + GID integration test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `cargo test --all-features` *(fails: checksum_seed_changes_strong_checksum)*
- `bash scripts/check-comments.sh $(git ls-files '*.rs')`
- `cargo fmt --all --check`


------
https://chatgpt.com/codex/tasks/task_e_68b74b0195d88323bf78ec304644b4c9