### PR TITLE
Wrap oc-rsyncd as thin oc-rsync --daemon wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ daemon:
 
 ## oc-rsyncd
 
-A dedicated `oc-rsyncd` binary starts the daemon directly and accepts the same
-flags as `oc-rsync --daemon`.
+The `oc-rsyncd` binary is a thin wrapper around `oc-rsync --daemon` that
+forwards all arguments.  Its `--help` and `--version` output therefore match the
+daemon mode of `oc-rsync` byte-for-byte.
 
 ```bash
 oc-rsyncd --module 'data=/srv/export'

--- a/bin/oc-rsyncd/src/main.rs
+++ b/bin/oc-rsyncd/src/main.rs
@@ -1,124 +1,24 @@
 // bin/oc-rsyncd/src/main.rs
-use daemon::{load_config, parse_daemon_args, run_daemon, Handler, Module};
-use oc_rsync_cli::version;
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::Arc;
-use transport::AddressFamily;
+use std::ffi::OsString;
+use std::process::Command;
 
 fn main() {
-    if std::env::args().any(|a| a == "--version" || a == "-V") {
-        if !std::env::args().any(|a| a == "--quiet" || a == "-q") {
-            println!("{}", version::render_version_lines().join("\n"));
-        }
-        return;
-    }
+    let oc_rsync = std::env::var_os("OC_RSYNC_BIN")
+        .or_else(|| option_env!("CARGO_BIN_EXE_oc-rsync").map(OsString::from))
+        .unwrap_or_else(|| OsString::from("oc-rsync"));
 
-    let mut config: Option<PathBuf> = None;
-    let mut args = Vec::new();
-    let mut iter = std::env::args().skip(1);
-    while let Some(arg) = iter.next() {
-        if arg == "--config" {
-            if let Some(p) = iter.next() {
-                config = Some(PathBuf::from(p));
-            }
-        } else if let Some(rest) = arg.strip_prefix("--config=") {
-            config = Some(PathBuf::from(rest));
-        } else {
-            args.push(arg);
-        }
-    }
+    let status = Command::new(oc_rsync)
+        .arg("--daemon")
+        .args(std::env::args_os().skip(1))
+        .status()
+        .unwrap_or_else(|e| {
+            eprintln!("{e}");
+            std::process::exit(1);
+        });
 
-    let opts = parse_daemon_args(args).unwrap_or_else(|e| {
-        eprintln!("{e}");
-        std::process::exit(1);
-    });
-
-    let cfg = load_config(config.as_deref()).unwrap_or_else(|e| {
-        eprintln!("{e}");
-        std::process::exit(1);
-    });
-
-    let mut modules: HashMap<String, Module> = cfg
-        .modules
-        .into_iter()
-        .map(|m| (m.name.clone(), m))
-        .collect();
-
-    if let Some(val) = cfg.use_chroot {
-        for m in modules.values_mut() {
-            m.use_chroot = val;
-        }
-    }
-    if let Some(val) = cfg.numeric_ids {
-        for m in modules.values_mut() {
-            m.numeric_ids = val;
-        }
-    }
-    if let Some(val) = cfg.read_only {
-        for m in modules.values_mut() {
-            m.read_only = val;
-        }
-    }
-    if let Some(val) = cfg.write_only {
-        for m in modules.values_mut() {
-            m.write_only = val;
-        }
-    }
-    if !cfg.refuse_options.is_empty() {
-        for m in modules.values_mut() {
-            m.refuse_options = cfg.refuse_options.clone();
-        }
-    }
-
-    let list = cfg.list.unwrap_or(true);
-    let max_conn = cfg.max_connections;
-
-    let mut port = opts.port;
-    if let Some(p) = cfg.port {
-        port = p;
-    }
-    let mut address = opts.address;
-    let mut family = opts.family;
-    if let Some(a) = cfg.address6 {
-        address = Some(a);
-        family = Some(AddressFamily::V6);
-    } else if let Some(a) = cfg.address {
-        address = Some(a);
-        family = Some(AddressFamily::V4);
-    }
-
-    let uid = cfg.uid.unwrap_or(65534);
-    let gid = cfg.gid.unwrap_or(65534);
-
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
-
-    if let Err(e) = run_daemon(
-        modules,
-        cfg.secrets_file,
-        None,
-        cfg.hosts_allow,
-        cfg.hosts_deny,
-        cfg.log_file,
-        None,
-        cfg.motd_file,
-        cfg.pid_file,
-        cfg.lock_file,
-        None,
-        cfg.timeout,
-        None,
-        max_conn,
-        cfg.refuse_options,
-        list,
-        port,
-        address,
-        family,
-        uid,
-        gid,
-        handler,
-        false,
-    ) {
-        eprintln!("{e}");
+    if let Some(code) = status.code() {
+        std::process::exit(code);
+    } else {
         std::process::exit(1);
     }
 }

--- a/bin/oc-rsyncd/tests/wrapper.rs
+++ b/bin/oc-rsyncd/tests/wrapper.rs
@@ -1,0 +1,41 @@
+// bin/oc-rsyncd/tests/wrapper.rs
+use assert_cmd::cargo::{cargo_bin, CommandCargoExt};
+use std::process::Command;
+
+#[test]
+fn version_matches_daemon() {
+    let expected = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--daemon", "--version"])
+        .output()
+        .unwrap();
+
+    let actual = Command::cargo_bin("oc-rsyncd")
+        .unwrap()
+        .env("OC_RSYNC_BIN", cargo_bin("oc-rsync"))
+        .arg("--version")
+        .output()
+        .unwrap();
+
+    assert_eq!(actual.stdout, expected.stdout);
+    assert_eq!(actual.stderr, expected.stderr);
+}
+
+#[test]
+fn help_matches_daemon() {
+    let expected = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--daemon", "--help"])
+        .output()
+        .unwrap();
+
+    let actual = Command::cargo_bin("oc-rsyncd")
+        .unwrap()
+        .env("OC_RSYNC_BIN", cargo_bin("oc-rsync"))
+        .arg("--help")
+        .output()
+        .unwrap();
+
+    assert_eq!(actual.stdout, expected.stdout);
+    assert_eq!(actual.stderr, expected.stderr);
+}

--- a/crates/meta/tests/numeric_ids_nonroot.rs
+++ b/crates/meta/tests/numeric_ids_nonroot.rs
@@ -11,7 +11,6 @@ use users::get_user_by_name;
 #[test]
 fn numeric_ids_chown_permission_denied_matches_rsync() -> std::io::Result<()> {
     if !Uid::effective().is_root() {
-        // The test requires root to set up differing numeric IDs.
         return Ok(());
     }
     let dir = tempdir()?;
@@ -29,7 +28,6 @@ fn numeric_ids_chown_permission_denied_matches_rsync() -> std::io::Result<()> {
 
     let src_file = src.join("file");
     fs::write(&src_file, b"data")?;
-    // Assign a uid/gid that will not match the running user.
     chown(&src_file, Some(Uid::from_raw(1)), Some(Gid::from_raw(1)))?;
     let meta = Metadata::from_path(&src_file, Options::default())?;
 

--- a/packaging/oc-rsyncd.conf
+++ b/packaging/oc-rsyncd.conf
@@ -1,6 +1,7 @@
 # packaging/oc-rsyncd.conf
 # Sample oc-rsync daemon configuration mirroring rsyncd.conf semantics
 # Installed at /etc/oc-rsyncd.conf
+# Used with `oc-rsync --daemon` (also invoked by the `oc-rsyncd` wrapper).
 
 # PID file location
 pid file = /run/oc-rsyncd.pid

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -1,6 +1,8 @@
 # packaging/systemd/oc-rsyncd.service
 [Unit]
 Description=oc-rsync daemon
+# oc-rsyncd is a thin wrapper around `oc-rsync --daemon`.
+# This service calls `oc-rsync --daemon` directly.
 Documentation=man:oc-rsyncd(8) man:oc-rsyncd.conf(5) man:oc-rsync(1)
 Wants=network-online.target
 After=network-online.target


### PR DESCRIPTION
## Summary
- route oc-rsyncd through `oc-rsync --daemon` instead of implementing arguments itself
- verify oc-rsyncd `--help` and `--version` output matches `oc-rsync --daemon`
- document wrapper behavior in README and packaging samples

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: daemon_config_write_only_module_rejects_reads)*
- `cargo test -p oc-rsyncd-bin`


------
https://chatgpt.com/codex/tasks/task_e_68b769c716e88323877f55391b269b77