### PR TITLE
Skip chown tests when not root

### DIFF
--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -4,10 +4,11 @@ use std::os::unix::fs::PermissionsExt;
 
 use filetime::FileTime;
 use meta::{Metadata, Options};
-use nix::unistd::{chown, Gid, Uid};
+use nix::unistd::{chown, geteuid, Gid, Uid};
 use std::time::SystemTime;
 use tempfile::tempdir;
 
+// Requires root privileges to change file ownership; skipped otherwise.
 #[test]
 fn roundtrip_full_metadata() -> std::io::Result<()> {
     let dir = tempdir()?;
@@ -39,6 +40,10 @@ fn roundtrip_full_metadata() -> std::io::Result<()> {
         FileTime::from_unix_time(1, 0),
         FileTime::from_unix_time(1, 0),
     )?;
+    if geteuid().as_raw() != 0 {
+        eprintln!("skipping roundtrip_full_metadata: requires root");
+        return Ok(());
+    }
     chown(&dst, Some(Uid::from_raw(1)), Some(Gid::from_raw(1)))?;
 
     let opts = Options {
@@ -65,6 +70,7 @@ fn roundtrip_full_metadata() -> std::io::Result<()> {
     Ok(())
 }
 
+// Requires root privileges to change file ownership; skipped otherwise.
 #[test]
 fn default_skips_owner_group_perms() -> std::io::Result<()> {
     let dir = tempdir()?;
@@ -86,6 +92,10 @@ fn default_skips_owner_group_perms() -> std::io::Result<()> {
         nix::sys::stat::Mode::from_bits_truncate(0o600),
         nix::sys::stat::FchmodatFlags::NoFollowSymlink,
     )?;
+    if geteuid().as_raw() != 0 {
+        eprintln!("skipping default_skips_owner_group_perms: requires root");
+        return Ok(());
+    }
     chown(&dst, Some(Uid::from_raw(1)), Some(Gid::from_raw(1)))?;
 
     let orig = Metadata::from_path(&dst, Options::default())?;


### PR DESCRIPTION
## Summary
- avoid chown calls in metadata roundtrip tests unless running as root
- document root-only requirement for ownership tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused imports in crates/cli/src/lib.rs)*
- `cargo test` *(fails: hung tests, aborted after running for over 60s)*
- `make verify-comments` *(fails: incorrect header and additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b78591a8148323bac9114c96052c15