### PR TITLE
Fix clap ErrorKind exit code mapping

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -8,8 +8,7 @@ use std::io::ErrorKind;
 fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
     use clap::error::ErrorKind::*;
     match kind {
-        UnknownArgument => ExitCode::Unsupported,
-        InvalidValue
+        UnknownArgument
         | InvalidSubcommand
         | NoEquals
         | ValueValidation
@@ -21,6 +20,7 @@ fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
         | MissingSubcommand
         | InvalidUtf8
         | DisplayHelpOnMissingArgumentOrSubcommand => ExitCode::SyntaxOrUsage,
+        InvalidValue => ExitCode::Unsupported,
         DisplayHelp | DisplayVersion => ExitCode::Ok,
         Io | Format => ExitCode::FileIo,
         _ => ExitCode::SyntaxOrUsage,
@@ -87,5 +87,41 @@ fn main() {
             _ => ExitCode::Protocol,
         };
         std::process::exit(u8::from(code) as i32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::exit_code_from_error_kind;
+    use clap::error::ErrorKind::*;
+    use protocol::ExitCode;
+
+    #[test]
+    fn maps_error_kinds_to_exit_codes() {
+        let cases = [
+            (UnknownArgument, ExitCode::SyntaxOrUsage),
+            (InvalidSubcommand, ExitCode::SyntaxOrUsage),
+            (NoEquals, ExitCode::SyntaxOrUsage),
+            (ValueValidation, ExitCode::SyntaxOrUsage),
+            (TooManyValues, ExitCode::SyntaxOrUsage),
+            (TooFewValues, ExitCode::SyntaxOrUsage),
+            (WrongNumberOfValues, ExitCode::SyntaxOrUsage),
+            (ArgumentConflict, ExitCode::SyntaxOrUsage),
+            (MissingRequiredArgument, ExitCode::SyntaxOrUsage),
+            (MissingSubcommand, ExitCode::SyntaxOrUsage),
+            (InvalidUtf8, ExitCode::SyntaxOrUsage),
+            (
+                DisplayHelpOnMissingArgumentOrSubcommand,
+                ExitCode::SyntaxOrUsage,
+            ),
+            (InvalidValue, ExitCode::Unsupported),
+            (DisplayHelp, ExitCode::Ok),
+            (DisplayVersion, ExitCode::Ok),
+            (Io, ExitCode::FileIo),
+            (Format, ExitCode::FileIo),
+        ];
+        for (kind, code) in cases {
+            assert_eq!(exit_code_from_error_kind(kind), code);
+        }
     }
 }

--- a/tests/clap_error_codes.rs
+++ b/tests/clap_error_codes.rs
@@ -5,7 +5,7 @@ use protocol::ExitCode;
 use tempfile::tempdir;
 
 #[test]
-fn unsupported_option_returns_exit_code_unsupported() {
+fn unknown_option_is_usage_error() {
     let src = tempdir().unwrap();
     let dst = tempdir().unwrap();
     Command::cargo_bin("oc-rsync")
@@ -17,11 +17,9 @@ fn unsupported_option_returns_exit_code_unsupported() {
         ])
         .assert()
         .failure()
-        .code(u8::from(ExitCode::Unsupported) as i32)
+        .code(u8::from(ExitCode::SyntaxOrUsage) as i32)
         .stderr(contains("rsync: --bad-option: unknown option"))
-        .stderr(contains(
-            "rsync error: requested action not supported (code 4)",
-        ));
+        .stderr(contains("rsync error: syntax or usage error (code 1)"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- map all `clap::error::ErrorKind` variants to rsync-compatible `ExitCode` values
- test each `ErrorKind` mapping
- update CLI integration test for unknown options

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_config_write_only_module_rejects_reads)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b77513db6483238174614554a771f9