### PR TITLE
Add logging SubscriberConfig builder

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -22,7 +22,7 @@ pub use engine::EngineError;
 use engine::{sync, DeleteMode, IdMapper, Result, Stats, StrongHash, SyncOptions};
 use filters::{default_cvs_rules, parse_with_options, Matcher, Rule};
 pub use formatter::render_help;
-use logging::{human_bytes, parse_escapes, DebugFlag, InfoFlag, LogFormat};
+use logging::{human_bytes, parse_escapes, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
 use meta::{parse_chmod, parse_chown, parse_id_map, IdKind};
 use protocol::CharsetConv;
 #[cfg(feature = "acl")]
@@ -145,16 +145,19 @@ fn init_logging(matches: &ArgMatches) {
         info.clear();
         debug.clear();
     }
-    logging::init(
-        log_format,
-        verbose,
-        &info,
-        &debug,
-        quiet,
-        log_file.map(|p| (p, log_file_fmt)),
-        syslog,
-        journald,
-    );
+    let cfg = SubscriberConfig::builder()
+        .format(log_format)
+        .verbose(verbose)
+        .info(info)
+        .debug(debug)
+        .quiet(quiet)
+        .log_file(log_file.map(|p| (p, log_file_fmt)))
+        .syslog(syslog)
+        .journald(journald)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    logging::init(cfg);
 }
 
 fn locale_charset() -> Option<String> {

--- a/crates/logging/tests/journald.rs
+++ b/crates/logging/tests/journald.rs
@@ -1,7 +1,7 @@
 // crates/logging/tests/journald.rs
 #![cfg(all(unix, feature = "journald"))]
 
-use logging::{subscriber, LogFormat};
+use logging::{subscriber, LogFormat, SubscriberConfig};
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::info;
@@ -13,7 +13,19 @@ fn journald_emits_message() {
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
     std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path);
-    let sub = subscriber(LogFormat::Text, 1, &[], &[], false, None, false, true);
+    let cfg = SubscriberConfig::builder()
+        .format(LogFormat::Text)
+        .verbose(1)
+        .info(vec![])
+        .debug(vec![])
+        .quiet(false)
+        .log_file(None)
+        .syslog(false)
+        .journald(true)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(cfg);
     with_default(sub, || {
         info!(target: "test", "hi");
     });

--- a/crates/logging/tests/levels.rs
+++ b/crates/logging/tests/levels.rs
@@ -1,11 +1,23 @@
 // crates/logging/tests/levels.rs
-use logging::{subscriber, DebugFlag, InfoFlag, LogFormat};
+use logging::{subscriber, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
 use tracing::subscriber::with_default;
 use tracing::Level;
 
 #[test]
 fn info_not_emitted_by_default() {
-    let sub = subscriber(LogFormat::Text, 0, &[], &[], false, None, false, false);
+    let cfg = SubscriberConfig::builder()
+        .format(LogFormat::Text)
+        .verbose(0)
+        .info(vec![])
+        .debug(vec![])
+        .quiet(false)
+        .log_file(None)
+        .syslog(false)
+        .journald(false)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(cfg);
     with_default(sub, || {
         assert!(!tracing::enabled!(Level::INFO));
     });
@@ -13,7 +25,19 @@ fn info_not_emitted_by_default() {
 
 #[test]
 fn verbose_enables_info() {
-    let sub = subscriber(LogFormat::Text, 1, &[], &[], false, None, false, false);
+    let cfg = SubscriberConfig::builder()
+        .format(LogFormat::Text)
+        .verbose(1)
+        .info(vec![])
+        .debug(vec![])
+        .quiet(false)
+        .log_file(None)
+        .syslog(false)
+        .journald(false)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(cfg);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -21,16 +45,19 @@ fn verbose_enables_info() {
 
 #[test]
 fn debug_enables_debug() {
-    let sub = subscriber(
-        LogFormat::Text,
-        0,
-        &[],
-        &[DebugFlag::Flist],
-        false,
-        None,
-        false,
-        false,
-    );
+    let cfg = SubscriberConfig::builder()
+        .format(LogFormat::Text)
+        .verbose(0)
+        .info(vec![])
+        .debug(vec![DebugFlag::Flist])
+        .quiet(false)
+        .log_file(None)
+        .syslog(false)
+        .journald(false)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(cfg);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -38,7 +65,19 @@ fn debug_enables_debug() {
 
 #[test]
 fn debug_with_two_v() {
-    let sub = subscriber(LogFormat::Text, 2, &[], &[], false, None, false, false);
+    let cfg = SubscriberConfig::builder()
+        .format(LogFormat::Text)
+        .verbose(2)
+        .info(vec![])
+        .debug(vec![])
+        .quiet(false)
+        .log_file(None)
+        .syslog(false)
+        .journald(false)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(cfg);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -46,16 +85,19 @@ fn debug_with_two_v() {
 
 #[test]
 fn info_flag_enables_info() {
-    let sub = subscriber(
-        LogFormat::Text,
-        0,
-        &[InfoFlag::Progress],
-        &[],
-        false,
-        None,
-        false,
-        false,
-    );
+    let cfg = SubscriberConfig::builder()
+        .format(LogFormat::Text)
+        .verbose(0)
+        .info(vec![InfoFlag::Progress])
+        .debug(vec![])
+        .quiet(false)
+        .log_file(None)
+        .syslog(false)
+        .journald(false)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(cfg);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -63,7 +105,19 @@ fn info_flag_enables_info() {
 
 #[test]
 fn json_verbose_enables_info() {
-    let sub = subscriber(LogFormat::Json, 1, &[], &[], false, None, false, false);
+    let cfg = SubscriberConfig::builder()
+        .format(LogFormat::Json)
+        .verbose(1)
+        .info(vec![])
+        .debug(vec![])
+        .quiet(false)
+        .log_file(None)
+        .syslog(false)
+        .journald(false)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(cfg);
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });

--- a/crates/logging/tests/syslog.rs
+++ b/crates/logging/tests/syslog.rs
@@ -1,7 +1,7 @@
 // crates/logging/tests/syslog.rs
 #![cfg(all(unix, feature = "syslog"))]
 
-use logging::{subscriber, LogFormat};
+use logging::{subscriber, LogFormat, SubscriberConfig};
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::info;
@@ -13,7 +13,19 @@ fn syslog_emits_message() {
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
     std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path);
-    let sub = subscriber(LogFormat::Text, 1, &[], &[], false, None, true, false);
+    let cfg = SubscriberConfig::builder()
+        .format(LogFormat::Text)
+        .verbose(1)
+        .info(vec![])
+        .debug(vec![])
+        .quiet(false)
+        .log_file(None)
+        .syslog(true)
+        .journald(false)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(cfg);
     with_default(sub, || {
         info!(target: "test", "hello");
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 use compress::available_codecs;
 use engine::{Result, SyncOptions};
 use filters::Matcher;
-use logging::{subscriber, DebugFlag, InfoFlag, LogFormat};
+use logging::{subscriber, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
 use std::path::Path;
 use tracing::subscriber::with_default;
 
@@ -115,16 +115,19 @@ impl SyncConfigBuilder {
 }
 
 pub fn synchronize_with_config(src: &Path, dst: &Path, cfg: &SyncConfig) -> Result<()> {
-    let sub = subscriber(
-        cfg.log_format,
-        cfg.verbose,
-        &cfg.info,
-        &cfg.debug,
-        false,
-        None,
-        false,
-        false,
-    );
+    let sub_cfg = SubscriberConfig::builder()
+        .format(cfg.log_format)
+        .verbose(cfg.verbose)
+        .info(cfg.info.clone())
+        .debug(cfg.debug.clone())
+        .quiet(false)
+        .log_file(None)
+        .syslog(false)
+        .journald(false)
+        .colored(true)
+        .timestamps(false)
+        .build();
+    let sub = subscriber(sub_cfg);
     with_default(sub, || -> Result<()> {
         let opts = SyncOptions {
             perms: cfg.perms,


### PR DESCRIPTION
## Summary
- introduce `SubscriberConfig` and builder for logging options
- refactor subscriber and init to take `SubscriberConfig`
- update call sites and tests to use the new configuration API

## Testing
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `cargo test -p logging`
- `make verify-comments` *(fails: contains disallowed comments)*
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b75b6f67b48323b2f0b119a822dacf