### PR TITLE
Add md5 and sha1 checksum seed tests

### DIFF
--- a/tests/checksum_seed.rs
+++ b/tests/checksum_seed.rs
@@ -1,5 +1,5 @@
 // tests/checksum_seed.rs
-use checksums::ChecksumConfigBuilder;
+use checksums::{ChecksumConfigBuilder, StrongHash};
 
 #[test]
 fn checksum_seed_changes_weak_checksum() {
@@ -24,5 +24,45 @@ fn checksum_seed_changes_strong_checksum() {
     let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
     assert_eq!(hex0, "ea91f391e02b5e19f432b43bd87a531d");
     assert_eq!(hex1, "92e5994e0babddace03f0ff88f767181");
+    assert_ne!(hex0, hex1);
+}
+
+#[test]
+fn checksum_seed_changes_strong_checksum_md5() {
+    let data = b"hello world";
+    let cfg0 = ChecksumConfigBuilder::new()
+        .seed(0)
+        .strong(StrongHash::Md5)
+        .build();
+    let cfg1 = ChecksumConfigBuilder::new()
+        .seed(1)
+        .strong(StrongHash::Md5)
+        .build();
+    let strong0 = cfg0.checksum(data).strong;
+    let strong1 = cfg1.checksum(data).strong;
+    let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
+    let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
+    assert_eq!(hex0, "be4b47980f89d075f8f7e7a9fab84e29");
+    assert_eq!(hex1, "157438ee5881306a9af554cc9b3e5974");
+    assert_ne!(hex0, hex1);
+}
+
+#[test]
+fn checksum_seed_changes_strong_checksum_sha1() {
+    let data = b"hello world";
+    let cfg0 = ChecksumConfigBuilder::new()
+        .seed(0)
+        .strong(StrongHash::Sha1)
+        .build();
+    let cfg1 = ChecksumConfigBuilder::new()
+        .seed(1)
+        .strong(StrongHash::Sha1)
+        .build();
+    let strong0 = cfg0.checksum(data).strong;
+    let strong1 = cfg1.checksum(data).strong;
+    let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
+    let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
+    assert_eq!(hex0, "1fb6475c524899f98b088f7608bdab8f1591e078");
+    assert_eq!(hex1, "076b085b6d84fa708d235291ae6ac3059b45bb37");
     assert_ne!(hex0, hex1);
 }


### PR DESCRIPTION
## Summary
- test md5 strong checksum responds to checksum seeds
- test sha1 strong checksum responds to checksum seeds

## Testing
- `cargo fmt --all`
- `make verify-comments` *(fails: crates/meta/tests/numeric_ids_nonroot.rs: contains disallowed comments)*
- `bash scripts/check-comments.sh tests/checksum_seed.rs`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_config_write_only_module_rejects_reads)*
- `cargo test --test checksum_seed`


------
https://chatgpt.com/codex/tasks/task_e_68b76993879c8323b46463ef0d25dd02