### PR TITLE
Ensure stats assigned before bandwidth limit branch

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -996,16 +996,15 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
                             addr_family,
                         )
                         .map_err(EngineError::from)?;
+                        let stats;
                         if let Some(limit) = opts.bwlimit {
                             let mut dst_session = RateLimitedTransport::new(dst_session, limit);
-                            let stats = pipe_sessions(&mut src_session, &mut dst_session)?;
-                            check_session_errors(&src_session, iconv.as_ref())?;
-                            stats
+                            stats = pipe_sessions(&mut src_session, &mut dst_session)?;
                         } else {
-                            let stats = pipe_sessions(&mut src_session, &mut dst_session)?;
-                            check_session_errors(&src_session, iconv.as_ref())?;
-                            stats
+                            stats = pipe_sessions(&mut src_session, &mut dst_session)?;
                         }
+                        check_session_errors(&src_session, iconv.as_ref())?;
+                        stats
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Declare `stats` before the `bwlimit` branch in the remote daemon case so all paths initialize it and session errors are checked once.

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: delete_policy)*

------
https://chatgpt.com/codex/tasks/task_e_68b817cee2388323896171a2af8fefbb