### PR TITLE
Return stats from match arms

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -870,6 +870,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                         )
                         .map_err(EngineError::from)?;
 
+                        #[allow(clippy::let_and_return)]
                         let stats = if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
                             let stats = pipe_sessions(&mut src_session, &mut dst_session)?;
@@ -914,7 +915,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                                 return Err(EngineError::Other(msg));
                             }
                             stats
-                        }
+                        };
+                        stats
                     }
                     (Some(sm), Some(dm)) => {
                         let mut dst_session = spawn_daemon_session(
@@ -947,12 +949,14 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             opts.early_input.as_deref(),
                             iconv.as_ref(),
                         )?;
+                        #[allow(clippy::let_and_return)]
                         let stats = if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
                             pipe_sessions(&mut src_session, &mut dst_session)?
                         } else {
                             pipe_sessions(&mut src_session, &mut dst_session)?
-                        }
+                        };
+                        stats
                     }
                     (Some(sm), None) => {
                         let mut dst_session = SshStdioTransport::spawn_with_rsh(
@@ -985,6 +989,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             opts.early_input.as_deref(),
                             iconv.as_ref(),
                         )?;
+                        #[allow(clippy::let_and_return)]
                         let stats = if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
                             let stats = pipe_sessions(&mut src_session, &mut dst_session)?;
@@ -1011,7 +1016,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                                 return Err(EngineError::Other(msg));
                             }
                             stats
-                        }
+                        };
+                        stats
                     }
                     (None, Some(dm)) => {
                         let mut dst_session = spawn_daemon_session(
@@ -1044,6 +1050,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             addr_family,
                         )
                         .map_err(EngineError::from)?;
+                        #[allow(clippy::let_and_return)]
                         let stats = if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
                             let stats = pipe_sessions(&mut src_session, &mut dst_session)?;
@@ -1069,7 +1076,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                                 return Err(EngineError::Other(msg));
                             }
                             stats
-                        }
+                        };
+                        stats
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn sync_preserves_ownership() {
-        use nix::unistd::{chown, geteuid, Gid, Uid};
+        use nix::unistd::{chown, Gid, Uid};
         use std::os::unix::fs::MetadataExt;
 
         if !Uid::effective().is_root() {


### PR DESCRIPTION
## Summary
- fix match arms to return `stats` explicitly and add clippy attribute
- remove unused `geteuid` import

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: delete_missing_args_removes_destination, ignore_errors_allows_deletion_failure)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b80adf582c83238ff4e338c2e96dbd