### PR TITLE
Implement full rsyncd.conf parsing and daemon startup integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,9 +1012,11 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
+ "daemon",
  "logging",
  "oc-rsync-cli",
  "protocol",
+ "transport",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,10 +63,6 @@ name = "oc-rsync"
 path = "bin/oc-rsync/src/main.rs"
 
 [[bin]]
-name = "oc-rsyncd"
-path = "bin/oc-rsyncd/src/main.rs"
-
-[[bin]]
 name = "flag_matrix"
 path = "tools/flag_matrix.rs"
 

--- a/bin/oc-rsyncd/Cargo.toml
+++ b/bin/oc-rsyncd/Cargo.toml
@@ -12,6 +12,8 @@ path = "src/main.rs"
 oc-rsync-cli = { path = "../../crates/cli" }
 logging = { path = "../../crates/logging" }
 protocol = { path = "../../crates/protocol" }
+daemon = { path = "../../crates/daemon" }
+transport = { path = "../../crates/transport" }
 clap = { version = "4" }
 
 [dev-dependencies]

--- a/bin/oc-rsyncd/src/main.rs
+++ b/bin/oc-rsyncd/src/main.rs
@@ -1,31 +1,10 @@
 // bin/oc-rsyncd/src/main.rs
+use daemon::{load_config, parse_daemon_args, run_daemon, Handler, Module};
 use oc_rsync_cli::version;
-use oc_rsync_cli::{cli_command, EngineError};
-use protocol::ExitCode;
-use std::ffi::OsString;
-use std::io::ErrorKind;
-
-fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
-    use clap::error::ErrorKind::*;
-    match kind {
-        UnknownArgument => ExitCode::Unsupported,
-        InvalidValue
-        | InvalidSubcommand
-        | NoEquals
-        | ValueValidation
-        | TooManyValues
-        | TooFewValues
-        | WrongNumberOfValues
-        | ArgumentConflict
-        | MissingRequiredArgument
-        | MissingSubcommand
-        | InvalidUtf8
-        | DisplayHelpOnMissingArgumentOrSubcommand => ExitCode::SyntaxOrUsage,
-        DisplayHelp | DisplayVersion => ExitCode::Ok,
-        Io | Format => ExitCode::FileIo,
-        _ => ExitCode::SyntaxOrUsage,
-    }
-}
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use transport::AddressFamily;
 
 fn main() {
     if std::env::args().any(|a| a == "--version" || a == "-V") {
@@ -34,56 +13,112 @@ fn main() {
         }
         return;
     }
-    let mut cmd = cli_command();
-    let mut args: Vec<OsString> = std::env::args_os().collect();
-    if !args.iter().any(|a| a == "--daemon") {
-        args.insert(1, OsString::from("--daemon"));
-    }
-    let matches = cmd.try_get_matches_from_mut(args).unwrap_or_else(|e| {
-        use clap::error::ErrorKind;
-        let kind = e.kind();
-        let code = exit_code_from_error_kind(kind);
-        if kind == ErrorKind::DisplayHelp {
-            println!("{}", oc_rsync_cli::render_help(&cmd));
-        } else {
-            let first = e.to_string();
-            let first = first.lines().next().unwrap_or("");
-            let msg = match kind {
-                ErrorKind::UnknownArgument => {
-                    let arg = first.split('\'').nth(1).unwrap_or("");
-                    format!("{arg}: unknown option")
-                }
-                _ => first.strip_prefix("error: ").unwrap_or(first).to_string(),
-            };
-            let desc = match code {
-                ExitCode::Unsupported => "requested action not supported",
-                _ => "syntax or usage error",
-            };
-            let code_num = u8::from(code);
-            eprintln!("rsync: {msg}");
-            eprintln!("rsync error: {desc} (code {code_num})");
-        }
-        std::process::exit(u8::from(code) as i32);
-    });
-    if let Err(e) = oc_rsync_cli::run(&matches) {
-        eprintln!("{e}");
-        let code = match &e {
-            EngineError::Io(err)
-                if matches!(
-                    err.kind(),
-                    ErrorKind::TimedOut
-                        | ErrorKind::ConnectionRefused
-                        | ErrorKind::AddrNotAvailable
-                        | ErrorKind::NetworkUnreachable
-                        | ErrorKind::WouldBlock,
-                ) =>
-            {
-                ExitCode::ConnTimeout
+
+    let mut config: Option<PathBuf> = None;
+    let mut args = Vec::new();
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        if arg == "--config" {
+            if let Some(p) = iter.next() {
+                config = Some(PathBuf::from(p));
             }
-            EngineError::MaxAlloc => ExitCode::Malloc,
-            EngineError::Exit(code, _) => *code,
-            _ => ExitCode::Protocol,
-        };
-        std::process::exit(u8::from(code) as i32);
+        } else if let Some(rest) = arg.strip_prefix("--config=") {
+            config = Some(PathBuf::from(rest));
+        } else {
+            args.push(arg);
+        }
+    }
+
+    let opts = parse_daemon_args(args).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(1);
+    });
+
+    let cfg = load_config(config.as_deref()).unwrap_or_else(|e| {
+        eprintln!("{e}");
+        std::process::exit(1);
+    });
+
+    let mut modules: HashMap<String, Module> = cfg
+        .modules
+        .into_iter()
+        .map(|m| (m.name.clone(), m))
+        .collect();
+
+    if let Some(val) = cfg.use_chroot {
+        for m in modules.values_mut() {
+            m.use_chroot = val;
+        }
+    }
+    if let Some(val) = cfg.numeric_ids {
+        for m in modules.values_mut() {
+            m.numeric_ids = val;
+        }
+    }
+    if let Some(val) = cfg.read_only {
+        for m in modules.values_mut() {
+            m.read_only = val;
+        }
+    }
+    if let Some(val) = cfg.write_only {
+        for m in modules.values_mut() {
+            m.write_only = val;
+        }
+    }
+    if !cfg.refuse_options.is_empty() {
+        for m in modules.values_mut() {
+            m.refuse_options = cfg.refuse_options.clone();
+        }
+    }
+
+    let list = cfg.list.unwrap_or(true);
+    let max_conn = cfg.max_connections;
+
+    let mut port = opts.port;
+    if let Some(p) = cfg.port {
+        port = p;
+    }
+    let mut address = opts.address;
+    let mut family = opts.family;
+    if let Some(a) = cfg.address6 {
+        address = Some(a);
+        family = Some(AddressFamily::V6);
+    } else if let Some(a) = cfg.address {
+        address = Some(a);
+        family = Some(AddressFamily::V4);
+    }
+
+    let uid = cfg.uid.unwrap_or(65534);
+    let gid = cfg.gid.unwrap_or(65534);
+
+    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+
+    if let Err(e) = run_daemon(
+        modules,
+        cfg.secrets_file,
+        None,
+        cfg.hosts_allow,
+        cfg.hosts_deny,
+        cfg.log_file,
+        None,
+        cfg.motd_file,
+        cfg.pid_file,
+        cfg.lock_file,
+        None,
+        cfg.timeout,
+        None,
+        max_conn,
+        cfg.refuse_options,
+        list,
+        port,
+        address,
+        family,
+        uid,
+        gid,
+        handler,
+        false,
+    ) {
+        eprintln!("{e}");
+        std::process::exit(1);
     }
 }

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -74,7 +74,7 @@ when available.
 | Module parsing and secrets auth | ✅ | [tests/daemon_config.rs](../tests/daemon_config.rs)<br>[tests/daemon_auth.sh](../tests/daemon_auth.sh) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
 | IPv6 listener and rate limiting | ✅ | [tests/daemon.rs](../tests/daemon.rs) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
 | Chroot and uid/gid dropping | ⚠️ | [tests/daemon_features.sh](../tests/daemon_features.sh) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
