### PR TITLE
Add oc-rsyncd wrapper and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "logging",
  "oc-rsync-cli",
  "protocol",
+ "tempfile",
 ]
 
 [[package]]

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4" }
 
 [dev-dependencies]
 assert_cmd = "2"
+tempfile = "3"
 
 [features]
 default = []

--- a/bin/oc-rsync/src/daemon.rs
+++ b/bin/oc-rsync/src/daemon.rs
@@ -1,13 +1,34 @@
 // bin/oc-rsync/src/daemon.rs
 use oc_rsync_cli::version;
+use std::ffi::OsString;
+use std::process::Command;
 
 fn main() {
-    if std::env::args().any(|a| a == "--version" || a == "-V") {
-        if !std::env::args().any(|a| a == "--quiet" || a == "-q") {
+    let version = OsString::from("--version");
+    let version_short = OsString::from("-V");
+    let quiet = OsString::from("--quiet");
+    let quiet_short = OsString::from("-q");
+    if std::env::args_os().any(|a| a == version || a == version_short) {
+        if !std::env::args_os().any(|a| a == quiet || a == quiet_short) {
             println!("{}", version::render_version_lines().join("\n"));
         }
         return;
     }
-    eprintln!("oc-rsyncd is not yet implemented. Use `oc-rsync --daemon` instead.");
-    std::process::exit(1);
+
+    let oc_rsync = std::env::var_os("OC_RSYNC_BIN")
+        .or_else(|| option_env!("CARGO_BIN_EXE_oc-rsync").map(OsString::from))
+        .unwrap_or_else(|| OsString::from("oc-rsync"));
+    let status = Command::new(&oc_rsync)
+        .arg("--daemon")
+        .args(std::env::args_os().skip(1))
+        .status()
+        .unwrap_or_else(|e| {
+            eprintln!("{e}");
+            std::process::exit(1);
+        });
+    if let Some(code) = status.code() {
+        std::process::exit(code);
+    } else {
+        std::process::exit(1);
+    }
 }

--- a/bin/oc-rsync/tests/daemon.rs
+++ b/bin/oc-rsync/tests/daemon.rs
@@ -1,0 +1,92 @@
+// bin/oc-rsync/tests/daemon.rs
+use assert_cmd::cargo::{cargo_bin, CommandCargoExt};
+use std::fs;
+use std::io::{BufRead, BufReader};
+use std::net::TcpStream;
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::Duration;
+use tempfile::tempdir;
+
+fn wait_for_daemon(port: u16) {
+    for _ in 0..50 {
+        if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        sleep(Duration::from_millis(50));
+    }
+    panic!("daemon did not start");
+}
+
+#[test]
+fn starts_daemon() {
+    let tmp = tempdir().unwrap();
+    let mut child = Command::cargo_bin("oc-rsyncd")
+        .unwrap()
+        .env("OC_RSYNC_BIN", cargo_bin("oc-rsync"))
+        .args([
+            "--no-detach",
+            "--port=0",
+            "--address=127.0.0.1",
+            "--module",
+            &format!("data={}", tmp.path().display()),
+        ])
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let port = {
+        let mut line = String::new();
+        let mut reader = BufReader::new(child.stdout.take().unwrap());
+        reader.read_line(&mut line).unwrap();
+        line.trim().parse::<u16>().unwrap()
+    };
+
+    wait_for_daemon(port);
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+fn accepts_config_option() {
+    let tmp = tempdir().unwrap();
+    let pid_file = tmp.path().join("pid");
+    let cfg_path = tmp.path().join("conf");
+    fs::write(
+        &cfg_path,
+        format!(
+            "pid file = {}\n[data]\npath = {}\n",
+            pid_file.display(),
+            tmp.path().display()
+        ),
+    )
+    .unwrap();
+
+    let mut child = Command::cargo_bin("oc-rsyncd")
+        .unwrap()
+        .env("OC_RSYNC_BIN", cargo_bin("oc-rsync"))
+        .args([
+            "--no-detach",
+            "--port=0",
+            "--address=127.0.0.1",
+            "--config",
+            cfg_path.to_str().unwrap(),
+        ])
+        .stdout(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let port = {
+        let mut line = String::new();
+        let mut reader = BufReader::new(child.stdout.take().unwrap());
+        reader.read_line(&mut line).unwrap();
+        line.trim().parse::<u16>().unwrap()
+    };
+
+    wait_for_daemon(port);
+    assert!(pid_file.exists());
+
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary
- replace placeholder oc-rsyncd with wrapper that launches `oc-rsync --daemon`
- support `--version`/`--quiet` parity and `OC_RSYNC_BIN` override
- add integration tests ensuring oc-rsyncd starts and honors config files

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint SHELL=/bin/bash`
- `make verify-comments SHELL=/bin/bash` *(fails: crates/cli/src/formatter.rs contains disallowed comments)*
- `cargo test` *(fails: checksum_seed_changes_strong_checksum)*
- `cargo test -p oc-rsync-bin`
- `cargo test -p oc-rsync-bin --all-features` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68b7650e31b0832381e34955854829cd