### PR TITLE
test: cover group ID round-trip

### DIFF
--- a/crates/engine/tests/flist.rs
+++ b/crates/engine/tests/flist.rs
@@ -41,6 +41,42 @@ fn roundtrip() {
 }
 
 #[test]
+fn group_id_roundtrip() {
+    let entries = vec![
+        Entry {
+            path: b"a".to_vec(),
+            uid: 1,
+            gid: 2,
+            group: Some(42),
+            xattrs: Vec::new(),
+            acl: Vec::new(),
+            default_acl: Vec::new(),
+        },
+        Entry {
+            path: b"a/b".to_vec(),
+            uid: 1,
+            gid: 3,
+            group: Some(42),
+            xattrs: Vec::new(),
+            acl: Vec::new(),
+            default_acl: Vec::new(),
+        },
+        Entry {
+            path: b"c".to_vec(),
+            uid: 4,
+            gid: 3,
+            group: Some(99),
+            xattrs: Vec::new(),
+            acl: Vec::new(),
+            default_acl: Vec::new(),
+        },
+    ];
+    let payloads = flist::encode(&entries, None);
+    let decoded = flist::decode(&payloads, None).unwrap();
+    assert_eq!(decoded, entries);
+}
+
+#[test]
 fn iconv_roundtrip() {
     let cv = CharsetConv::new(
         Encoding::for_label(b"latin1").unwrap(),

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -36,7 +36,7 @@ when available.
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
 | Path-delta encoding with uid/gid tables | ✅ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
-| Group ID preservation | ⚠️ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
+| Group ID preservation | ✅ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
 | Extended attributes and ACL entries | ✅ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
 
 ## Walk


### PR DESCRIPTION
## Summary
- test file list group ID round-trip encoding/decoding
- mark group ID preservation feature as complete

## Testing
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: contains disallowed comments)*
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*

------
https://chatgpt.com/codex/tasks/task_e_68b761577fc4832382896d4d9ad8537c