### PR TITLE
write build info to out dir

### DIFF
--- a/bin/oc-rsync/build.rs
+++ b/bin/oc-rsync/build.rs
@@ -9,14 +9,13 @@ fn main() {
     println!("cargo:rustc-env=BUILD_REVISION={revision}");
     println!("cargo:rustc-env=OFFICIAL_BUILD={official}");
 
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("missing manifest dir");
-    let docs_dir = Path::new(&manifest_dir).join("../../docs");
-    let _ = fs::create_dir_all(&docs_dir);
-    let info_path = docs_dir.join("build_info.md");
+    let out_dir = env::var("OUT_DIR").expect("missing OUT_DIR");
+    let info_path = Path::new(&out_dir).join("build_info.md");
     let contents = format!(
         "rsync upstream version: {upstream}\nbuild revision: {revision}\nofficial build: {official}\n"
     );
-    fs::write(info_path, contents).expect("failed to write build_info.md");
+    fs::write(&info_path, contents).expect("failed to write build_info.md");
+    println!("cargo:rustc-env=BUILD_INFO_PATH={}", info_path.display());
 
     println!("cargo:rerun-if-env-changed=RSYNC_UPSTREAM_VER");
     println!("cargo:rerun-if-env-changed=BUILD_REVISION");

--- a/bin/oc-rsync/tests/version.rs
+++ b/bin/oc-rsync/tests/version.rs
@@ -41,7 +41,7 @@ fn exit_code_is_zero() {
 
 #[test]
 fn build_info_file_has_expected_values() {
-    let info = std::fs::read_to_string("../../docs/build_info.md").unwrap();
+    let info = std::fs::read_to_string(env!("BUILD_INFO_PATH")).unwrap();
     assert!(info.contains(env!("RSYNC_UPSTREAM_VER")));
     assert!(info.contains(env!("BUILD_REVISION")));
     assert!(info.contains(env!("OFFICIAL_BUILD")));

--- a/bin/oc-rsyncd/build.rs
+++ b/bin/oc-rsyncd/build.rs
@@ -9,14 +9,13 @@ fn main() {
     println!("cargo:rustc-env=BUILD_REVISION={revision}");
     println!("cargo:rustc-env=OFFICIAL_BUILD={official}");
 
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("missing manifest dir");
-    let docs_dir = Path::new(&manifest_dir).join("../../docs");
-    let _ = fs::create_dir_all(&docs_dir);
-    let info_path = docs_dir.join("build_info.md");
+    let out_dir = env::var("OUT_DIR").expect("missing OUT_DIR");
+    let info_path = Path::new(&out_dir).join("build_info.md");
     let contents = format!(
         "rsync upstream version: {upstream}\nbuild revision: {revision}\nofficial build: {official}\n"
     );
-    fs::write(info_path, contents).expect("failed to write build_info.md");
+    fs::write(&info_path, contents).expect("failed to write build_info.md");
+    println!("cargo:rustc-env=BUILD_INFO_PATH={}", info_path.display());
 
     println!("cargo:rerun-if-env-changed=RSYNC_UPSTREAM_VER");
     println!("cargo:rerun-if-env-changed=BUILD_REVISION");

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -35,11 +35,6 @@ fn packaging_includes_service_unit() {
         "daemon man page missing from package list:\n{}",
         listing
     );
-    assert!(
-        listing.lines().any(|l| l.trim() == "docs/build_info.md"),
-        "build info missing from package list:\n{}",
-        listing
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- generate build_info.md in Cargo OUT_DIR for both oc-rsync and oc-rsyncd
- read build_info.md via BUILD_INFO_PATH env var in tests and remove docs check in packaging test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: checksum_seed_changes_strong_checksum assertion)*
- `make verify-comments SHELL=bash` *(fails: disallowed comments)*
- `make lint SHELL=bash`
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68b764faf18c8323ad8920816e1b99f3