### PR TITLE
Add fuzzy-match tests to engine

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -351,7 +351,8 @@ fn levenshtein(a: &str, b: &str) -> usize {
     prev[b.len()]
 }
 
-fn fuzzy_match(dest: &Path) -> Option<PathBuf> {
+#[doc(hidden)]
+pub fn fuzzy_match(dest: &Path) -> Option<PathBuf> {
     let parent = dest.parent()?;
     let stem = dest.file_stem()?.to_string_lossy().to_string();
     let mut best: Option<(usize, PathBuf)> = None;

--- a/crates/engine/tests/fuzzy.rs
+++ b/crates/engine/tests/fuzzy.rs
@@ -1,0 +1,60 @@
+// crates/engine/tests/fuzzy.rs
+use std::fs;
+
+use compress::available_codecs;
+use engine::{fuzzy_match, sync, SyncOptions};
+use filters::Matcher;
+use tempfile::tempdir;
+
+#[test]
+fn fuzzy_match_exact_stem() {
+    let tmp = tempdir().unwrap();
+    let target = tmp.path().join("file.txt");
+    let candidate = tmp.path().join("file.old");
+    fs::write(&candidate, b"old").unwrap();
+    assert_eq!(fuzzy_match(&target).unwrap(), candidate);
+}
+
+#[test]
+fn fuzzy_match_prefers_closest_name() {
+    let tmp = tempdir().unwrap();
+    let target = tmp.path().join("file.txt");
+    let close = tmp.path().join("fike");
+    let far = tmp.path().join("bike");
+    fs::write(&close, b"close").unwrap();
+    fs::write(&far, b"far").unwrap();
+    assert_eq!(fuzzy_match(&target).unwrap(), close);
+}
+
+#[test]
+fn fuzzy_match_case_insensitive() {
+    let tmp = tempdir().unwrap();
+    let target = tmp.path().join("FILE.txt");
+    let candidate = tmp.path().join("file");
+    fs::write(&candidate, b"data").unwrap();
+    assert_eq!(fuzzy_match(&target).unwrap(), candidate);
+}
+
+#[test]
+fn engine_sync_uses_fuzzy_match() {
+    let tmp = tempdir().unwrap();
+    let src_dir = tmp.path().join("src");
+    let dst_dir = tmp.path().join("dst");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+    fs::write(src_dir.join("file"), b"hello").unwrap();
+    fs::write(dst_dir.join("file.old"), b"world").unwrap();
+    fs::write(dst_dir.join("fike"), b"???").unwrap();
+    sync(
+        &src_dir,
+        &dst_dir,
+        &Matcher::default(),
+        &available_codecs(),
+        &SyncOptions {
+            fuzzy: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(fs::read(dst_dir.join("file")).unwrap(), b"hello");
+}


### PR DESCRIPTION
## Summary
- expose `fuzzy_match` for testing
- add unit and integration tests for fuzzy match behavior

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p engine` *(fails: symlink_atimes_roundtrip)*
- `make verify-comments` *(fails: crates/meta/tests/roundtrip.rs: additional comments)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b7923f375483239c759eb7f8b58bdb