### PR TITLE
test: share full metadata options

### DIFF
--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -1,3 +1,4 @@
+// crates/cli/src/daemon.rs
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write};

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -32,9 +32,8 @@ pub use engine::EngineError;
 use engine::{pipe_sessions, sync, DeleteMode, Result, Stats, StrongHash, SyncOptions};
 use filters::{default_cvs_rules, Matcher, Rule};
 pub use formatter::render_help;
-use logging::{human_bytes, parse_escapes, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
-use meta::{parse_chmod, parse_chown, parse_id_map, IdKind};
-use protocol::CharsetConv;
+use logging::{human_bytes, parse_escapes, InfoFlag};
+use meta::{parse_chmod, parse_chown, IdKind};
 #[cfg(feature = "acl")]
 use protocol::CAP_ACLS;
 #[cfg(feature = "xattr")]

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -1,3 +1,4 @@
+// crates/cli/src/options.rs
 use std::path::PathBuf;
 use std::time::Duration;
 

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -1,3 +1,4 @@
+// crates/cli/src/utils.rs
 use std::collections::HashSet;
 use std::env;
 use std::ffi::OsString;

--- a/crates/meta/tests/chown_nonroot.rs
+++ b/crates/meta/tests/chown_nonroot.rs
@@ -47,9 +47,11 @@ fn chown_permission_denied_matches_rsync() -> std::io::Result<()> {
 
     let our_file = our_dest.join("file");
     fs::copy(&src_file, &our_file)?;
-    let mut opts = Options::default();
-    opts.owner = true;
-    opts.group = true;
+    let opts = Options {
+        owner: true,
+        group: true,
+        ..Default::default()
+    };
     meta.apply(&our_file, opts)?;
     let our_meta = fs::symlink_metadata(&our_file)?;
 

--- a/crates/meta/tests/common.rs
+++ b/crates/meta/tests/common.rs
@@ -1,0 +1,14 @@
+// crates/meta/tests/common.rs
+use meta::Options;
+
+pub fn full_metadata_opts() -> Options {
+    Options {
+        owner: true,
+        group: true,
+        perms: true,
+        times: true,
+        atimes: true,
+        crtimes: true,
+        ..Default::default()
+    }
+}

--- a/crates/meta/tests/fake_super.rs
+++ b/crates/meta/tests/fake_super.rs
@@ -1,10 +1,15 @@
 // crates/meta/tests/fake_super.rs
 #[cfg(all(unix, feature = "xattr"))]
-use meta::{Metadata, Options};
+use meta::Metadata;
 #[cfg(all(unix, feature = "xattr"))]
 use std::fs;
 #[cfg(all(unix, feature = "xattr"))]
 use tempfile::tempdir;
+
+#[cfg(all(unix, feature = "xattr"))]
+mod common;
+#[cfg(all(unix, feature = "xattr"))]
+use common::full_metadata_opts;
 
 #[cfg(all(unix, feature = "xattr"))]
 use nix::unistd::Uid;
@@ -27,14 +32,9 @@ fn fake_super_roundtrip() -> std::io::Result<()> {
         xattr::set(&src, "user.rsync.gid", b"0")?;
         xattr::set(&src, "user.rsync.mode", b"4755")?;
     }
-    let opts = Options {
-        owner: true,
-        group: true,
-        perms: true,
-        fake_super: true,
-        xattrs: true,
-        ..Default::default()
-    };
+    let mut opts = full_metadata_opts();
+    opts.fake_super = true;
+    opts.xattrs = true;
     let meta = Metadata::from_path(&src, opts.clone())?;
     meta.apply(&dst, opts.clone())?;
     #[cfg(feature = "xattr")]

--- a/crates/meta/tests/numeric_ids_nonroot.rs
+++ b/crates/meta/tests/numeric_ids_nonroot.rs
@@ -51,10 +51,12 @@ fn numeric_ids_chown_permission_denied_matches_rsync() -> std::io::Result<()> {
 
     let our_file = our_dest.join("file");
     fs::copy(&src_file, &our_file)?;
-    let mut opts = Options::default();
-    opts.owner = true;
-    opts.group = true;
-    opts.numeric_ids = true;
+    let opts = Options {
+        owner: true,
+        group: true,
+        numeric_ids: true,
+        ..Default::default()
+    };
     meta.apply(&our_file, opts)?;
     let our_meta = fs::symlink_metadata(&our_file)?;
 

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -8,6 +8,9 @@ use nix::unistd::{chown, Gid, Uid};
 use std::time::SystemTime;
 use tempfile::tempdir;
 
+mod common;
+use common::full_metadata_opts;
+
 #[test]
 fn roundtrip_full_metadata() -> std::io::Result<()> {
     let dir = tempdir()?;
@@ -41,15 +44,7 @@ fn roundtrip_full_metadata() -> std::io::Result<()> {
     )?;
     chown(&dst, Some(Uid::from_raw(1)), Some(Gid::from_raw(1)))?;
 
-    let opts = Options {
-        owner: true,
-        group: true,
-        perms: true,
-        times: true,
-        atimes: true,
-        crtimes: true,
-        ..Default::default()
-    };
+    let opts = full_metadata_opts();
     let meta = Metadata::from_path(&src, opts.clone())?;
     meta.apply(&dst, opts.clone())?;
     let applied = Metadata::from_path(&dst, opts)?;


### PR DESCRIPTION
## Summary
- add `full_metadata_opts` helper for meta tests
- use common options in metadata roundtrip and fake super tests
- fix lint and header issues in related tests and CLI modules

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test -p meta` *(fails: chown_permission_denied_matches_rsync)*
- `cargo test -p meta --all-features -- --skip chown_permission_denied_matches_rsync` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68b7857eea6483238b139fccf688f4cc