### PR TITLE
test(cli): ensure ARG_ORDER covers all arguments

### DIFF
--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -274,3 +274,26 @@ pub fn render_help(cmd: &Command) -> String {
     }
     out
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::options::cli_command;
+
+    #[test]
+    fn arg_order_matches_arguments() {
+        let cmd = cli_command();
+        let args: Vec<_> = cmd
+            .get_arguments()
+            .filter(|a| !a.is_hide_set() && !a.is_positional())
+            .collect();
+
+        for arg in &args {
+            let id = arg.get_id().as_str();
+            let count = ARG_ORDER.iter().filter(|&&v| v == id).count();
+            assert_eq!(count, 1, "{id} appears {count} times in ARG_ORDER");
+        }
+
+        assert_eq!(ARG_ORDER.len(), args.len());
+    }
+}


### PR DESCRIPTION
## Summary
- verify each CLI argument is included exactly once in `ARG_ORDER`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: progress_parity snapshot mismatch; sparse_files_preserved >60s)*
- `cargo test --all-features` *(fails: linking with `cc` failed: cannot find -lacl)*
- `cargo fmt --all`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8013f4fac8323bb228c13154284ee