### PR TITLE
Add oc-rsyncd binary and cross-platform build targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         toolchain: stable
         override: true
     - name: Build
-      run: cargo build --verbose
+      run: make build
     - name: Run tests
       run: cargo test --verbose
     - name: Validate interop matrix docs

--- a/Makefile
+++ b/Makefile
@@ -57,15 +57,30 @@ test-golden:
 build:
 	@echo "RSYNC_UPSTREAM_VER=$(RSYNC_UPSTREAM_VER) BUILD_REVISION=$(BUILD_REVISION) OFFICIAL_BUILD=$(OFFICIAL_BUILD)"
 	@env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" BUILD_REVISION="$(BUILD_REVISION)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" \
-	cargo build -p oc-rsync-bin --bin oc-rsync --release
+	cargo build -p oc-rsync-bin --bin oc-rsync --bin oc-rsyncd --release
 
 # Max performance build (uses your [profile.maxspeed])
 build-maxspeed:
 	@echo "RSYNC_UPSTREAM_VER=$(RSYNC_UPSTREAM_VER) BUILD_REVISION=$(BUILD_REVISION) OFFICIAL_BUILD=$(OFFICIAL_BUILD) [maxspeed]"
 	@env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" BUILD_REVISION="$(BUILD_REVISION)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" \
-	cargo build -p oc-rsync-bin --bin oc-rsync --profile maxspeed --release
+	cargo build -p oc-rsync-bin --bin oc-rsync --bin oc-rsyncd --profile maxspeed --release
+
+TARGETS := aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu x86_64-pc-windows-gnu
+
+.PHONY: $(addprefix build-,$(TARGETS)) $(addprefix build-maxspeed-,$(TARGETS))
+
+build-%:
+	@echo "RSYNC_UPSTREAM_VER=$(RSYNC_UPSTREAM_VER) BUILD_REVISION=$(BUILD_REVISION) OFFICIAL_BUILD=$(OFFICIAL_BUILD) target=$*"
+	@env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" BUILD_REVISION="$(BUILD_REVISION)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" \
+	cargo build -p oc-rsync-bin --bin oc-rsync --bin oc-rsyncd --release --target $*
+
+build-maxspeed-%:
+	@echo "RSYNC_UPSTREAM_VER=$(RSYNC_UPSTREAM_VER) BUILD_REVISION=$(BUILD_REVISION) OFFICIAL_BUILD=$(OFFICIAL_BUILD) [maxspeed] target=$*"
+	@env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" BUILD_REVISION="$(BUILD_REVISION)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" \
+	cargo build -p oc-rsync-bin --bin oc-rsync --bin oc-rsyncd --profile maxspeed --release --target $*
 
 # Show version from the release artifact built above
 version: build
 	./target/release/oc-rsync --version
+	./target/release/oc-rsyncd --version
 

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -8,6 +8,10 @@ build = "build.rs"
 name = "oc-rsync"
 path = "src/main.rs"
 
+[[bin]]
+name = "oc-rsyncd"
+path = "src/daemon.rs"
+
 [dependencies]
 oc-rsync-cli = { path = "../../crates/cli" }
 engine = { path = "../../crates/engine" }

--- a/bin/oc-rsync/src/daemon.rs
+++ b/bin/oc-rsync/src/daemon.rs
@@ -1,0 +1,13 @@
+// bin/oc-rsync/src/daemon.rs
+use oc_rsync_cli::version;
+
+fn main() {
+    if std::env::args().any(|a| a == "--version" || a == "-V") {
+        if !std::env::args().any(|a| a == "--quiet" || a == "-q") {
+            println!("{}", version::render_version_lines().join("\n"));
+        }
+        return;
+    }
+    eprintln!("oc-rsyncd is not yet implemented. Use `oc-rsync --daemon` instead.");
+    std::process::exit(1);
+}


### PR DESCRIPTION
## Summary
- compile both `oc-rsync` and `oc-rsyncd` in build targets
- add cross-platform build rules
- expose both binaries in `version` target and CI

## Testing
- `make build`
- `make version`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `cargo test --all-features` *(fails: missing system library `acl`)*
- `timeout 10s make verify-comments` *(fails: disallowed comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b753aa85f48323bfb3ae333f4c21df