### PR TITLE
cfg-gate can_chown mutability

### DIFF
--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -313,7 +313,10 @@ impl Metadata {
             expected_uid = uid;
             expected_gid = gid;
 
+            #[cfg(target_os = "linux")]
             let mut can_chown = unistd::Uid::effective().is_root();
+            #[cfg(not(target_os = "linux"))]
+            let can_chown = unistd::Uid::effective().is_root();
             #[cfg(target_os = "linux")]
             {
                 if !can_chown {


### PR DESCRIPTION
## Summary
- avoid unused `mut` warnings by only mutating `can_chown` on Linux

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test` *(fails: daemon_config_write_only_module_rejects_reads)*

------
https://chatgpt.com/codex/tasks/task_e_68b781d9c34083238aae5779cc0b0a5d