### PR TITLE
Use actual uid/gid in daemon auth test

### DIFF
--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -264,6 +264,9 @@ fn pipe_transport_opts(
 #[test]
 #[serial]
 fn module_authentication_and_hosts_enforced() {
+    use nix::unistd::{getegid, geteuid};
+    let uid = geteuid().as_raw();
+    let gid = getegid().as_raw();
     let dir = tempdir().unwrap();
     let auth = dir.path().join("auth");
     fs::write(&auth, "alice data\n").unwrap();
@@ -292,8 +295,8 @@ fn module_authentication_and_hosts_enforced() {
         true,
         &[],
         "127.0.0.1",
-        0,
-        0,
+        uid,
+        gid,
         &handler,
     )
     .unwrap();
@@ -310,8 +313,8 @@ fn module_authentication_and_hosts_enforced() {
         true,
         &[],
         "127.0.0.1",
-        0,
-        0,
+        uid,
+        gid,
         &handler,
     )
     .unwrap_err();
@@ -328,8 +331,8 @@ fn module_authentication_and_hosts_enforced() {
         true,
         &[],
         "10.0.0.1",
-        0,
-        0,
+        uid,
+        gid,
         &handler,
     )
     .unwrap_err();


### PR DESCRIPTION
## Summary
- capture the current effective uid/gid in the daemon authentication test
- use these ids when invoking `handle_connection`

## Testing
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `cargo test --test daemon`
- `cargo test` *(fails: local_sync_without_flag_fails)*

------
https://chatgpt.com/codex/tasks/task_e_68b791eb06808323b15230de4917e878