### PR TITLE
Align stats output with rsync

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1053,17 +1053,24 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         }
     };
     if opts.stats && !opts.quiet {
-        println!("Number of deleted files: {}", stats.files_deleted);
+        if stats.files_deleted > 0 {
+            println!("Number of deleted files: {}", stats.files_deleted);
+        }
         println!(
             "Number of regular files transferred: {}",
             stats.files_transferred
         );
         let bytes = if opts.human_readable {
-            human_bytes(stats.bytes_transferred)
+            let hb = human_bytes(stats.bytes_transferred);
+            if hb.trim_end().ends_with('B') {
+                hb
+            } else {
+                format!("{hb} bytes")
+            }
         } else {
-            stats.bytes_transferred.to_string()
+            format!("{} bytes", stats.bytes_transferred)
         };
-        println!("Total transferred file size: {} bytes", bytes);
+        println!("Total transferred file size: {bytes}");
         tracing::info!(
             target: InfoFlag::Stats.target(),
             files_transferred = stats.files_transferred,

--- a/tests/snapshots/cli__stats_parity.snap
+++ b/tests/snapshots/cli__stats_parity.snap
@@ -1,8 +1,6 @@
 ---
-# updated snapshot after aligning stats output
 source: tests/cli.rs
 expression: "our_stats.join(\"\\n\")"
 ---
-Number of deleted files: 0
 Number of regular files transferred: 1
 Total transferred file size: 5 bytes


### PR DESCRIPTION
## Summary
- suppress "Number of deleted files" when no deletions occur
- format transferred byte counts to mirror rsync output
- harden stats parity test and update snapshot

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(passes)*
- `make lint`
- `make verify-comments` *(fails: crates/meta/tests/roundtrip.rs: additional comments)*

------
https://chatgpt.com/codex/tasks/task_e_68b7913f8cd483238b0414f95c52331e