### PR TITLE
test: check flags in help output

### DIFF
--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -3,7 +3,7 @@ use clap::Command;
 use std::env;
 use textwrap::{wrap, Options as WrapOptions};
 
-const RSYNC_HELP: &str = include_str!("../../../tests/fixtures/rsync-help.txt");
+const RSYNC_HELP: &str = include_str!("../../../tests/fixtures/rsync-help-80.txt");
 
 const HELP_PREFIX: &str = "rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you\nare welcome to redistribute it under certain conditions.  See the GNU\nGeneral Public Licence for details.\n\nrsync is a file transfer program capable of efficient remote update\nvia a fast differencing algorithm.\n\nUsage: rsync [OPTION]... SRC [SRC]... DEST\n  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST\n  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST\n  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST\n  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]\n  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]\n  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]\nThe ':' usages connect via remote shell, while '::' & 'rsync://' usages connect\nto an rsync daemon, and require SRC or DEST to start with a module name.\n\nOptions\n";
 

--- a/crates/cli/tests/cli_parity.rs
+++ b/crates/cli/tests/cli_parity.rs
@@ -171,7 +171,7 @@ fn partial_progress_alias_matches_upstream() {
 
 #[test]
 fn dparam_flag_matches_upstream() {
-    let help_output = include_str!("../../../tests/fixtures/rsync-help.txt");
+    let help_output = include_str!("../../../tests/fixtures/rsync-help-80.txt");
     assert!(help_output.contains("--dparam"));
 
     let matches = cli_command()
@@ -218,7 +218,7 @@ fn no_option_alias_matches_upstream() {
 #[test]
 fn help_usage_matches_upstream() {
     let help = std::fs::read_to_string(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/rsync-help.txt"),
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/rsync-help-80.txt"),
     )
     .unwrap();
     let upstream_usage = help

--- a/crates/cli/tests/help.rs
+++ b/crates/cli/tests/help.rs
@@ -8,7 +8,7 @@ use std::env;
 fn help_columns_80() {
     env::set_var("COLUMNS", "80");
     let out = render_help(&cli_command());
-    let expected = include_str!("../../../tests/fixtures/rsync-help.txt").trim_end();
+    let expected = include_str!("../../../tests/fixtures/rsync-help-80.txt").trim_end();
     assert_eq!(out, expected);
 }
 

--- a/crates/cli/tests/iconv.rs
+++ b/crates/cli/tests/iconv.rs
@@ -10,7 +10,7 @@ fn iconv_help_matches_upstream() {
     let our_line = ours.lines().find(|l| l.contains("--iconv")).unwrap().trim();
 
     let help = std::fs::read_to_string(
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/rsync-help.txt"),
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../tests/fixtures/rsync-help-80.txt"),
     )
     .unwrap();
     let upstream_line = help.lines().find(|l| l.contains("--iconv")).unwrap().trim();

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,14 +1,44 @@
 # Fixture Generation
 
-The help text fixtures are used to ensure `oc-rsync --help` matches the
-expected output.
+The fixtures in this directory capture upstream and oc-rsync help output in a
+locale-independent way.
 
-To regenerate `rsync-help.txt`, run the binary with the C locale to avoid
-locale-specific differences:
+## `rsync-help.txt`
+
+`rsync-help.txt` contains a JSON array of `{ "flag": "--option", "description": "..." }
+pairs extracted from `rsync --help`.  It is used by tests to verify that
+`oc-rsync --help` exposes all of the expected options.
+
+Regenerate this file with the C locale to avoid locale-specific differences:
 
 ```sh
-LC_ALL=C LANG=C COLUMNS=80 cargo run --bin oc-rsync -- --help > tests/fixtures/rsync-help.txt
+LC_ALL=C LANG=C rsync --help | python - <<'PY' > tests/fixtures/rsync-help.txt
+import json, os, re, sys
+lines=sys.stdin.read().splitlines()
+opts=[]
+collect=False
+for line in lines:
+    if line.strip()=="Options":
+        collect=True
+        continue
+    if collect:
+        if line.startswith('Use "rsync --daemon --help"'):
+            break
+        if not line.strip():
+            continue
+        spec, desc = re.split(r'\s{2,}', line.strip(), maxsplit=1)
+        flag = next((p.strip() for p in spec.split(',') if p.strip().startswith('--')), spec.strip())
+        opts.append({'flag': flag, 'description': desc.strip()})
+print(json.dumps(opts, indent=2))
+PY
 ```
 
-For wider help output, replace `COLUMNS=80` with the desired width and write
-that output to a separate fixture file.
+## `rsync-help-80.txt` and `rsync-help-120.txt`
+
+These files capture the full `oc-rsync --help` output at specific widths.  They
+are regenerated in the C locale with:
+
+```sh
+LC_ALL=C LANG=C COLUMNS=80  cargo run --bin oc-rsync -- --help > tests/fixtures/rsync-help-80.txt
+LC_ALL=C LANG=C COLUMNS=120 cargo run --bin oc-rsync -- --help > tests/fixtures/rsync-help-120.txt
+```

--- a/tests/fixtures/rsync-help-80.txt
+++ b/tests/fixtures/rsync-help-80.txt
@@ -1,0 +1,169 @@
+oc-rsync compatible with rsync  version 3.4.1  protocol version 32
+Copyright (C) 2025 by Ofer Chen.
+
+rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.
+
+rsync is a file transfer program capable of efficient remote update
+via a fast differencing algorithm.
+
+Usage: rsync [OPTION]... SRC [SRC]... DEST
+  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
+  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
+  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
+  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
+  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
+  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
+The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
+to an rsync daemon, and require SRC or DEST to start with a module name.
+
+Options
+--verbose, -v            increase verbosity
+--info=FLAGS             fine-grained informational verbosity
+--debug=FLAGS            fine-grained debug verbosity
+--stderr=e|a|c           change stderr output mode (default: errors)
+--quiet, -q              suppress non-error messages
+--no-motd                suppress daemon-mode MOTD
+--checksum, -c           skip based on checksum, not mod-time & size
+--archive, -a            archive mode is -rlptgoD (no -A,-X,-U,-N,-H)
+--no-OPTION              turn off an implied OPTION (e.g. --no-D)
+--recursive, -r          recurse into directories
+--relative, -R           use relative path names
+--no-implied-dirs        don't send implied dirs with --relative
+--backup, -b             make backups (see --suffix & --backup-dir)
+--backup-dir=DIR         make backups into hierarchy based in DIR
+--suffix=SUFFIX          backup suffix (default ~ w/o --backup-dir)
+--update, -u             skip files that are newer on the receiver
+--inplace                update destination files in-place
+--append                 append data onto shorter files
+--append-verify          --append w/old data in file checksum
+--dirs, -d               transfer directories without recursing
+--old-dirs, --old-d      works like --dirs when talking to old rsync
+--mkpath                 create destination's missing path components
+--links, -l              copy symlinks as symlinks
+--copy-links, -L         transform symlink into referent file/dir
+--copy-unsafe-links      only "unsafe" symlinks are transformed
+--safe-links             ignore symlinks that point outside the tree
+--munge-links            munge symlinks to make them safe & unusable
+--copy-dirlinks, -k      transform symlink to dir into referent dir
+--keep-dirlinks, -K      treat symlinked dir on receiver as dir
+--hard-links, -H         preserve hard links
+--perms, -p              preserve permissions
+--executability, -E      preserve executability
+--chmod=CHMOD            affect file and/or directory permissions
+--acls, -A               preserve ACLs (implies --perms)
+--xattrs, -X             preserve extended attributes
+--owner, -o              preserve owner (super-user only)
+--group, -g              preserve group
+--devices                preserve device files (super-user only)
+--copy-devices           copy device contents as a regular file
+--write-devices          write to devices as files (implies --inplace)
+--specials               preserve special files
+-D                       same as --devices --specials
+--times, -t              preserve modification times
+--atimes, -U             preserve access (use) times
+--open-noatime           avoid changing the atime on opened files
+--crtimes, -N            preserve create times (newness)
+--omit-dir-times, -O     omit directories from --times
+--omit-link-times, -J    omit symlinks from --times
+--super                  receiver attempts super-user activities
+--fake-super             store/recover privileged attrs using xattrs
+--sparse, -S             turn sequences of nulls into sparse blocks
+--preallocate            allocate dest files before writing them
+--dry-run, -n            perform a trial run with no changes made
+--whole-file, -W         copy files whole (w/o delta-xfer algorithm)
+--checksum-choice=STR    choose the checksum algorithm (aka --cc)
+--one-file-system, -x    don't cross filesystem boundaries
+--block-size=SIZE, -B    force a fixed checksum block-size
+--rsh=COMMAND, -e        specify the remote shell to use
+--rsync-path=PROGRAM     specify the rsync to run on remote machine
+--existing               skip creating new files on receiver
+--ignore-existing        skip updating files that exist on receiver
+--remove-source-files    sender removes synchronized files (non-dir)
+--del                    an alias for --delete-during
+--delete                 delete extraneous files from dest dirs
+--delete-before          receiver deletes before xfer, not during
+--delete-during          receiver deletes during the transfer
+--delete-delay           find deletions during, delete after
+--delete-after           receiver deletes after transfer, not during
+--delete-excluded        also delete excluded files from dest dirs
+--ignore-missing-args    ignore missing source args without error
+--delete-missing-args    delete missing source args from destination
+--ignore-errors          delete even if there are I/O errors
+--force                  force deletion of dirs even if not empty
+--max-delete=NUM         don't delete more than NUM files
+--max-size=SIZE          don't transfer any file larger than SIZE
+--min-size=SIZE          don't transfer any file smaller than SIZE
+--max-alloc=SIZE         change a limit relating to memory alloc
+--partial                keep partially transferred files
+--partial-dir=DIR        put a partially transferred file into DIR
+--delay-updates          put all updated files into place at end
+--prune-empty-dirs, -m   prune empty directory chains from file-list
+--numeric-ids            don't map uid/gid values by user/group name
+--usermap=STRING         custom username mapping
+--groupmap=STRING        custom groupname mapping
+--chown=USER:GROUP       simple username/groupname mapping
+--timeout=SECONDS        set I/O timeout in seconds
+--contimeout=SECONDS     set daemon connection timeout in seconds
+--ignore-times, -I       don't skip files that match size and time
+--size-only              skip files that match in size
+--modify-window=NUM, -@  set the accuracy for mod-time comparisons
+--temp-dir=DIR, -T       create temporary files in directory DIR
+--fuzzy, -y              find similar file for basis if no dest file
+--compare-dest=DIR       also compare destination files relative to DIR
+--copy-dest=DIR          ... and include copies of unchanged files
+--link-dest=DIR          hardlink to files in DIR when unchanged
+--compress, -z           compress file data during the transfer
+--compress-choice=STR    choose the compression algorithm (aka --zc)
+--compress-level=NUM     explicitly set compression level (aka --zl)
+--skip-compress=LIST     skip compressing files with suffix in LIST
+--cvs-exclude, -C        auto-ignore files in the same way CVS does
+--filter=RULE, -f        add a file-filtering RULE
+-F                       same as --filter='dir-merge /.rsync-filter'
+                         repeated: --filter='- .rsync-filter'
+--exclude=PATTERN        exclude files matching PATTERN
+--exclude-from=FILE      read exclude patterns from FILE
+--include=PATTERN        don't exclude files matching PATTERN
+--include-from=FILE      read include patterns from FILE
+--files-from=FILE        read list of source-file names from FILE
+--from0, -0              all *-from/filter files are delimited by 0s
+--old-args               disable the modern arg-protection idiom
+--secluded-args, -s      use the protocol to safely send the args
+--trust-sender           trust the remote sender's file list
+--copy-as=USER[:GROUP]   specify user & optional group for the copy
+--address=ADDRESS        bind address for outgoing socket to daemon
+--port=PORT              specify double-colon alternate port number
+--sockopts=OPTIONS       specify custom TCP options
+--blocking-io            use blocking I/O for the remote shell
+--outbuf=N|L|B           set out buffering to None, Line, or Block
+--stats                  give some file-transfer stats
+--8-bit-output, -8       leave high-bit chars unescaped in output
+--human-readable, -h     output numbers in a human-readable format
+--progress               show progress during transfer
+-P                       same as --partial --progress
+--itemize-changes, -i    output a change-summary for all updates
+--remote-option=OPT, -M  send OPTION to the remote side only
+--out-format=FORMAT      output updates using the specified FORMAT
+--log-file=FILE          log what we're doing to the specified FILE
+--log-file-format=FMT    log updates using the specified FMT
+--password-file=FILE     read daemon-access password from FILE
+--early-input=FILE       use FILE for daemon's early exec input
+--list-only              list the files instead of copying them
+--bwlimit=RATE           limit socket I/O bandwidth
+--stop-after=MINS        Stop rsync after MINS minutes have elapsed
+--stop-at=y-m-dTh:m      Stop rsync at the specified point in time
+--fsync                  fsync every written file
+--write-batch=FILE       write a batched update to FILE
+--only-write-batch=FILE  like --write-batch but w/o updating dest
+--read-batch=FILE        read a batched update from FILE
+--protocol=NUM           force an older protocol version to be used
+--iconv=CONVERT_SPEC     request charset conversion of filenames
+--checksum-seed=NUM      set block/file checksum seed (advanced)
+--ipv4, -4               prefer IPv4
+--ipv6, -6               prefer IPv6
+--version, -V            print the version + other info and exit
+--help, -h (*)           show this help (* -h is help only on its own)
+
+Use "rsync --daemon --help" to see the daemon-mode command-line options.
+Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.

--- a/tests/fixtures/rsync-help.txt
+++ b/tests/fixtures/rsync-help.txt
@@ -1,169 +1,578 @@
-oc-rsync compatible with rsync  version 3.4.1  protocol version 32
-Copyright (C) 2025 by Ofer Chen.
-
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
-are welcome to redistribute it under certain conditions.  See the GNU
-General Public Licence for details.
-
-rsync is a file transfer program capable of efficient remote update
-via a fast differencing algorithm.
-
-Usage: rsync [OPTION]... SRC [SRC]... DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
-  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
-  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
-  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
-  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
-The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
-to an rsync daemon, and require SRC or DEST to start with a module name.
-
-Options
---verbose, -v            increase verbosity
---info=FLAGS             fine-grained informational verbosity
---debug=FLAGS            fine-grained debug verbosity
---stderr=e|a|c           change stderr output mode (default: errors)
---quiet, -q              suppress non-error messages
---no-motd                suppress daemon-mode MOTD
---checksum, -c           skip based on checksum, not mod-time & size
---archive, -a            archive mode is -rlptgoD (no -A,-X,-U,-N,-H)
---no-OPTION              turn off an implied OPTION (e.g. --no-D)
---recursive, -r          recurse into directories
---relative, -R           use relative path names
---no-implied-dirs        don't send implied dirs with --relative
---backup, -b             make backups (see --suffix & --backup-dir)
---backup-dir=DIR         make backups into hierarchy based in DIR
---suffix=SUFFIX          backup suffix (default ~ w/o --backup-dir)
---update, -u             skip files that are newer on the receiver
---inplace                update destination files in-place
---append                 append data onto shorter files
---append-verify          --append w/old data in file checksum
---dirs, -d               transfer directories without recursing
---old-dirs, --old-d      works like --dirs when talking to old rsync
---mkpath                 create destination's missing path components
---links, -l              copy symlinks as symlinks
---copy-links, -L         transform symlink into referent file/dir
---copy-unsafe-links      only "unsafe" symlinks are transformed
---safe-links             ignore symlinks that point outside the tree
---munge-links            munge symlinks to make them safe & unusable
---copy-dirlinks, -k      transform symlink to dir into referent dir
---keep-dirlinks, -K      treat symlinked dir on receiver as dir
---hard-links, -H         preserve hard links
---perms, -p              preserve permissions
---executability, -E      preserve executability
---chmod=CHMOD            affect file and/or directory permissions
---acls, -A               preserve ACLs (implies --perms)
---xattrs, -X             preserve extended attributes
---owner, -o              preserve owner (super-user only)
---group, -g              preserve group
---devices                preserve device files (super-user only)
---copy-devices           copy device contents as a regular file
---write-devices          write to devices as files (implies --inplace)
---specials               preserve special files
--D                       same as --devices --specials
---times, -t              preserve modification times
---atimes, -U             preserve access (use) times
---open-noatime           avoid changing the atime on opened files
---crtimes, -N            preserve create times (newness)
---omit-dir-times, -O     omit directories from --times
---omit-link-times, -J    omit symlinks from --times
---super                  receiver attempts super-user activities
---fake-super             store/recover privileged attrs using xattrs
---sparse, -S             turn sequences of nulls into sparse blocks
---preallocate            allocate dest files before writing them
---dry-run, -n            perform a trial run with no changes made
---whole-file, -W         copy files whole (w/o delta-xfer algorithm)
---checksum-choice=STR    choose the checksum algorithm (aka --cc)
---one-file-system, -x    don't cross filesystem boundaries
---block-size=SIZE, -B    force a fixed checksum block-size
---rsh=COMMAND, -e        specify the remote shell to use
---rsync-path=PROGRAM     specify the rsync to run on remote machine
---existing               skip creating new files on receiver
---ignore-existing        skip updating files that exist on receiver
---remove-source-files    sender removes synchronized files (non-dir)
---del                    an alias for --delete-during
---delete                 delete extraneous files from dest dirs
---delete-before          receiver deletes before xfer, not during
---delete-during          receiver deletes during the transfer
---delete-delay           find deletions during, delete after
---delete-after           receiver deletes after transfer, not during
---delete-excluded        also delete excluded files from dest dirs
---ignore-missing-args    ignore missing source args without error
---delete-missing-args    delete missing source args from destination
---ignore-errors          delete even if there are I/O errors
---force                  force deletion of dirs even if not empty
---max-delete=NUM         don't delete more than NUM files
---max-size=SIZE          don't transfer any file larger than SIZE
---min-size=SIZE          don't transfer any file smaller than SIZE
---max-alloc=SIZE         change a limit relating to memory alloc
---partial                keep partially transferred files
---partial-dir=DIR        put a partially transferred file into DIR
---delay-updates          put all updated files into place at end
---prune-empty-dirs, -m   prune empty directory chains from file-list
---numeric-ids            don't map uid/gid values by user/group name
---usermap=STRING         custom username mapping
---groupmap=STRING        custom groupname mapping
---chown=USER:GROUP       simple username/groupname mapping
---timeout=SECONDS        set I/O timeout in seconds
---contimeout=SECONDS     set daemon connection timeout in seconds
---ignore-times, -I       don't skip files that match size and time
---size-only              skip files that match in size
---modify-window=NUM, -@  set the accuracy for mod-time comparisons
---temp-dir=DIR, -T       create temporary files in directory DIR
---fuzzy, -y              find similar file for basis if no dest file
---compare-dest=DIR       also compare destination files relative to DIR
---copy-dest=DIR          ... and include copies of unchanged files
---link-dest=DIR          hardlink to files in DIR when unchanged
---compress, -z           compress file data during the transfer
---compress-choice=STR    choose the compression algorithm (aka --zc)
---compress-level=NUM     explicitly set compression level (aka --zl)
---skip-compress=LIST     skip compressing files with suffix in LIST
---cvs-exclude, -C        auto-ignore files in the same way CVS does
---filter=RULE, -f        add a file-filtering RULE
--F                       same as --filter='dir-merge /.rsync-filter'
-                         repeated: --filter='- .rsync-filter'
---exclude=PATTERN        exclude files matching PATTERN
---exclude-from=FILE      read exclude patterns from FILE
---include=PATTERN        don't exclude files matching PATTERN
---include-from=FILE      read include patterns from FILE
---files-from=FILE        read list of source-file names from FILE
---from0, -0              all *-from/filter files are delimited by 0s
---old-args               disable the modern arg-protection idiom
---secluded-args, -s      use the protocol to safely send the args
---trust-sender           trust the remote sender's file list
---copy-as=USER[:GROUP]   specify user & optional group for the copy
---address=ADDRESS        bind address for outgoing socket to daemon
---port=PORT              specify double-colon alternate port number
---sockopts=OPTIONS       specify custom TCP options
---blocking-io            use blocking I/O for the remote shell
---outbuf=N|L|B           set out buffering to None, Line, or Block
---stats                  give some file-transfer stats
---8-bit-output, -8       leave high-bit chars unescaped in output
---human-readable, -h     output numbers in a human-readable format
---progress               show progress during transfer
--P                       same as --partial --progress
---itemize-changes, -i    output a change-summary for all updates
---remote-option=OPT, -M  send OPTION to the remote side only
---out-format=FORMAT      output updates using the specified FORMAT
---log-file=FILE          log what we're doing to the specified FILE
---log-file-format=FMT    log updates using the specified FMT
---password-file=FILE     read daemon-access password from FILE
---early-input=FILE       use FILE for daemon's early exec input
---list-only              list the files instead of copying them
---bwlimit=RATE           limit socket I/O bandwidth
---stop-after=MINS        Stop rsync after MINS minutes have elapsed
---stop-at=y-m-dTh:m      Stop rsync at the specified point in time
---fsync                  fsync every written file
---write-batch=FILE       write a batched update to FILE
---only-write-batch=FILE  like --write-batch but w/o updating dest
---read-batch=FILE        read a batched update from FILE
---protocol=NUM           force an older protocol version to be used
---iconv=CONVERT_SPEC     request charset conversion of filenames
---checksum-seed=NUM      set block/file checksum seed (advanced)
---ipv4, -4               prefer IPv4
---ipv6, -6               prefer IPv6
---version, -V            print the version + other info and exit
---help, -h (*)           show this help (* -h is help only on its own)
-
-Use "rsync --daemon --help" to see the daemon-mode command-line options.
-Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
+[
+  {
+    "flag": "--verbose",
+    "description": "increase verbosity"
+  },
+  {
+    "flag": "--info=FLAGS",
+    "description": "fine-grained informational verbosity"
+  },
+  {
+    "flag": "--debug=FLAGS",
+    "description": "fine-grained debug verbosity"
+  },
+  {
+    "flag": "--stderr=e|a|c",
+    "description": "change stderr output mode (default: errors)"
+  },
+  {
+    "flag": "--quiet",
+    "description": "suppress non-error messages"
+  },
+  {
+    "flag": "--no-motd",
+    "description": "suppress daemon-mode MOTD"
+  },
+  {
+    "flag": "--checksum",
+    "description": "skip based on checksum, not mod-time & size"
+  },
+  {
+    "flag": "--archive",
+    "description": "archive mode is -rlptgoD (no -A,-X,-U,-N,-H)"
+  },
+  {
+    "flag": "--no-OPTION",
+    "description": "turn off an implied OPTION (e.g. --no-D)"
+  },
+  {
+    "flag": "--recursive",
+    "description": "recurse into directories"
+  },
+  {
+    "flag": "--relative",
+    "description": "use relative path names"
+  },
+  {
+    "flag": "--no-implied-dirs",
+    "description": "don't send implied dirs with --relative"
+  },
+  {
+    "flag": "--backup",
+    "description": "make backups (see --suffix & --backup-dir)"
+  },
+  {
+    "flag": "--backup-dir=DIR",
+    "description": "make backups into hierarchy based in DIR"
+  },
+  {
+    "flag": "--suffix=SUFFIX",
+    "description": "backup suffix (default ~ w/o --backup-dir)"
+  },
+  {
+    "flag": "--update",
+    "description": "skip files that are newer on the receiver"
+  },
+  {
+    "flag": "--inplace",
+    "description": "update destination files in-place"
+  },
+  {
+    "flag": "--append",
+    "description": "append data onto shorter files"
+  },
+  {
+    "flag": "--append-verify",
+    "description": "--append w/old data in file checksum"
+  },
+  {
+    "flag": "--dirs",
+    "description": "transfer directories without recursing"
+  },
+  {
+    "flag": "--old-dirs",
+    "description": "works like --dirs when talking to old rsync"
+  },
+  {
+    "flag": "--mkpath",
+    "description": "create destination's missing path components"
+  },
+  {
+    "flag": "--links",
+    "description": "copy symlinks as symlinks"
+  },
+  {
+    "flag": "--copy-links",
+    "description": "transform symlink into referent file/dir"
+  },
+  {
+    "flag": "--copy-unsafe-links",
+    "description": "only \"unsafe\" symlinks are transformed"
+  },
+  {
+    "flag": "--safe-links",
+    "description": "ignore symlinks that point outside the tree"
+  },
+  {
+    "flag": "--munge-links",
+    "description": "munge symlinks to make them safe & unusable"
+  },
+  {
+    "flag": "--copy-dirlinks",
+    "description": "transform symlink to dir into referent dir"
+  },
+  {
+    "flag": "--keep-dirlinks",
+    "description": "treat symlinked dir on receiver as dir"
+  },
+  {
+    "flag": "--hard-links",
+    "description": "preserve hard links"
+  },
+  {
+    "flag": "--perms",
+    "description": "preserve permissions"
+  },
+  {
+    "flag": "--executability",
+    "description": "preserve executability"
+  },
+  {
+    "flag": "--chmod=CHMOD",
+    "description": "affect file and/or directory permissions"
+  },
+  {
+    "flag": "--acls",
+    "description": "preserve ACLs (implies --perms)"
+  },
+  {
+    "flag": "--xattrs",
+    "description": "preserve extended attributes"
+  },
+  {
+    "flag": "--owner",
+    "description": "preserve owner (super-user only)"
+  },
+  {
+    "flag": "--group",
+    "description": "preserve group"
+  },
+  {
+    "flag": "--devices",
+    "description": "preserve device files (super-user only)"
+  },
+  {
+    "flag": "--copy-devices",
+    "description": "copy device contents as a regular file"
+  },
+  {
+    "flag": "--write-devices",
+    "description": "write to devices as files (implies --inplace)"
+  },
+  {
+    "flag": "--specials",
+    "description": "preserve special files"
+  },
+  {
+    "flag": "-D",
+    "description": "same as --devices --specials"
+  },
+  {
+    "flag": "--times",
+    "description": "preserve modification times"
+  },
+  {
+    "flag": "--atimes",
+    "description": "preserve access (use) times"
+  },
+  {
+    "flag": "--open-noatime",
+    "description": "avoid changing the atime on opened files"
+  },
+  {
+    "flag": "--crtimes",
+    "description": "preserve create times (newness)"
+  },
+  {
+    "flag": "--omit-dir-times",
+    "description": "omit directories from --times"
+  },
+  {
+    "flag": "--omit-link-times",
+    "description": "omit symlinks from --times"
+  },
+  {
+    "flag": "--super",
+    "description": "receiver attempts super-user activities"
+  },
+  {
+    "flag": "--fake-super",
+    "description": "store/recover privileged attrs using xattrs"
+  },
+  {
+    "flag": "--sparse",
+    "description": "turn sequences of nulls into sparse blocks"
+  },
+  {
+    "flag": "--preallocate",
+    "description": "allocate dest files before writing them"
+  },
+  {
+    "flag": "--dry-run",
+    "description": "perform a trial run with no changes made"
+  },
+  {
+    "flag": "--whole-file",
+    "description": "copy files whole (w/o delta-xfer algorithm)"
+  },
+  {
+    "flag": "--checksum-choice=STR",
+    "description": "choose the checksum algorithm (aka --cc)"
+  },
+  {
+    "flag": "--one-file-system",
+    "description": "don't cross filesystem boundaries"
+  },
+  {
+    "flag": "--block-size=SIZE",
+    "description": "force a fixed checksum block-size"
+  },
+  {
+    "flag": "--rsh=COMMAND",
+    "description": "specify the remote shell to use"
+  },
+  {
+    "flag": "--rsync-path=PROGRAM",
+    "description": "specify the rsync to run on remote machine"
+  },
+  {
+    "flag": "--existing",
+    "description": "skip creating new files on receiver"
+  },
+  {
+    "flag": "--ignore-existing",
+    "description": "skip updating files that exist on receiver"
+  },
+  {
+    "flag": "--remove-source-files",
+    "description": "sender removes synchronized files (non-dir)"
+  },
+  {
+    "flag": "--del",
+    "description": "an alias for --delete-during"
+  },
+  {
+    "flag": "--delete",
+    "description": "delete extraneous files from dest dirs"
+  },
+  {
+    "flag": "--delete-before",
+    "description": "receiver deletes before xfer, not during"
+  },
+  {
+    "flag": "--delete-during",
+    "description": "receiver deletes during the transfer"
+  },
+  {
+    "flag": "--delete-delay",
+    "description": "find deletions during, delete after"
+  },
+  {
+    "flag": "--delete-after",
+    "description": "receiver deletes after transfer, not during"
+  },
+  {
+    "flag": "--delete-excluded",
+    "description": "also delete excluded files from dest dirs"
+  },
+  {
+    "flag": "--ignore-missing-args",
+    "description": "ignore missing source args without error"
+  },
+  {
+    "flag": "--delete-missing-args",
+    "description": "delete missing source args from destination"
+  },
+  {
+    "flag": "--ignore-errors",
+    "description": "delete even if there are I/O errors"
+  },
+  {
+    "flag": "--force",
+    "description": "force deletion of dirs even if not empty"
+  },
+  {
+    "flag": "--max-delete=NUM",
+    "description": "don't delete more than NUM files"
+  },
+  {
+    "flag": "--max-size=SIZE",
+    "description": "don't transfer any file larger than SIZE"
+  },
+  {
+    "flag": "--min-size=SIZE",
+    "description": "don't transfer any file smaller than SIZE"
+  },
+  {
+    "flag": "--max-alloc=SIZE",
+    "description": "change a limit relating to memory alloc"
+  },
+  {
+    "flag": "--partial",
+    "description": "keep partially transferred files"
+  },
+  {
+    "flag": "--partial-dir=DIR",
+    "description": "put a partially transferred file into DIR"
+  },
+  {
+    "flag": "--delay-updates",
+    "description": "put all updated files into place at end"
+  },
+  {
+    "flag": "--prune-empty-dirs",
+    "description": "prune empty directory chains from file-list"
+  },
+  {
+    "flag": "--numeric-ids",
+    "description": "don't map uid/gid values by user/group name"
+  },
+  {
+    "flag": "--usermap=STRING",
+    "description": "custom username mapping"
+  },
+  {
+    "flag": "--groupmap=STRING",
+    "description": "custom groupname mapping"
+  },
+  {
+    "flag": "--chown=USER:GROUP",
+    "description": "simple username/groupname mapping"
+  },
+  {
+    "flag": "--timeout=SECONDS",
+    "description": "set I/O timeout in seconds"
+  },
+  {
+    "flag": "--contimeout=SECONDS",
+    "description": "set daemon connection timeout in seconds"
+  },
+  {
+    "flag": "--ignore-times",
+    "description": "don't skip files that match size and time"
+  },
+  {
+    "flag": "--size-only",
+    "description": "skip files that match in size"
+  },
+  {
+    "flag": "--modify-window=NUM",
+    "description": "set the accuracy for mod-time comparisons"
+  },
+  {
+    "flag": "--temp-dir=DIR",
+    "description": "create temporary files in directory DIR"
+  },
+  {
+    "flag": "--fuzzy",
+    "description": "find similar file for basis if no dest file"
+  },
+  {
+    "flag": "--compare-dest=DIR",
+    "description": "also compare destination files relative to DIR"
+  },
+  {
+    "flag": "--copy-dest=DIR",
+    "description": "... and include copies of unchanged files"
+  },
+  {
+    "flag": "--link-dest=DIR",
+    "description": "hardlink to files in DIR when unchanged"
+  },
+  {
+    "flag": "--compress",
+    "description": "compress file data during the transfer"
+  },
+  {
+    "flag": "--compress-choice=STR",
+    "description": "choose the compression algorithm (aka --zc)"
+  },
+  {
+    "flag": "--compress-level=NUM",
+    "description": "explicitly set compression level (aka --zl)"
+  },
+  {
+    "flag": "--skip-compress=LIST",
+    "description": "skip compressing files with suffix in LIST"
+  },
+  {
+    "flag": "--cvs-exclude",
+    "description": "auto-ignore files in the same way CVS does"
+  },
+  {
+    "flag": "--filter=RULE",
+    "description": "add a file-filtering RULE"
+  },
+  {
+    "flag": "-F",
+    "description": "same as --filter='dir-merge /.rsync-filter'"
+  },
+  {
+    "flag": "--exclude=PATTERN",
+    "description": "exclude files matching PATTERN"
+  },
+  {
+    "flag": "--exclude-from=FILE",
+    "description": "read exclude patterns from FILE"
+  },
+  {
+    "flag": "--include=PATTERN",
+    "description": "don't exclude files matching PATTERN"
+  },
+  {
+    "flag": "--include-from=FILE",
+    "description": "read include patterns from FILE"
+  },
+  {
+    "flag": "--files-from=FILE",
+    "description": "read list of source-file names from FILE"
+  },
+  {
+    "flag": "--from0",
+    "description": "all *-from/filter files are delimited by 0s"
+  },
+  {
+    "flag": "--old-args",
+    "description": "disable the modern arg-protection idiom"
+  },
+  {
+    "flag": "--secluded-args",
+    "description": "use the protocol to safely send the args"
+  },
+  {
+    "flag": "--trust-sender",
+    "description": "trust the remote sender's file list"
+  },
+  {
+    "flag": "--copy-as=USER[:GROUP]",
+    "description": "specify user & optional group for the copy"
+  },
+  {
+    "flag": "--address=ADDRESS",
+    "description": "bind address for outgoing socket to daemon"
+  },
+  {
+    "flag": "--port=PORT",
+    "description": "specify double-colon alternate port number"
+  },
+  {
+    "flag": "--sockopts=OPTIONS",
+    "description": "specify custom TCP options"
+  },
+  {
+    "flag": "--blocking-io",
+    "description": "use blocking I/O for the remote shell"
+  },
+  {
+    "flag": "--outbuf=N|L|B",
+    "description": "set out buffering to None, Line, or Block"
+  },
+  {
+    "flag": "--stats",
+    "description": "give some file-transfer stats"
+  },
+  {
+    "flag": "--8-bit-output",
+    "description": "leave high-bit chars unescaped in output"
+  },
+  {
+    "flag": "--human-readable",
+    "description": "output numbers in a human-readable format"
+  },
+  {
+    "flag": "--progress",
+    "description": "show progress during transfer"
+  },
+  {
+    "flag": "-P",
+    "description": "same as --partial --progress"
+  },
+  {
+    "flag": "--itemize-changes",
+    "description": "output a change-summary for all updates"
+  },
+  {
+    "flag": "--remote-option=OPT",
+    "description": "send OPTION to the remote side only"
+  },
+  {
+    "flag": "--out-format=FORMAT",
+    "description": "output updates using the specified FORMAT"
+  },
+  {
+    "flag": "--log-file=FILE",
+    "description": "log what we're doing to the specified FILE"
+  },
+  {
+    "flag": "--log-file-format=FMT",
+    "description": "log updates using the specified FMT"
+  },
+  {
+    "flag": "--password-file=FILE",
+    "description": "read daemon-access password from FILE"
+  },
+  {
+    "flag": "--early-input=FILE",
+    "description": "use FILE for daemon's early exec input"
+  },
+  {
+    "flag": "--list-only",
+    "description": "list the files instead of copying them"
+  },
+  {
+    "flag": "--bwlimit=RATE",
+    "description": "limit socket I/O bandwidth"
+  },
+  {
+    "flag": "--stop-after=MINS",
+    "description": "Stop rsync after MINS minutes have elapsed"
+  },
+  {
+    "flag": "--stop-at=y-m-dTh:m",
+    "description": "Stop rsync at the specified point in time"
+  },
+  {
+    "flag": "--fsync",
+    "description": "fsync every written file"
+  },
+  {
+    "flag": "--write-batch=FILE",
+    "description": "write a batched update to FILE"
+  },
+  {
+    "flag": "--only-write-batch=FILE",
+    "description": "like --write-batch but w/o updating dest"
+  },
+  {
+    "flag": "--read-batch=FILE",
+    "description": "read a batched update from FILE"
+  },
+  {
+    "flag": "--protocol=NUM",
+    "description": "force an older protocol version to be used"
+  },
+  {
+    "flag": "--iconv=CONVERT_SPEC",
+    "description": "request charset conversion of filenames"
+  },
+  {
+    "flag": "--checksum-seed=NUM",
+    "description": "set block/file checksum seed (advanced)"
+  },
+  {
+    "flag": "--ipv4",
+    "description": "prefer IPv4"
+  },
+  {
+    "flag": "--ipv6",
+    "description": "prefer IPv6"
+  },
+  {
+    "flag": "--version",
+    "description": "print the version + other info and exit"
+  },
+  {
+    "flag": "--help",
+    "description": "show this help (* -h is help only on its own)"
+  }
+]

--- a/tests/help_output.rs
+++ b/tests/help_output.rs
@@ -1,10 +1,21 @@
 // tests/help_output.rs
 use assert_cmd::Command;
+use serde::Deserialize;
+use std::collections::HashMap;
 use std::fs;
 
+#[derive(Deserialize)]
+struct FlagDesc {
+    flag: String,
+    description: String,
+}
+
 #[test]
-fn help_matches_rsync() {
-    let expected = fs::read_to_string("tests/fixtures/rsync-help.txt").unwrap();
+fn help_contains_expected_flags() {
+    let expected: Vec<FlagDesc> =
+        serde_json::from_str(&fs::read_to_string("tests/fixtures/rsync-help.txt").unwrap())
+            .unwrap();
+
     let output = Command::cargo_bin("oc-rsync")
         .unwrap()
         .env("COLUMNS", "80")
@@ -13,6 +24,46 @@ fn help_matches_rsync() {
         .arg("--help")
         .output()
         .unwrap();
-    let got = String::from_utf8_lossy(&output.stdout);
-    assert_eq!(got, expected);
+
+    let mut actual: HashMap<String, String> = HashMap::new();
+    let mut in_options = false;
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if line.trim() == "Options" {
+            in_options = true;
+            continue;
+        }
+        if !in_options {
+            continue;
+        }
+        if line.starts_with("Use \"rsync --daemon --help\"") {
+            break;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        let trimmed = line.trim_end();
+        if let Some(idx) = trimmed.find("  ") {
+            let (spec, desc) = trimmed.split_at(idx);
+            let flag = spec
+                .split(',')
+                .find(|s| s.trim_start().starts_with("--"))
+                .unwrap_or(spec)
+                .trim()
+                .to_string();
+            let desc = desc.split_whitespace().collect::<String>();
+            actual.insert(flag, desc);
+        }
+    }
+
+    for FlagDesc { flag, description } in expected {
+        let expected_desc = description.split_whitespace().collect::<String>();
+        let actual_desc = actual
+            .get(&flag)
+            .unwrap_or_else(|| panic!("missing flag {}", flag));
+        assert_eq!(
+            actual_desc, &expected_desc,
+            "description mismatch for {}",
+            flag
+        );
+    }
 }

--- a/tools/flag_matrix.rs
+++ b/tools/flag_matrix.rs
@@ -110,7 +110,7 @@ fn parse_feature_matrix() -> BTreeSet<String> {
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rsync_help_str = fs::read_to_string("tests/fixtures/rsync-help.txt")?;
+    let rsync_help_str = fs::read_to_string("tests/fixtures/rsync-help-80.txt")?;
     let (rsync_flags, rsync_aliases, rsync_alias_desc) = parse_help(&rsync_help_str);
 
     let oc_rsync_help = Command::new("cargo")


### PR DESCRIPTION
## Summary
- store upstream `rsync --help` options as structured `flag -> description` pairs
- verify `oc-rsync --help` contains all expected option pairs
- document how to regenerate help fixtures and keep oc-rsync help snapshots

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test help_output`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b818704b5c832392cfbe087ca3b4fe