### PR TITLE
Add linting, coverage, packaging and sync workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,26 +2,62 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  linux:
+  lint-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        override: true
-    - name: Build
-      run: make build
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Validate interop matrix docs
-      run: scripts/check-run-matrix-docs.sh
-      
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Format
+        run: cargo fmt --all --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Test with coverage
+        run: cargo llvm-cov --all-features --fail-under-lines 95
+      - name: Validate interop matrix docs
+        run: scripts/check-run-matrix-docs.sh
+
+  build:
+    needs: lint-test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} --bin oc-rsync
+      - name: Package artifacts
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/oc-rsync dist/oc-rsync-${{ matrix.target }}
+          sha256sum dist/oc-rsync-${{ matrix.target }} > dist/oc-rsync-${{ matrix.target }}.sha256
+          cargo install cargo-sbom || true
+          cargo sbom --output dist/oc-rsync-${{ matrix.target }}-sbom.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oc-rsync-${{ matrix.target }}
+          path: dist
+

--- a/.github/workflows/daily-status.yml
+++ b/.github/workflows/daily-status.yml
@@ -1,0 +1,25 @@
+name: Daily Status
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate status report
+        run: |
+          DATE=$(date -u +%F)
+          mkdir -p reports
+          echo "# Daily status for $DATE" > reports/daily_estimate.md
+      - uses: actions/upload-artifact@v4
+        with:
+          name: daily-status
+          path: reports/daily_estimate.md
+

--- a/.github/workflows/nightly-upstream-sync.yml
+++ b/.github/workflows/nightly-upstream-sync.yml
@@ -1,0 +1,35 @@
+name: Nightly Upstream Sync
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build oc-rsync
+        run: cargo build --bin oc-rsync
+      - name: Fetch upstream rsync
+        run: scripts/fetch-rsync.sh
+      - name: Generate oc-rsync manpages
+        run: scripts/generate-manpages.sh
+      - name: Version diff
+        run: |
+          rsync --version > upstream_version.txt
+          cargo run --quiet --bin oc-rsync -- --version > oc_rsync_version.txt
+          diff -u upstream_version.txt oc_rsync_version.txt || true
+      - name: Manpage diff
+        run: |
+          diff -u rsync-3.4.1/rsync.1 man/oc-rsync.1 || true
+          diff -u rsync-3.4.1/rsyncd.conf.5 man/oc-rsyncd.conf.5 || true
+

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,0 +1,19 @@
+name: Super-Linter
+
+on:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Super-Linter
+        uses: github/super-linter@v6
+        env:
+          DEFAULT_BRANCH: main
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
- expand CI to enforce formatting, linting and coverage and cross-compile artifacts with checksums and SBOM
- add GitHub Super-Linter workflow
- add nightly upstream sync and daily status report workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_config_write_only_module_rejects_reads)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76f6c546c8323a5c26e96353378c0