### PR TITLE
Add demux message limits

### DIFF
--- a/crates/protocol/tests/demux_limits.rs
+++ b/crates/protocol/tests/demux_limits.rs
@@ -1,0 +1,18 @@
+// crates/protocol/tests/demux_limits.rs
+use protocol::{Demux, Message};
+use std::time::Duration;
+
+#[test]
+fn limits_info_capacity() {
+    let mut demux = Demux::with_capacity(Duration::from_secs(1), 5);
+    let _rx = demux.register_channel(0);
+    for i in 0..100 {
+        demux
+            .ingest_message(0, Message::Info(i.to_string()))
+            .unwrap();
+    }
+    let infos = demux.take_infos();
+    assert_eq!(infos.len(), 5);
+    let expected: Vec<String> = (95..100).map(|i| i.to_string()).collect();
+    assert_eq!(infos, expected);
+}


### PR DESCRIPTION
## Summary
- add configurable capacity limiting to demux message buffers
- default to rsync-like unlimited capacity
- test demux drops excess messages

## Testing
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p protocol`
- `cargo test -p protocol --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68b7ff9d025c832380f4a98a9ef61b29