### PR TITLE
test: verify version output against rsync

### DIFF
--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -1,0 +1,16 @@
+# Fixture Generation
+
+The test suite uses fixtures derived from upstream `rsync` to validate CLI parity.
+
+## `rsync-version.txt`
+
+`tests/fixtures/rsync-version.txt` stores the output of `rsync --version` for comparison
+with `oc-rsync --version`.
+
+Regenerate the fixture with:
+
+```sh
+LC_ALL=C COLUMNS=80 rsync --version > tests/fixtures/rsync-version.txt
+```
+
+Setting `LC_ALL` and `COLUMNS` ensures a stable locale and line wrapping.

--- a/tests/fixtures/rsync-version.txt
+++ b/tests/fixtures/rsync-version.txt
@@ -1,0 +1,20 @@
+rsync  version 3.2.7  protocol version 31
+Copyright (C) 1996-2022 by Andrew Tridgell, Wayne Davison, and others.
+Web site: https://rsync.samba.org/
+Capabilities:
+    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
+    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
+    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
+    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
+Optimizations:
+    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
+Checksum list:
+    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
+Compress list:
+    zstd lz4 zlibx zlib none
+Daemon auth list:
+    sha512 sha256 sha1 md5 md4
+
+rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.

--- a/tests/version_output.rs
+++ b/tests/version_output.rs
@@ -1,0 +1,17 @@
+// tests/version_output.rs
+use assert_cmd::Command;
+use std::fs;
+
+#[test]
+fn version_matches_rsync() {
+    let expected = fs::read_to_string("tests/fixtures/rsync-version.txt").unwrap();
+    let output = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .env("LC_ALL", "C")
+        .env("COLUMNS", "80")
+        .arg("--version")
+        .output()
+        .unwrap();
+    let got = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(got, expected);
+}


### PR DESCRIPTION
## Summary
- capture `rsync --version` output as a fixture and add a parity test
- document how to regenerate version fixture

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: cannot find value `stats` in crates/cli/src/lib.rs)*
- `cargo test` *(fails: cannot find value `stats` in crates/cli/src/lib.rs)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8126e8700832387e7c6b2ee9aa351