### PR TITLE
Add xtask utilities and daily status workflow

### DIFF
--- a/.github/workflows/daily-status.yml
+++ b/.github/workflows/daily-status.yml
@@ -1,0 +1,26 @@
+name: Daily Status
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - run: cargo install cargo-llvm-cov
+      - run: mkdir -p reports && cargo llvm-cov --workspace --json --summary-only --output-path reports/coverage.json
+      - run: cargo run --package xtask --bin status
+      - uses: actions/upload-artifact@v4
+        with:
+          name: daily-status
+          path: reports/daily_estimate.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "rustc_lexer",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "bin/oc-rsync",
     "bin/oc-rsyncd",
     "crates/logging",
+    "xtask",
 ]
 resolver = "2"
 

--- a/reports/daily_estimate.md
+++ b/reports/daily_estimate.md
@@ -1,0 +1,3 @@
+# Daily Estimate
+
+Placeholder

--- a/scripts/check-comments.sh
+++ b/scripts/check-comments.sh
@@ -5,4 +5,4 @@ files="$@"
 if [ $# -eq 0 ]; then
     files=$(git ls-files '*.rs')
 fi
-cargo run --quiet --bin strip-rs-comments -- --check $files
+cargo run --quiet -p xtask --bin comment_lint -- $files

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rustc_lexer = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[[bin]]
+name = "comment_lint"
+path = "src/bin/comment_lint.rs"
+
+[[bin]]
+name = "status"
+path = "src/bin/status.rs"

--- a/xtask/src/bin/comment_lint.rs
+++ b/xtask/src/bin/comment_lint.rs
@@ -1,0 +1,61 @@
+// xtask/src/bin/comment_lint.rs
+use rustc_lexer::{tokenize, TokenKind};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn check_file(path: &Path, root: &Path) -> bool {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    };
+    let Ok(content) = fs::read_to_string(&abs) else {
+        return false;
+    };
+    let rel = abs.strip_prefix(root).unwrap_or(&abs);
+    let rel_str = rel.to_string_lossy().replace('\\', "/");
+    let first = content.lines().next().unwrap_or("");
+    let header = format!("// {}", rel_str);
+    if first.trim_end() != header {
+        eprintln!("{}: incorrect header", rel_str);
+        return false;
+    }
+    let mut pos = 0;
+    let mut allow = true;
+    for token in tokenize(&content) {
+        let text = &content[pos..pos + token.len];
+        if matches!(
+            token.kind,
+            TokenKind::LineComment | TokenKind::BlockComment { .. }
+        ) {
+            if allow {
+                if text.starts_with("///") {
+                    eprintln!("{}: doc comment", rel_str);
+                    return false;
+                }
+            } else {
+                eprintln!("{}: additional comments", rel_str);
+                return false;
+            }
+        }
+        if text.contains('\n') {
+            allow = false;
+        }
+        pos += token.len;
+    }
+    true
+}
+
+fn main() {
+    let root = env::current_dir().unwrap();
+    let mut ok = true;
+    for arg in env::args().skip(1) {
+        if !check_file(PathBuf::from(arg).as_path(), &root) {
+            ok = false;
+        }
+    }
+    if !ok {
+        std::process::exit(1);
+    }
+}

--- a/xtask/src/bin/status.rs
+++ b/xtask/src/bin/status.rs
@@ -1,0 +1,34 @@
+// xtask/src/bin/status.rs
+use serde_json::Value;
+use std::fs;
+
+fn read_coverage() -> f64 {
+    let text = fs::read_to_string("reports/coverage.json").unwrap_or_default();
+    let v: Value = serde_json::from_str(&text).unwrap_or_default();
+    v.pointer("/data/0/totals/lines/percent")
+        .and_then(|x| x.as_f64())
+        .unwrap_or(0.0)
+}
+
+fn count_features() -> (usize, usize) {
+    let text = fs::read_to_string("docs/feature_matrix.md").unwrap_or_default();
+    let mut total = 0;
+    let mut done = 0;
+    for line in text.lines() {
+        if line.starts_with("| `--") {
+            total += 1;
+            if line.contains("| ✅ |") {
+                done += 1;
+            }
+        }
+    }
+    (done, total)
+}
+
+fn main() {
+    let cov = read_coverage();
+    let (done, total) = count_features();
+    let out = format!("# Daily Estimate\n\ncoverage: {cov:.1}%\nfeatures: {done}/{total}\n");
+    fs::create_dir_all("reports").ok();
+    fs::write("reports/daily_estimate.md", out).unwrap();
+}


### PR DESCRIPTION
## Summary
- add `xtask` workspace utilities for comment linting and status reporting
- generate placeholder daily estimate report and workflow

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(failed: daemon_config_write_only_module_rejects_reads)*
- `cargo test --all-features` *(failed: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b76f6fa7b883239d3e9bd1a603013a