### PR TITLE
Skip super override test when not root

### DIFF
--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -873,9 +873,13 @@ fn fake_super_stores_xattrs() {
     assert!(xattr::get(&dst_file, "user.rsync.uid").unwrap().is_some());
 }
 
-#[cfg(all(feature = "xattr"))]
+#[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn super_overrides_fake_super() {
+    if !Uid::effective().is_root() {
+        println!("Skipping super_overrides_fake_super test: requires root");
+        return;
+    }
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let dst = tmp.path().join("dst");


### PR DESCRIPTION
## Summary
- skip `super_overrides_fake_super` when not run as root
- gate the test on Unix and `xattr`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: `daemon_config_write_only_module_rejects_reads`)*
- `cargo test -p engine --features xattr` *(fails: duplicate `xattrs_roundtrip`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b78144b4a88323a6efe88af60d615e