### PR TITLE
Handle non-directory destinations without appending source name

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -337,6 +337,10 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         RemoteSpec::Local(p) => &p.path,
         RemoteSpec::Remote { path, .. } => &path.path,
     };
+    let dst_is_dir = match &dst {
+        RemoteSpec::Local(p) => p.path.is_dir(),
+        RemoteSpec::Remote { .. } => true,
+    };
     if opts.relative {
         let rel = if src_path.is_absolute() {
             src_path.strip_prefix(Path::new("/")).unwrap_or(src_path)
@@ -347,7 +351,7 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
             RemoteSpec::Local(p) => p.path.push(rel),
             RemoteSpec::Remote { path, .. } => path.path.push(rel),
         }
-    } else if !src_trailing {
+    } else if !src_trailing && dst_is_dir {
         let name = src_path
             .file_name()
             .map(|s| s.to_owned())


### PR DESCRIPTION
## Summary
- avoid blindly appending source basename to destination
- fix `--delete-missing-args` to remove explicit destination paths

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: ignore_errors_allows_deletion_failure due to running as root)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b81964c48083238e1677feca2d805b