### PR TITLE
feat(cli): add legacy args flags

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -61,7 +61,7 @@ pub fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
     let mut opts =
         ClientOpts::from_arg_matches(matches).map_err(|e| EngineError::Other(e.to_string()))?;
-    if matches.value_source("secluded_args") != Some(ValueSource::CommandLine) {
+    if !opts.old_args && matches.value_source("secluded_args") != Some(ValueSource::CommandLine) {
         if let Ok(val) = env::var("RSYNC_PROTECT_ARGS") {
             if val != "0" {
                 opts.secluded_args = true;
@@ -103,6 +103,9 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         if !opts.no_specials {
             opts.specials = true;
         }
+    }
+    if opts.old_dirs {
+        opts.dirs = true;
     }
     let matcher = build_matcher(&opts, matches)?;
     let addr_family = if opts.ipv4 {
@@ -201,6 +204,13 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     #[cfg(feature = "acl")]
     if acls {
         remote_opts.push("--acls".into());
+    }
+    if opts.old_args {
+        remote_opts.push("--old-args".into());
+    }
+    if opts.old_dirs {
+        remote_opts.push("-r".into());
+        remote_opts.push("--exclude=/*/*".into());
     }
 
     if let Some(cfg) = &opts.config {

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -20,6 +20,13 @@ pub(crate) struct ClientOpts {
     pub recursive: bool,
     #[arg(short = 'd', long, help_heading = "Selection")]
     pub dirs: bool,
+    #[arg(
+        long = "old-dirs",
+        visible_alias = "old-d",
+        help_heading = "Selection",
+        help = "works like --dirs when talking to old rsync"
+    )]
+    pub old_dirs: bool,
     #[arg(short = 'R', long, help_heading = "Selection")]
     pub relative: bool,
     #[arg(long = "no-implied-dirs", help_heading = "Selection")]
@@ -510,6 +517,13 @@ pub(crate) struct ClientOpts {
         help = "send OPTION to the remote side only"
     )]
     pub remote_option: Vec<String>,
+    #[arg(
+        long = "old-args",
+        help_heading = "Misc",
+        help = "disable the modern arg-protection idiom",
+        conflicts_with = "secluded_args"
+    )]
+    pub old_args: bool,
     #[arg(
         short = 's',
         long = "secluded-args",

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -75,7 +75,7 @@
 | -0 | --from0 | all *-from/filter files are delimited by 0s | no |  | no |
 |  | --include-from=FILE | read include patterns from FILE | no |  | no |
 |  | --include=PATTERN | don't exclude files matching PATTERN | no |  | no |
-|  | --old-args | disable the modern arg-protection idiom | no |  | no |
+|  | --old-args | disable the modern arg-protection idiom | yes |  | no |
 | -s | --secluded-args | use the protocol to safely send the args | no |  | no |
 |  | --trust-sender | trust the remote sender's file list | no |  | no |
 | -F |  | same as --filter='dir-merge /.rsync-filter' repeated: --filter='- .rsync-filter' | no |  | no |
@@ -177,7 +177,7 @@
 |  | --munge-links | munge symlinks to make them safe & unusable | yes |  | no |
 |  | --no-OPTION | turn off an implied OPTION (e.g. --no-D) | no |  | no |
 |  | --no-implied-dirs | don't send implied dirs with --relative | yes |  | no |
-| --old-d | --old-dirs | works like --dirs when talking to old rsync | no |  | no |
+| --old-d | --old-dirs | works like --dirs when talking to old rsync | yes |  | no |
 | -x | --one-file-system | don't cross filesystem boundaries | yes |  | no |
 |  | --partial | keep partially transferred files | yes |  | no |
 |  | --partial-dir=DIR | put a partially transferred file into DIR | yes |  | no |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -113,9 +113,9 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--no-implied-dirs` | ✅ | Y | Y | Y | [tests/no_implied_dirs.rs](../tests/no_implied_dirs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | preserves existing symlinked directories |
 | `--no-motd` | ✅ | Y | Y | Y | [tests/daemon.rs](../tests/daemon.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--numeric-ids` | ✅ | N | N | N | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--old-args` | ❌ | N | N | N | — | — | not yet implemented |
-| `--old-d` | ❌ | N | N | N | [gaps.md](gaps.md) | — | alias for `--old-dirs` |
-| `--old-dirs` | ❌ | N | N | N | — | — | not yet implemented |
+| `--old-args` | ✅ | N | N | N | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | disable modern arg-protection idiom |
+| `--old-d` | ✅ | N | N | N | [tests/cli_flags.rs](../tests/cli_flags.rs) | — | alias for `--old-dirs` |
+| `--old-dirs` | ✅ | N | N | N | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | works like --dirs when talking to old rsync |
 | `--omit-dir-times` | ✅ | Y | Y | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--omit-link-times` | ✅ | Y | Y | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--one-file-system` | ✅ | Y | Y | Y | [crates/walk/tests/walk.rs](../crates/walk/tests/walk.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -121,3 +121,30 @@ fn delete_flags_last_one_wins() {
     assert!(matches.get_flag("delete_before"));
     assert!(!matches.get_flag("delete_after"));
 }
+
+#[test]
+fn old_args_flag_is_accepted() {
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--old-args", "--version"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn old_dirs_flag_is_accepted() {
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--old-dirs", "--version"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn old_d_alias_is_accepted() {
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--old-d", "--version"])
+        .assert()
+        .success();
+}

--- a/tools/flag_matrix.json
+++ b/tools/flag_matrix.json
@@ -441,12 +441,12 @@
   },
   {
     "flag": "--old-args",
-    "status": "Ignored",
+    "status": "Supported",
     "notes": ""
   },
   {
     "flag": "--old-dirs",
-    "status": "Ignored",
+    "status": "Supported",
     "notes": ""
   },
   {

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -88,8 +88,8 @@
 | --no-implied-dirs | Ignored |  |
 | --no-motd | Supported |  |
 | --numeric-ids | Supported |  |
-| --old-args | Ignored |  |
-| --old-dirs | Ignored |  |
+| --old-args | Supported |  |
+| --old-dirs | Supported |  |
 | --omit-dir-times | Supported |  |
 | --omit-link-times | Supported |  |
 | --one-file-system | Supported |  |


### PR DESCRIPTION
## Summary
- support `--old-args`, `--old-dirs`, and alias `--old-d`
- negotiate legacy behavior for old peers
- document and test legacy flag handling

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: ignore_errors_allows_deletion_failure unexpected success)*
- `cargo test --test delete_policy ignore_errors_allows_deletion_failure -- --exact` *(fails: Unexpected success)
- `cargo test --all-features` *(fails: linking with `cc` failed: exit status: 1)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b824a0c30c832391560e5e23fc7cac