### PR TITLE
Use slice first in CLI test

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -824,9 +824,9 @@ fn progress_parity() {
 
     let up_parts: Vec<_> = up_line.split_whitespace().collect();
     let our_parts: Vec<_> = our_line.split_whitespace().collect();
-    assert_eq!(up_parts.get(0), our_parts.get(0));
+    assert_eq!(up_parts.first(), our_parts.first());
     assert_eq!(up_parts.get(1), our_parts.get(1));
-    assert!(our_parts.get(2).map_or(false, |s| s.ends_with("KB/s")));
+    assert!(our_parts.get(2).is_some_and(|s| s.ends_with("KB/s")));
     let rate_placeholder: String = our_parts[2]
         .chars()
         .map(|c| if c.is_ascii_digit() { 'X' } else { c })

--- a/tests/daemon_config.rs
+++ b/tests/daemon_config.rs
@@ -277,7 +277,6 @@ fn daemon_config_write_only_module_rejects_reads() {
     t.send(b"\n").unwrap();
     let mut resp = [0u8; 128];
     let n = t.receive(&mut resp).unwrap_or(0);
-    let msg = String::from_utf8_lossy(&resp[..n]);
     assert!(n == 0 || String::from_utf8_lossy(&resp[..n]).contains("write only"));
     let _ = child.kill();
     let _ = child.wait();


### PR DESCRIPTION
## Summary
- prefer `first()` over numeric index access in CLI test
- clean up unused variable in daemon config test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: running tests/daemon_config.rs for >60s)*
- `make verify-comments` *(fails: incorrect header in crates/cli/src/daemon.rs etc.)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b78b0ee2d48323be0b28722d501bea