### PR TITLE
Ensure stats are reported and test success

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1065,9 +1065,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         }
     };
     if opts.stats && !opts.quiet {
-        if stats.files_deleted > 0 {
-            println!("Number of deleted files: {}", stats.files_deleted);
-        }
+        println!("Number of deleted files: {}", stats.files_deleted);
         println!(
             "Number of regular files transferred: {}",
             stats.files_transferred

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -847,6 +847,12 @@ fn stats_parity() {
         .output()
         .unwrap();
 
+    assert!(
+        ours.status.success(),
+        "oc-rsync failed: {}",
+        String::from_utf8_lossy(&ours.stderr)
+    );
+
     let up_stdout = String::from_utf8_lossy(&up.stdout);
     let mut up_stats: Vec<String> = up_stdout
         .lines()

--- a/tests/snapshots/cli__stats_parity.snap
+++ b/tests/snapshots/cli__stats_parity.snap
@@ -2,5 +2,6 @@
 source: tests/cli.rs
 expression: "our_stats.join(\"\\n\")"
 ---
+Number of deleted files: 0
 Number of regular files transferred: 1
 Total transferred file size: 5 bytes


### PR DESCRIPTION
## Summary
- assert `oc-rsync` succeeds before parsing stats output
- always print deleted file count in `--stats` output
- update stats snapshot to include deleted count

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: test suite hangs on `sparse_files_preserved`, aborted after 60s)*
- `cargo test stats_parity --test cli -- --nocapture`
- `cargo test stats_are_printed --test cli -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68b7f01ed76c83238e21be581306be65