### PR TITLE
Skip ownership test when not root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,13 @@ mod tests {
         use nix::unistd::{chown, Gid, Uid};
         use std::os::unix::fs::MetadataExt;
 
+        if !Uid::effective().is_root() {
+            println!(
+                "skipping sync_preserves_ownership: requires root privileges to change ownership"
+            );
+            return;
+        }
+
         let (_dir, src_dir, dst_dir) = setup_dirs();
 
         let file = src_dir.join("file.txt");


### PR DESCRIPTION
## Summary
- avoid failing sync_preserves_ownership test when run without sufficient privileges

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(hangs at daemon_config_read_only_module_rejects_writes)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b801826f9c8323ae596d4c4dc783de