### PR TITLE
Refactor remote stats return

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -914,7 +914,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                                 return Err(EngineError::Other(msg));
                             }
                             stats
-                        }
+                        };
+                        stats
                     }
                     (Some(sm), Some(dm)) => {
                         let mut dst_session = spawn_daemon_session(
@@ -952,7 +953,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             pipe_sessions(&mut src_session, &mut dst_session)?
                         } else {
                             pipe_sessions(&mut src_session, &mut dst_session)?
-                        }
+                        };
+                        stats
                     }
                     (Some(sm), None) => {
                         let mut dst_session = SshStdioTransport::spawn_with_rsh(
@@ -1011,7 +1013,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                                 return Err(EngineError::Other(msg));
                             }
                             stats
-                        }
+                        };
+                        stats
                     }
                     (None, Some(dm)) => {
                         let mut dst_session = spawn_daemon_session(
@@ -1069,7 +1072,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                                 return Err(EngineError::Other(msg));
                             }
                             stats
-                        }
+                        };
+                        stats
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- return stats explicitly in remote-to-remote sync match arms

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: test sparse_files_preserved running over 60s)*

------
https://chatgpt.com/codex/tasks/task_e_68b80b8223848323bbd4144decc076dd