### PR TITLE
tests: add recursive flag for stats parity

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -840,6 +840,7 @@ fn stats_parity() {
         .env("LC_ALL", "C")
         .env("COLUMNS", "80")
         .args([
+            "--recursive",
             "--stats",
             format!("{}/", src.display()).as_str(),
             dst_ours.to_str().unwrap(),


### PR DESCRIPTION
## Summary
- include `--recursive` in `stats_parity` test to match upstream `rsync`

## Testing
- `INSTA_UPDATE=always cargo test --test cli stats_parity`
- `cargo test` *(fails: delete_policy::ignore_errors_allows_deletion_failure, delete_policy::delete_missing_args_removes_destination)*
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: clippy::double-must-use in src/lib.rs)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68b805237cb88323a0f147de594c3c13