### PR TITLE
docs: drop TCP retries references

### DIFF
--- a/docs/transport.md
+++ b/docs/transport.md
@@ -1,0 +1,7 @@
+# Transport
+
+The transport layer handles network communication for `oc-rsync`.
+It currently supports plain TCP connections and SSH tunnels.
+
+Connection attempts are made once and any errors are reported
+immediately without automatic retries.


### PR DESCRIPTION
## Summary
- document transport layer without obsolete TCP retry options

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `make verify-comments SHELL=/bin/bash` *(fails: disallowed comments in acl tests)*
- `make lint SHELL=/bin/bash`


------
https://chatgpt.com/codex/tasks/task_e_68b7529a2ffc8323b040cd4c25f43046