### PR TITLE
Add cargo config for optimized release builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,33 @@
+[profile.release]
+lto = "fat"
+codegen-units = 1
+opt-level = 3
+panic = "abort"
+strip = "symbols"
+
+debug = false
+overflow-checks = false
+incremental = false
+
+[profile.maxspeed]
+inherits = "release"
+
+[build]
+rustflags = ["-Ctarget-cpu=native"]
+
+[target.aarch64-apple-darwin]
+linker = "clang"
+rustflags = ["-Ctarget-cpu=apple-m1"]
+
+[target.x86_64-apple-darwin]
+linker = "clang"
+rustflags = ["-Ctarget-cpu=x86-64-v2"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-Ctarget-cpu=x86-64-v2"]
+
+[target.x86_64-pc-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc"
+ar = "x86_64-w64-mingw32-gcc-ar"
+rustflags = ["-Ctarget-cpu=x86-64-v2"]
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       with:
         toolchain: stable
         override: true
-    - name: Build
-      run: make build
-    - name: Run tests
-      run: cargo test --verbose
+    - name: Build (release profile)
+      run: cargo build --profile release --workspace --bins
+    - name: Run tests (release profile)
+      run: cargo test --profile release --verbose
     - name: Validate interop matrix docs
       run: scripts/check-run-matrix-docs.sh
       

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,24 +83,3 @@ acl = ["engine/acl", "oc-rsync-cli/acl", "meta/acl"]
 cli = []
 # Enables AVX-512 implementations requiring a nightly toolchain
 nightly = ["checksums/nightly", "compress/nightly"]
-
-[profile.release]
-# Keep release sane for local builds; CI will use [profile.maxspeed]
-opt-level = 3
-lto = "thin"
-codegen-units = 16
-panic = "abort"
-debug = false
-overflow-checks = false
-incremental = false
-
-# Ultra-optimized profile (CI will use this)
-[profile.maxspeed]
-inherits = "release"
-opt-level = 3           # maximum LLVM optimizations
-lto = "fat"             # best runtime perf (slower link, larger bin)
-codegen-units = 1       # better inlining/opts across crates
-panic = "abort"         # remove unwinding paths
-debug = false
-overflow-checks = false
-incremental = false


### PR DESCRIPTION
## Summary
- add centralized cargo config defining optimized release profile
- remove old profile settings from Cargo.toml
- run release-profile builds and tests in CI

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_config_write_only_module_rejects_reads)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76f67f75083239923c3e98248d3e3