### PR TITLE
Annotate SyncConfigBuilder with #[must_use]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,83 +56,99 @@ impl SyncConfig {
 }
 
 #[derive(Default)]
+#[must_use]
 pub struct SyncConfigBuilder {
     cfg: SyncConfig,
 }
 
 impl SyncConfigBuilder {
+    #[must_use]
     pub fn log_format(mut self, log_format: LogFormat) -> Self {
         self.cfg.log_format = log_format;
         self
     }
 
+    #[must_use]
     pub fn verbose(mut self, verbose: u8) -> Self {
         self.cfg.verbose = verbose;
         self
     }
 
+    #[must_use]
     pub fn info(mut self, info: Vec<InfoFlag>) -> Self {
         self.cfg.info = info;
         self
     }
 
+    #[must_use]
     pub fn debug(mut self, debug: Vec<DebugFlag>) -> Self {
         self.cfg.debug = debug;
         self
     }
 
+    #[must_use]
     pub fn perms(mut self, enable: bool) -> Self {
         self.cfg.perms = enable;
         self
     }
 
+    #[must_use]
     pub fn times(mut self, enable: bool) -> Self {
         self.cfg.times = enable;
         self
     }
 
+    #[must_use]
     pub fn atimes(mut self, enable: bool) -> Self {
         self.cfg.atimes = enable;
         self
     }
 
+    #[must_use]
     pub fn links(mut self, enable: bool) -> Self {
         self.cfg.links = enable;
         self
     }
 
+    #[must_use]
     pub fn devices(mut self, enable: bool) -> Self {
         self.cfg.devices = enable;
         self
     }
 
+    #[must_use]
     pub fn specials(mut self, enable: bool) -> Self {
         self.cfg.specials = enable;
         self
     }
 
+    #[must_use]
     pub fn owner(mut self, enable: bool) -> Self {
         self.cfg.owner = enable;
         self
     }
 
+    #[must_use]
     pub fn group(mut self, enable: bool) -> Self {
         self.cfg.group = enable;
         self
     }
 
     #[cfg(feature = "xattr")]
+    #[must_use]
     pub fn xattrs(mut self, enable: bool) -> Self {
         self.cfg.xattrs = enable;
         self
     }
 
     #[cfg(feature = "acl")]
+    #[must_use]
     pub fn acls(mut self, enable: bool) -> Self {
         self.cfg.acls = enable;
         self
     }
 
+    #[must_use]
     pub fn build(self) -> SyncConfig {
         self.cfg
     }


### PR DESCRIPTION
## Summary
- mark `SyncConfigBuilder` and its builder methods with `#[must_use]` to flag unused results

## Testing
- `cargo fmt --all`
- `cargo test` *(fails: snapshot assertion for `progress_parity`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b801892d7883239ab80df80622457d