### PR TITLE
Use constant-time token comparison

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "encoding_rs",
  "filelist",
  "indexmap",
+ "subtle",
 ]
 
 [[package]]
@@ -1500,6 +1501,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -12,7 +12,6 @@ use tempfile::tempdir;
 mod common;
 use common::full_metadata_opts;
 
-// Requires root privileges to change file ownership; skipped otherwise.
 #[test]
 fn roundtrip_full_metadata() -> std::io::Result<()> {
     let dir = tempdir()?;

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -10,6 +10,7 @@ compress = { path = "../compress" }
 checksums = { path = "../checksums" }
 filelist = { path = "../filelist" }
 encoding_rs = "0.8"
+subtle = "2"
 
 [features]
 default = []

--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -3,6 +3,7 @@ use std::io::{self, Read, Write};
 use std::time::Duration;
 
 use checksums::{strong_digest, StrongHash};
+use subtle::ConstantTimeEq;
 
 use crate::{
     negotiate_caps, negotiate_version, Demux, ExitCode, Frame, Message, Mux, UnknownExit,
@@ -107,7 +108,9 @@ impl<R: Read, W: Write> Server<R, W> {
             buf.extend_from_slice(CHALLENGE);
             buf.extend_from_slice(tok.as_bytes());
             let expected = strong_digest(&buf, StrongHash::Md5, 0);
-            if expected[..16] != resp {
+            let expected_arr: [u8; 16] =
+                expected[..16].try_into().expect("MD5 digests are 16 bytes");
+            if expected_arr.ct_eq(&resp).unwrap_u8() != 1 {
                 return Err(io::Error::new(
                     io::ErrorKind::PermissionDenied,
                     "invalid challenge response",

--- a/crates/protocol/tests/auth.rs
+++ b/crates/protocol/tests/auth.rs
@@ -71,3 +71,33 @@ fn server_rejects_invalid_challenge() {
     assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
     assert_eq!(output, CHALLENGE.to_vec());
 }
+
+#[test]
+fn server_rejects_mismatched_token_constant_time() {
+    let local = available_codecs();
+    let payload = encode_codecs(&local);
+    let frame = Message::Codecs(payload.clone()).to_frame(0, None);
+    let mut frame_buf = Vec::new();
+    frame.encode(&mut frame_buf).unwrap();
+    let latest = SUPPORTED_PROTOCOLS[0];
+    let server_token = "secret";
+    let wrong_token = "not_secret";
+    let mut data = CHALLENGE.to_vec();
+    data.extend_from_slice(wrong_token.as_bytes());
+    let resp = strong_digest(&data, StrongHash::Md5, 0);
+    let mut input = Cursor::new({
+        let mut v = vec![0, 0];
+        v.extend_from_slice(&resp);
+        v.extend_from_slice(&latest.to_be_bytes());
+        v.extend_from_slice(&SUPPORTED_CAPS.to_be_bytes());
+        v.extend_from_slice(&frame_buf);
+        v
+    });
+    let mut output = Vec::new();
+    let mut srv = Server::new(&mut input, &mut output, Duration::from_secs(30));
+    let err = srv
+        .handshake(latest, SUPPORTED_CAPS, &local, Some(server_token))
+        .unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_eq!(output, CHALLENGE.to_vec());
+}


### PR DESCRIPTION
## Summary
- avoid timing leaks in server challenge response by using `subtle::ConstantTimeEq`
- test mismatched token challenge handling to exercise constant-time path
- tidy meta roundtrip test comment for comment linter

## Testing
- `cargo fmt --all`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68b7924f71448323a78dcdf6f4cddc6b