### PR TITLE
Use short git revision and pass build metadata to tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # If user passes UPSTREAM/OFFICIAL, map them to RSYNC_UPSTREAM_VER/OFFICIAL_BUILD unless already set.
 RSYNC_UPSTREAM_VER ?= $(UPSTREAM)
 OFFICIAL_BUILD     ?= $(OFFICIAL)
-BUILD_REVISION     ?= $(shell git rev-parse HEAD)
+BUILD_REVISION     ?= $(shell git rev-parse --short=12 HEAD)
 
 VERIFY_COMMENT_FILES := $(shell git ls-files '*.rs')
 
@@ -35,7 +35,7 @@ interop:
 	bash tests/interop/run_matrix.sh
 
 test-golden:
-	cargo build --quiet -p oc-rsync-bin --bin oc-rsync
+	env RSYNC_UPSTREAM_VER="$(RSYNC_UPSTREAM_VER)" BUILD_REVISION="$(BUILD_REVISION)" OFFICIAL_BUILD="$(OFFICIAL_BUILD)" cargo build --quiet -p oc-rsync-bin --bin oc-rsync
 	@set -euo pipefail; \
 	for script in tests/golden/cli_parity/*.sh; do \
 		echo "Running $$script"; \


### PR DESCRIPTION
## Summary
- compute `BUILD_REVISION` using a short 12-character commit hash
- forward build metadata in the `test-golden` target so builds include revision info

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(failed: daemon_config_write_only_module_rejects_reads)*
- `cargo test --all-features` *(failed: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b77481bce88323be3c9608c951e963