### PR TITLE
tests: ensure progress parity uses recursive option

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -772,6 +772,7 @@ fn progress_parity() {
         .env("LC_ALL", "C")
         .env("COLUMNS", "80")
         .args([
+            "--recursive",
             "--progress",
             format!("{}/", src.display()).as_str(),
             dst_ours.to_str().unwrap(),


### PR DESCRIPTION
## Summary
- add `--recursive` to `oc-rsync` invocation in `progress_parity` test so it matches upstream `rsync`

## Testing
- `INSTA_UPDATE=always cargo test --test cli stats_parity` *(fails: expected `;`, found `}` in `crates/cli/src/lib.rs`)*
- `make lint` *(fails: expected `;`, found `}` in `crates/cli/src/lib.rs`)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68b8082481fc8323adf04fca51a0c794