### PR TITLE
cli: drop unused imports

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -32,9 +32,8 @@ pub use engine::EngineError;
 use engine::{pipe_sessions, sync, DeleteMode, Result, Stats, StrongHash, SyncOptions};
 use filters::{default_cvs_rules, Matcher, Rule};
 pub use formatter::render_help;
-use logging::{human_bytes, parse_escapes, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
-use meta::{parse_chmod, parse_chown, parse_id_map, IdKind};
-use protocol::CharsetConv;
+use logging::{human_bytes, parse_escapes, InfoFlag};
+use meta::{parse_chmod, parse_chown, IdKind};
 #[cfg(feature = "acl")]
 use protocol::CAP_ACLS;
 #[cfg(feature = "xattr")]


### PR DESCRIPTION
## Summary
- remove unused imports from CLI library

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused variable in tests/daemon_config.rs and Clippy warnings in tests/cli.rs)*
- `cargo test` *(terminated after long-running tests)*
- `cargo test -p oc-rsync-cli` *(fails: unresolved import `daemon::authenticate` and missing `clap::Parser` for `ClientOpts` tests)*
- `make verify-comments` *(fails: incorrect header in crates/cli/src/daemon.rs, crates/cli/src/options.rs, crates/cli/src/utils.rs)*
- `make lint`
- `cargo build -p oc-rsync-cli`


------
https://chatgpt.com/codex/tasks/task_e_68b787ab3e0c83238da86ae6bba70904