### PR TITLE
Fix destination directory handling in CLI

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -337,6 +337,10 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         RemoteSpec::Local(p) => &p.path,
         RemoteSpec::Remote { path, .. } => &path.path,
     };
+    let dst_is_dir = match &dst {
+        RemoteSpec::Local(p) => p.trailing_slash || p.path.is_dir(),
+        RemoteSpec::Remote { path, .. } => path.trailing_slash,
+    };
     if opts.relative {
         let rel = if src_path.is_absolute() {
             src_path.strip_prefix(Path::new("/")).unwrap_or(src_path)
@@ -347,7 +351,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
             RemoteSpec::Local(p) => p.path.push(rel),
             RemoteSpec::Remote { path, .. } => path.path.push(rel),
         }
-    } else if !src_trailing {
+    } else if !src_trailing && dst_is_dir {
         let name = src_path
             .file_name()
             .map(|s| s.to_owned())


### PR DESCRIPTION
## Summary
- Only append source name when destination is known to be a directory

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `cargo test --test delete_policy` *(fails when run as root; passes under user `nobody`)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b819ec6dc883238db188b9617e72a0