### PR TITLE
Handle non-UTF-8 args in version flag

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -2,6 +2,7 @@
 use oc_rsync_cli::version;
 use oc_rsync_cli::{cli_command, EngineError};
 use protocol::ExitCode;
+use std::ffi::OsString;
 use std::io::ErrorKind;
 
 fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
@@ -27,8 +28,12 @@ fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
 }
 
 fn main() {
-    if std::env::args().any(|a| a == "--version" || a == "-V") {
-        if !std::env::args().any(|a| a == "--quiet" || a == "-q") {
+    let version = OsString::from("--version");
+    let version_short = OsString::from("-V");
+    let quiet = OsString::from("--quiet");
+    let quiet_short = OsString::from("-q");
+    if std::env::args_os().any(|a| a == version || a == version_short) {
+        if !std::env::args_os().any(|a| a == quiet || a == quiet_short) {
             println!("{}", version::render_version_lines().join("\n"));
         }
         return;

--- a/bin/oc-rsync/tests/non_utf8_args.rs
+++ b/bin/oc-rsync/tests/non_utf8_args.rs
@@ -1,0 +1,35 @@
+// bin/oc-rsync/tests/non_utf8_args.rs
+#![cfg(unix)]
+use assert_cmd::Command;
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+
+fn non_utf8_arg() -> OsString {
+    OsString::from_vec(b"\xff".to_vec())
+}
+
+#[test]
+fn version_handles_non_utf8_arg() {
+    let output = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .arg(non_utf8_arg())
+        .arg("--version")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
+fn quiet_suppresses_version_with_non_utf8_arg() {
+    let output = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .arg(non_utf8_arg())
+        .arg("--version")
+        .arg("--quiet")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(output.stdout.is_empty());
+}


### PR DESCRIPTION
## Summary
- Use `std::env::args_os` with `OsString` comparisons to detect `--version` and `--quiet` flags
- Add tests ensuring `--version` works alongside non-UTF-8 arguments and respects `--quiet`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `make verify-comments SHELL=/bin/bash` *(fails: disallowed comments in crates/meta/tests)*
- `make lint SHELL=/bin/bash`


------
https://chatgpt.com/codex/tasks/task_e_68b7516db7a08323bdceb8f54658158d