### PR TITLE
Skip privilege tests when not root

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -128,6 +128,8 @@ creating files, and ownership requests from clients will be ignored.
 
 Before serving files the daemon confines itself to the module root. On Unix platforms it performs a `chroot` to the module path, changes its working directory to `/`, and drops privileges to a less privileged user and group (UID/GID 65534 by default). The `uid` and `gid` module directives may override the default IDs for specific exports.
 
+Unit tests exercising this chroot and privilege-dropping behavior require root privileges. When run as an unprivileged user these tests are skipped, so CI environments must provide sufficient permissions to execute them.
+
 ## Hosts allow/deny lists
 
 The daemon can restrict connections based on client address. The `--hosts-allow`

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -131,6 +131,11 @@ fn chroot_drops_privileges() {
     use nix::sys::wait::waitpid;
     use nix::unistd::{fork, getegid, geteuid, ForkResult};
 
+    if geteuid().as_raw() != 0 {
+        eprintln!("skipping chroot_drops_privileges: requires root");
+        return;
+    }
+
     let dir = tempdir().unwrap();
     match unsafe { fork() } {
         Ok(ForkResult::Parent { child }) => {
@@ -153,7 +158,12 @@ fn chroot_drops_privileges() {
 #[serial]
 fn chroot_requires_root() {
     use nix::sys::wait::waitpid;
-    use nix::unistd::{fork, ForkResult};
+    use nix::unistd::{fork, geteuid, ForkResult};
+
+    if geteuid().as_raw() != 0 {
+        eprintln!("skipping chroot_requires_root: requires root");
+        return;
+    }
     let dir = tempdir().unwrap();
     match unsafe { fork() } {
         Ok(ForkResult::Parent { child }) => {


### PR DESCRIPTION
## Summary
- skip daemon chroot tests when not running as root
- document root requirement for chroot/privilege-dropping tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test daemon`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b82028a5d08323a4091de4158e7c57