### PR TITLE
Update oc-rsyncd systemd unit

### DIFF
--- a/packaging/oc-rsyncd.conf
+++ b/packaging/oc-rsyncd.conf
@@ -1,6 +1,6 @@
 # packaging/oc-rsyncd.conf
 # Sample oc-rsync daemon configuration mirroring rsyncd.conf semantics
-# Installed at /etc/oc-rsyncd/oc-rsyncd.conf
+# Installed at /etc/oc-rsyncd.conf
 
 # PID file location
 pid file = /run/oc-rsyncd/oc-rsyncd.pid

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -1,7 +1,7 @@
 # packaging/systemd/oc-rsyncd.service
 [Unit]
 Description=oc-rsync daemon
-Documentation=man:oc-rsync(1) man:oc-rsyncd.conf(5)
+Documentation=man:oc-rsyncd(8) man:oc-rsyncd.conf(5) man:oc-rsync(1)
 Wants=network-online.target
 After=network-online.target
 
@@ -10,7 +10,7 @@ Type=notify
 NotifyAccess=main
 User=ocrsync
 Group=ocrsync
-ExecStart=/usr/local/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd/oc-rsyncd.conf
+ExecStart=/usr/local/bin/oc-rsyncd --no-detach --config=/etc/oc-rsyncd.conf
 Restart=on-failure
 RestartSec=2s
 NoNewPrivileges=yes
@@ -31,8 +31,8 @@ RestrictSUIDSGID=yes
 RestrictRealtime=yes
 LockPersonality=yes
 RestrictNamespaces=yes
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE
-AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_CHOWN CAP_DAC_OVERRIDE
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_CHOWN CAP_DAC_OVERRIDE
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 MemoryDenyWriteExecute=yes
 SystemCallFilter=@system-service

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -46,13 +46,15 @@ fn service_unit_matches_spec() {
         "ProtectHome=true",
         "Restart=on-failure",
         "RestartSec=2s",
-        "CapabilityBoundingSet=CAP_NET_BIND_SERVICE",
-        "AmbientCapabilities=CAP_NET_BIND_SERVICE",
+        "CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_CHOWN CAP_DAC_OVERRIDE",
+        "AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_CHOWN CAP_DAC_OVERRIDE",
+        "RestrictNamespaces=yes",
         "RuntimeDirectory=oc-rsyncd",
         "LogsDirectory=oc-rsyncd",
         "StateDirectory=oc-rsyncd",
         "ConfigurationDirectory=oc-rsyncd",
-        "ExecStart=/usr/local/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd/oc-rsyncd.conf",
+        "ExecStart=/usr/local/bin/oc-rsyncd --no-detach --config=/etc/oc-rsyncd.conf",
+        "Documentation=man:oc-rsyncd(8) man:oc-rsyncd.conf(5) man:oc-rsync(1)",
     ] {
         assert!(
             unit.lines().any(|l| l.trim() == expected),


### PR DESCRIPTION
## Summary
- run oc-rsyncd directly in the systemd service and document new man pages
- expand service capabilities and restrictions to meet spec
- update service tests and sample config path

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `make verify-comments` *(fails: disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7538e039883238e936a302c1cd492