### PR TITLE
ci: harden workflow and document expectations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,19 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+  LC_ALL: C
+  LANG: C
+  COLUMNS: 80
 
 jobs:
   lint-test:
@@ -18,12 +29,15 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libacl1-dev
       - name: Format
         run: cargo fmt --all --check
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Verify comments
+        run: make verify-comments
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
@@ -49,6 +63,7 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
           override: true
+      - uses: Swatinem/rust-cache@v2
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libacl1-dev
       - name: Build release binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,20 @@ The Makefile offers shortcuts for common CI checks:
   --fail-under-lines 95 --fail-under-functions 95` to gather test coverage.
 - `make interop` – run the interoperability matrix with `tests/interop/run_matrix.sh`.
 
+## Continuous Integration
+
+The CI workflow runs with a consistent environment and enforces comment
+headers:
+
+- Environment variables: `RUSTFLAGS="-Dwarnings"`, `LC_ALL=C`, `LANG=C`, and
+  `COLUMNS=80`.
+- Repository access is read only (`permissions: { contents: read }`) and a
+  concurrency group (`ci-${{ github.ref }}`) cancels in-progress runs for the same
+  ref.
+- Builds cache dependencies using `Swatinem/rust-cache@v2`.
+- After `cargo clippy`, CI runs `make verify-comments` to ensure file header
+  comments follow the policy.
+
 ## Pull Request Process
 1. Fork the repository and create a topic branch.
 2. Ensure your branch is up to date with the `main` branch.


### PR DESCRIPTION
## Summary
- tighten CI environment with `RUSTFLAGS=-Dwarnings`, `LC_ALL=C`, `LANG=C`, and `COLUMNS=80`
- add read-only permissions, concurrency control, build cache, and comment header check
- document these CI expectations in CONTRIBUTING.md

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: cannot find value `stats` in `crates/cli/src/lib.rs`)*
- `cargo test` *(fails: cannot find value `stats` in `crates/cli/src/lib.rs`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8127cb3d883238d892480f2f1f867