### PR TITLE
Handle missing mux channel indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,6 +1190,7 @@ dependencies = [
  "filelist",
  "indexmap",
  "subtle",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,6 +11,7 @@ checksums = { path = "../checksums" }
 filelist = { path = "../filelist" }
 encoding_rs = "0.8"
 subtle = "2"
+tracing = "0.1"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- avoid panic when mux channel indices vanish during polling and warn instead
- allow unregistering mux channels and add regression test for removals
- record tracing dependency for protocol crate

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: ignore_errors_allows_deletion_failure)*
- `cargo test --test delete_policy` *(fails: ignore_errors_allows_deletion_failure)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8202dcc48832386723f139c262623