### PR TITLE
ci: install libacl system dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libacl1-dev
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy
@@ -47,6 +49,8 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
           override: true
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libacl1-dev
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }} --bin oc-rsync
       - name: Package artifacts


### PR DESCRIPTION
## Summary
- install libacl1-dev before building in CI

## Testing
- `cargo test` *(fails: daemon_config_write_only_module_rejects_reads)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b778361b2c8323a76b563cf6fac765