### PR TITLE
Add remote-to-remote piping support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
+ "transport",
  "walk",
  "xattr",
 ]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -19,7 +19,7 @@ mod formatter;
 use compress::{available_codecs, Codec};
 use encoding_rs::Encoding;
 pub use engine::EngineError;
-use engine::{sync, DeleteMode, IdMapper, Result, Stats, StrongHash, SyncOptions};
+use engine::{pipe_sessions, sync, DeleteMode, IdMapper, Result, Stats, StrongHash, SyncOptions};
 use filters::{default_cvs_rules, parse_with_options, Matcher, Rule};
 pub use formatter::render_help;
 use logging::{
@@ -1047,20 +1047,26 @@ pub fn parse_remote_spec(input: &str) -> Result<RemoteSpec> {
     }))
 }
 
-fn pipe_transports<S, D>(src: &mut S, dst: &mut D) -> io::Result<()>
-where
-    S: Transport,
-    D: Transport,
-{
-    let mut buf = [0u8; 8192];
-    loop {
-        let n = src.receive(&mut buf)?;
-        if n == 0 {
-            break;
+pub fn parse_remote_specs(src: &str, dst: &str) -> Result<(RemoteSpec, RemoteSpec)> {
+    let src_spec = parse_remote_spec(src)?;
+    let dst_spec = parse_remote_spec(dst)?;
+    if let (
+        RemoteSpec::Remote {
+            host: sh, path: sp, ..
+        },
+        RemoteSpec::Remote {
+            host: dh, path: dp, ..
+        },
+    ) = (&src_spec, &dst_spec)
+    {
+        if sh.is_empty() || dh.is_empty() {
+            return Err(EngineError::Other("remote host missing".into()));
         }
-        dst.send(&buf[..n])?;
+        if sp.path.as_os_str().is_empty() || dp.path.as_os_str().is_empty() {
+            return Err(EngineError::Other("remote path missing".into()));
+        }
     }
-    Ok(())
+    Ok((src_spec, dst_spec))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1317,8 +1323,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     if opts.recursive && !opts.quiet {
         println!("recursive mode enabled");
     }
-    let src = parse_remote_spec(&src_arg)?;
-    let mut dst = parse_remote_spec(&dst_arg)?;
+    let (src, mut dst) = parse_remote_specs(&src_arg, &dst_arg)?;
     if opts.mkpath {
         match &dst {
             RemoteSpec::Local(ps) => {
@@ -1961,8 +1966,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
 
                         if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
-                            pipe_transports(&mut src_session, &mut dst_session)
-                                .map_err(|e| EngineError::Other(e.to_string()))?;
+                            pipe_sessions(&mut src_session, &mut dst_session)?;
                             let (src_err, _) = src_session.stderr();
                             if !src_err.is_empty() {
                                 let msg = if let Some(cv) = iconv.as_ref() {
@@ -1983,8 +1987,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                                 return Err(EngineError::Other(msg));
                             }
                         } else {
-                            pipe_transports(&mut src_session, &mut dst_session)
-                                .map_err(|e| EngineError::Other(e.to_string()))?;
+                            pipe_sessions(&mut src_session, &mut dst_session)?;
                             let (src_err, _) = src_session.stderr();
                             if !src_err.is_empty() {
                                 let msg = if let Some(cv) = iconv.as_ref() {
@@ -2039,11 +2042,9 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                         )?;
                         if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
-                            pipe_transports(&mut src_session, &mut dst_session)
-                                .map_err(|e| EngineError::Other(e.to_string()))?;
+                            pipe_sessions(&mut src_session, &mut dst_session)?;
                         } else {
-                            pipe_transports(&mut src_session, &mut dst_session)
-                                .map_err(|e| EngineError::Other(e.to_string()))?;
+                            pipe_sessions(&mut src_session, &mut dst_session)?;
                         }
                         Stats::default()
                     }
@@ -2080,8 +2081,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                         )?;
                         if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
-                            pipe_transports(&mut src_session, &mut dst_session)
-                                .map_err(|e| EngineError::Other(e.to_string()))?;
+                            pipe_sessions(&mut src_session, &mut dst_session)?;
                             let dst_session = dst_session.into_inner();
                             let (dst_err, _) = dst_session.stderr();
                             if !dst_err.is_empty() {
@@ -2093,8 +2093,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                                 return Err(EngineError::Other(msg));
                             }
                         } else {
-                            pipe_transports(&mut src_session, &mut dst_session)
-                                .map_err(|e| EngineError::Other(e.to_string()))?;
+                            pipe_sessions(&mut src_session, &mut dst_session)?;
                             let (dst_err, _) = dst_session.stderr();
                             if !dst_err.is_empty() {
                                 let msg = if let Some(cv) = iconv.as_ref() {
@@ -2140,11 +2139,9 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                         .map_err(EngineError::from)?;
                         if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
-                            pipe_transports(&mut src_session, &mut dst_session)
-                                .map_err(|e| EngineError::Other(e.to_string()))?;
+                            pipe_sessions(&mut src_session, &mut dst_session)?;
                         } else {
-                            pipe_transports(&mut src_session, &mut dst_session)
-                                .map_err(|e| EngineError::Other(e.to_string()))?;
+                            pipe_sessions(&mut src_session, &mut dst_session)?;
                         }
                         let (src_err, _) = src_session.stderr();
                         if !src_err.is_empty() {

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -18,6 +18,7 @@ libc = "0.2"
 memmap2 = "0.9"
 tempfile = "3"
 tracing = "0.1"
+transport = { path = "../transport" }
 
 [dev-dependencies]
 compress = { path = "../compress" }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -19,6 +19,7 @@ use std::sync::OnceLock;
 #[cfg(unix)]
 use std::time::Duration;
 use tempfile::{Builder, NamedTempFile};
+use transport::{pipe, Transport};
 
 pub use checksums::StrongHash;
 use checksums::{ChecksumConfig, ChecksumConfigBuilder};
@@ -1969,6 +1970,15 @@ pub fn select_codec(remote: &[Codec], opts: &SyncOptions) -> Option<Codec> {
         .clone()
         .unwrap_or_else(|| vec![Codec::Zstd, Codec::Zlibx, Codec::Zlib]);
     choices.into_iter().find(|c| remote.contains(c))
+}
+
+pub fn pipe_sessions<S, D>(src: &mut S, dst: &mut D) -> Result<Stats>
+where
+    S: Transport,
+    D: Transport,
+{
+    pipe(src, dst).map_err(|e| EngineError::Other(e.to_string()))?;
+    Ok(Stats::default())
 }
 
 fn unescape_rsync(path: &str) -> String {

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -14,6 +14,22 @@ pub fn rate_limited<T: Transport>(inner: T, bwlimit: u64) -> RateLimitedTranspor
     RateLimitedTransport::new(inner, bwlimit)
 }
 
+pub fn pipe<S, D>(src: &mut S, dst: &mut D) -> io::Result<()>
+where
+    S: Transport,
+    D: Transport,
+{
+    let mut buf = [0u8; 8192];
+    loop {
+        let n = src.receive(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        dst.send(&buf[..n])?;
+    }
+    Ok(())
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum AddressFamily {
     V4,

--- a/crates/transport/tests/pipe.rs
+++ b/crates/transport/tests/pipe.rs
@@ -1,0 +1,72 @@
+// crates/transport/tests/pipe.rs
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+use tempfile::tempdir;
+use transport::{pipe, SshStdioTransport, TcpTransport};
+
+fn wait_for<F: Fn() -> bool>(cond: F) {
+    let start = std::time::Instant::now();
+    while !cond() {
+        if start.elapsed() > std::time::Duration::from_secs(1) {
+            panic!("timed out waiting for condition");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn pipe_ssh_transports() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src.txt");
+    let dst = dir.path().join("dst.txt");
+    fs::write(&src, b"ssh_remote").unwrap();
+
+    let mut src_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat {}", src.display())]).unwrap();
+    let mut dst_session =
+        SshStdioTransport::spawn("sh", ["-c", &format!("cat > {}", dst.display())]).unwrap();
+
+    pipe(&mut src_session, &mut dst_session).unwrap();
+    drop(dst_session);
+    drop(src_session);
+    wait_for(|| dst.exists());
+    let out = fs::read(dst).unwrap();
+    assert_eq!(out, b"ssh_remote");
+}
+
+#[test]
+fn pipe_tcp_transports() {
+    let dir = tempdir().unwrap();
+    let dst = dir.path().join("copy.txt");
+    let data = b"daemon_remote".to_vec();
+
+    let src_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let src_port = src_listener.local_addr().unwrap().port();
+    let src_handle = thread::spawn(move || {
+        let (mut stream, _) = src_listener.accept().unwrap();
+        stream.write_all(&data).unwrap();
+    });
+
+    let dst_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let dst_port = dst_listener.local_addr().unwrap().port();
+    let dst_file = dst.clone();
+    let dst_handle = thread::spawn(move || {
+        let (mut stream, _) = dst_listener.accept().unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).unwrap();
+        fs::write(dst_file, buf).unwrap();
+    });
+
+    let mut src_session = TcpTransport::connect("127.0.0.1", src_port, None, None).unwrap();
+    let mut dst_session = TcpTransport::connect("127.0.0.1", dst_port, None, None).unwrap();
+
+    pipe(&mut src_session, &mut dst_session).unwrap();
+    drop(dst_session);
+    drop(src_session);
+    src_handle.join().unwrap();
+    dst_handle.join().unwrap();
+    let out = fs::read(dst).unwrap();
+    assert_eq!(out, b"daemon_remote");
+}


### PR DESCRIPTION
## Summary
- detect remote source and destination simultaneously in CLI
- move remote piping into engine/transport
- exercise remote→remote data flow over SSH and daemon transports

## Testing
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: daemon_config_write_only_module_rejects_reads)*
- `cargo test -p transport --test pipe`


------
https://chatgpt.com/codex/tasks/task_e_68b77586f1bc83238d3a924bc28ca79c