### PR TITLE
Mirror upstream syslog/journald levels and prefixes

### DIFF
--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -368,7 +368,8 @@ where
             v.msg.push_str(event.metadata().target());
         }
         let pri = 8 + syslog_severity(*event.metadata().level());
-        let data = format!("<{pri}>{}", v.msg);
+        let pid = std::process::id();
+        let data = format!("<{pri}>rsync[{pid}]: {}", v.msg);
         let _ = self.sock.send(data.as_bytes());
     }
 }
@@ -412,7 +413,10 @@ where
             v.msg.push_str(event.metadata().target());
         }
         let prio = journald_priority(*event.metadata().level());
-        let data = format!("PRIORITY={prio}\nMESSAGE={}\n", v.msg);
+        let data = format!(
+            "PRIORITY={prio}\nSYSLOG_IDENTIFIER=rsync\nMESSAGE={}\n",
+            v.msg
+        );
         let _ = self.sock.send(data.as_bytes());
     }
 }

--- a/crates/logging/tests/journald.rs
+++ b/crates/logging/tests/journald.rs
@@ -32,6 +32,7 @@ fn journald_emits_message() {
     let mut buf = [0u8; 256];
     let (n, _) = server.recv_from(&mut buf).unwrap();
     let msg = std::str::from_utf8(&buf[..n]).unwrap();
-    assert!(msg.contains("MESSAGE=hi"));
+    let expected = "PRIORITY=6\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=hi\n";
+    assert_eq!(msg, expected);
     std::env::remove_var("OC_RSYNC_JOURNALD_PATH");
 }

--- a/crates/logging/tests/syslog.rs
+++ b/crates/logging/tests/syslog.rs
@@ -32,6 +32,7 @@ fn syslog_emits_message() {
     let mut buf = [0u8; 256];
     let (n, _) = server.recv_from(&mut buf).unwrap();
     let msg = std::str::from_utf8(&buf[..n]).unwrap();
-    assert!(msg.contains("hello"));
+    let expected = format!("<14>rsync[{}]: hello", std::process::id());
+    assert_eq!(msg, expected);
     std::env::remove_var("OC_RSYNC_SYSLOG_PATH");
 }

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -18,7 +18,7 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
 | `--out-format` and log file messages | ✅ | [tests/out_format.rs](../tests/out_format.rs)<br>[tests/log_file.rs](../tests/log_file.rs) | [crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |
-| System log integration (syslog/journald) | ⚠️ | [crates/logging/tests/syslog.rs](../crates/logging/tests/syslog.rs)<br>[crates/logging/tests/journald.rs](../crates/logging/tests/journald.rs) | [crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |
+| System log integration (syslog/journald) | ✅ | [crates/logging/tests/syslog.rs](../crates/logging/tests/syslog.rs)<br>[crates/logging/tests/journald.rs](../crates/logging/tests/journald.rs) | [crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |
 | Daemon MOTD/greeting messages | ❌ | — | — |
 
 _Future contributors: update this section when adding or fixing message behaviors._


### PR DESCRIPTION
## Summary
- Prefix syslog messages with `rsync[pid]` and include identifier for journald
- Tighten syslog and journald tests to assert exact message bytes
- Mark system log integration feature as complete in docs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: ignore_errors_allows_deletion_failure)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b824979a008323ba95c72c8185e9a0