### PR TITLE
Use msg in daemon test and add headers

### DIFF
--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -1,3 +1,5 @@
+// crates/cli/src/daemon.rs
+
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Write};

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -1,3 +1,5 @@
+// crates/cli/src/options.rs
+
 use std::path::PathBuf;
 use std::time::Duration;
 

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -1,3 +1,5 @@
+// crates/cli/src/utils.rs
+
 use std::collections::HashSet;
 use std::env;
 use std::ffi::OsString;

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -1,4 +1,5 @@
 // crates/meta/tests/roundtrip.rs
+
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 
@@ -8,7 +9,6 @@ use nix::unistd::{chown, geteuid, Gid, Uid};
 use std::time::SystemTime;
 use tempfile::tempdir;
 
-// Requires root privileges to change file ownership; skipped otherwise.
 #[test]
 fn roundtrip_full_metadata() -> std::io::Result<()> {
     let dir = tempdir()?;
@@ -70,7 +70,6 @@ fn roundtrip_full_metadata() -> std::io::Result<()> {
     Ok(())
 }
 
-// Requires root privileges to change file ownership; skipped otherwise.
 #[test]
 fn default_skips_owner_group_perms() -> std::io::Result<()> {
     let dir = tempdir()?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -824,9 +824,9 @@ fn progress_parity() {
 
     let up_parts: Vec<_> = up_line.split_whitespace().collect();
     let our_parts: Vec<_> = our_line.split_whitespace().collect();
-    assert_eq!(up_parts.get(0), our_parts.get(0));
+    assert_eq!(up_parts.first(), our_parts.first());
     assert_eq!(up_parts.get(1), our_parts.get(1));
-    assert!(our_parts.get(2).map_or(false, |s| s.ends_with("KB/s")));
+    assert!(our_parts.get(2).is_some_and(|s| s.ends_with("KB/s")));
     let rate_placeholder: String = our_parts[2]
         .chars()
         .map(|c| if c.is_ascii_digit() { 'X' } else { c })

--- a/tests/daemon_config.rs
+++ b/tests/daemon_config.rs
@@ -278,7 +278,7 @@ fn daemon_config_write_only_module_rejects_reads() {
     let mut resp = [0u8; 128];
     let n = t.receive(&mut resp).unwrap_or(0);
     let msg = String::from_utf8_lossy(&resp[..n]);
-    assert!(n == 0 || String::from_utf8_lossy(&resp[..n]).contains("write only"));
+    assert!(n == 0 || msg.contains("write only"));
     let _ = child.kill();
     let _ = child.wait();
 }


### PR DESCRIPTION
## Summary
- use previously decoded message in daemon config test assertion
- tweak CLI test for clippy compliance
- add missing path headers to CLI and meta files

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(hangs: daemon_config_read_only_module_rejects_writes)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b78b1dad448323b5484765bb8a7e15