### PR TITLE
Skip super_overrides_fake_super when not root

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3763,6 +3763,10 @@ fn cvs_exclude_skips_ignored_files() {
 #[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn super_overrides_fake_super() {
+    if !Uid::effective().is_root() {
+        eprintln!("skipping super_overrides_fake_super: requires root");
+        return;
+    }
     let tmp = tempdir().unwrap();
     let src_dir = tmp.path().join("src");
     let dst_dir = tmp.path().join("dst");


### PR DESCRIPTION
## Summary
- skip super_overrides_fake_super test unless running as root
- gate test with required unix + xattr configuration

## Testing
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `cargo test --features xattr` *(fails: daemon_config_write_only_module_rejects_reads)*

------
https://chatgpt.com/codex/tasks/task_e_68b77eaf8d0883238021ee2c360bbe33