### PR TITLE
docs: document oc-rsyncd usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,24 @@ daemon:
 - `packaging/oc-rsyncd.conf` – example configuration file
 - `packaging/systemd/oc-rsyncd.service` – systemd service unit
 
+## oc-rsyncd
+
+A dedicated `oc-rsyncd` binary starts the daemon directly and accepts the same
+flags as `oc-rsync --daemon`.
+
+```bash
+oc-rsyncd --module 'data=/srv/export'
+oc-rsyncd --config /etc/oc-rsyncd.conf
+```
+
+See [docs/daemon.md](docs/daemon.md) for more examples, the
+[`oc-rsyncd.conf(5)`](man/oc-rsyncd.conf.5) reference, and the hardened systemd
+unit at
+[`packaging/systemd/oc-rsyncd.service`](packaging/systemd/oc-rsyncd.service).
+
+The regular `oc-rsync` binary can also launch the daemon by supplying the
+`--daemon` flag.
+
 ## Milestone Roadmap
 1. **M1—Bootstrap** – repository builds; `walk` and `checksums` crates generate file signatures.
 2. **M2—Delta Engine** – `engine` drives local delta transfers with metadata preservation.

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -7,6 +7,46 @@ The default listener binds to all IPv4 interfaces on port 873. Supply
 listener to IPv4 or IPv6 addresses respectively. These can be combined with
 `--address` to bind a specific interface.
 
+## `oc-rsyncd`
+
+A dedicated `oc-rsyncd` binary ships alongside the main CLI and enables daemon
+mode without remembering `--daemon`. It is functionally equivalent to invoking
+`oc-rsync --daemon` and exposes the same flags.
+
+```text
+$ oc-rsyncd --help
+Usage: oc-rsyncd [OPTIONS] --module NAME=PATH...
+
+Options:
+  --config <FILE>        Load daemon configuration
+  --module <NAME=PATH>   Export a module (repeatable)
+  --address <ADDRESS>    Bind to a specific interface
+  --port <PORT>          Listen on a custom TCP port
+  --secrets-file <FILE>  Authentication tokens
+  --no-detach            Stay in the foreground
+```
+
+Common invocations:
+
+```bash
+# Inline module definition
+oc-rsyncd --module 'data=/srv/export'
+
+# Load modules from a config file
+oc-rsyncd --config /etc/oc-rsyncd.conf
+```
+
+The configuration syntax is documented in
+[`oc-rsyncd.conf(5)`](../man/oc-rsyncd.conf.5). A hardened systemd unit is
+available under
+[`packaging/systemd/oc-rsyncd.service`](../packaging/systemd/oc-rsyncd.service).
+
+The `oc-rsync` client can also launch the daemon directly:
+
+```bash
+oc-rsync --daemon --module 'data=/srv/export'
+```
+
 ## Configuration file
 
 `oc-rsync` understands a configuration file that mirrors


### PR DESCRIPTION
## Summary
- document dedicated `oc-rsyncd` binary
- link to `oc-rsyncd.conf(5)` and example systemd unit
- note that `oc-rsync` can also launch the daemon

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `make verify-comments SHELL=/bin/bash` *(fails: disallowed comments)*
- `make lint SHELL=/bin/bash`


------
https://chatgpt.com/codex/tasks/task_e_68b75363aa7483238cdf77732302127f