### PR TITLE
docs: record upstream protocol metadata

### DIFF
--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -9,3 +9,12 @@ The following upstream protocol versions are recognized:
 - 29
 
 When connecting to a peer, the highest shared version from this list is selected. Versions earlier than 29 are not supported.
+
+## Version constants
+
+```
+UPSTREAM_VERSION=3.4.1
+SUPPORTED_PROTOCOLS=[32,31,30,29]
+```
+
+The build scripts for `oc-rsync` and `oc-rsyncd` embed these values into the binaries by exporting them as compile-time environment variables (for example `cargo:rustc-env=RSYNC_UPSTREAM_VER=…`) in `build.rs`.


### PR DESCRIPTION
## Summary
- document upstream version and supported protocols in UPSTREAM.md
- note build.rs embedding of version/protocol metadata

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `make verify-comments SHELL=bash` *(fails: crates/cli/src/formatter.rs contains disallowed comments)*
- `make lint SHELL=bash`


------
https://chatgpt.com/codex/tasks/task_e_68b75ad135e88323a8f92b0366c28108