-| `rsyncd.conf` file parsing | ❌ | — | — |
+| `rsyncd.conf` file parsing | ✅ | [tests/daemon_config.rs](../tests/daemon_config.rs) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
 
 ## CLI
 | Feature | Status | Tests | Source |

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -70,13 +70,14 @@ fn parse_module_parses_options() {
     let auth = dir.path().join("auth");
     fs::write(&auth, "alice data\n").unwrap();
     let spec = format!(
-        "data={},hosts-allow=127.0.0.1,hosts-deny=10.0.0.1,auth-users=alice bob,secrets-file={},uid=0,gid=0,timeout=1,use-chroot=no,numeric-ids=yes",
+        "data={},comment=hi,write-only=yes,hosts-allow=127.0.0.1,hosts-deny=10.0.0.1,auth-users=alice bob,secrets-file={},uid=0,gid=0,timeout=1,use-chroot=no,numeric-ids=yes",
         dir.path().display(),
         auth.display()
     );
     let module = parse_module(&spec).unwrap();
     assert_eq!(module.name, "data");
     assert_eq!(module.path, fs::canonicalize(dir.path()).unwrap());
+    assert_eq!(module.comment.as_deref(), Some("hi"));
     assert_eq!(module.hosts_allow, vec!["127.0.0.1".to_string()]);
     assert_eq!(module.hosts_deny, vec!["10.0.0.1".to_string()]);
     assert_eq!(
@@ -89,6 +90,7 @@ fn parse_module_parses_options() {
     assert_eq!(module.timeout, Some(Duration::from_secs(1)));
     assert!(!module.use_chroot);
     assert!(module.numeric_ids);
+    assert!(module.write_only);
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- support module comments and write-only flag in daemon configuration
- load configuration at oc-rsyncd startup and apply global defaults
- test write-only behaviour and new config directives; document parity

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: contains disallowed comments, crates/cli/src/version.rs: contains doc comments, crates/meta/tests/acl_codec.rs: contains disallowed comments, crates/meta/tests/acl_gid.rs: contains disallowed comments)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b7618181cc8323846a3cdbe75e21f0