### PR TITLE
Honor no-detach flag for foreground daemon operation

### DIFF
--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -19,7 +19,7 @@ use protocol::{negotiate_version, CharsetConv};
 use transport::{parse_sockopts, AddressFamily, SockOpt, TcpTransport, Transport};
 
 #[derive(Args, Debug)]
-pub(crate) struct DaemonOpts {
+pub struct DaemonOpts {
     #[arg(long)]
     pub daemon: bool,
     #[arg(long = "no-detach")]
@@ -356,6 +356,7 @@ pub(crate) fn run_daemon(opts: DaemonOpts, matches: &ArgMatches) -> Result<()> {
         65534,
         handler,
         quiet,
+        opts.no_detach,
     )
     .map_err(|e| EngineError::Other(format!("daemon failed to bind to port {port}: {e}")))
 }

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::daemon::DaemonOpts;
+pub use crate::daemon::DaemonOpts;
 use crate::formatter;
 use crate::utils::{parse_duration, parse_nonzero_duration, parse_size};
 use clap::{ArgAction, Args, CommandFactory, Parser};

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 transport = { path = "../transport" }
-nix = { version = "0.27", features = ["user", "fs"] }
+nix = { version = "0.27", features = ["user", "fs", "process"] }
 protocol = { path = "../protocol" }
 sd-notify = "0.4"
 ipnet = "2"

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -9,6 +9,8 @@ use std::sync::{atomic::AtomicUsize, atomic::Ordering, Arc};
 use std::time::Duration;
 
 #[cfg(unix)]
+use nix::unistd::{fork, setsid, ForkResult};
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 use ipnet::IpNet;
@@ -1095,7 +1097,22 @@ pub fn run_daemon(
     gid: u32,
     handler: Arc<Handler>,
     quiet: bool,
+    no_detach: bool,
 ) -> io::Result<()> {
+    #[cfg(not(unix))]
+    let _ = no_detach;
+    #[cfg(unix)]
+    if !no_detach {
+        match unsafe { fork() } {
+            Ok(ForkResult::Parent { .. }) => return Ok(()),
+            Ok(ForkResult::Child) => {
+                setsid().map_err(io::Error::other)?;
+            }
+            Err(e) => {
+                return Err(io::Error::other(e));
+            }
+        }
+    }
     if let Some(path) = &pid_file {
         let mut f = OpenOptions::new()
             .create(true)

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -614,6 +614,7 @@ fn spawn_daemon() -> io::Result<(Child, u16, tempfile::TempDir)> {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -644,6 +645,7 @@ fn spawn_daemon_with_timeout(timeout: u64) -> io::Result<(Child, u16, tempfile::
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -720,7 +722,12 @@ fn daemon_allows_path_traversal_without_chroot() {
     fs::write(&cfg_path, cfg).unwrap();
     let mut child = StdCommand::cargo_bin("oc-rsync")
         .unwrap()
-        .args(["--daemon", "--config", cfg_path.to_str().unwrap()])
+        .args([
+            "--daemon",
+            "--no-detach",
+            "--config",
+            cfg_path.to_str().unwrap(),
+        ])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
@@ -819,6 +826,7 @@ fn spawn_daemon_with_address(addr: &str) -> io::Result<(Child, u16, tempfile::Te
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -853,7 +861,12 @@ fn spawn_daemon_with_config_address(addr: &str) -> io::Result<(Child, u16, tempf
     fs::write(&cfg_path, cfg).unwrap();
     let mut child = StdCommand::cargo_bin("oc-rsync")
         .unwrap()
-        .args(["--daemon", "--config", cfg_path.to_str().unwrap()])
+        .args([
+            "--daemon",
+            "--no-detach",
+            "--config",
+            cfg_path.to_str().unwrap(),
+        ])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
@@ -875,6 +888,7 @@ fn spawn_daemon_ipv4() -> io::Result<(Child, u16, tempfile::TempDir)> {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -902,6 +916,7 @@ fn spawn_daemon_ipv6() -> io::Result<(Child, u16, tempfile::TempDir)> {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1130,6 +1145,7 @@ fn daemon_runs_with_numeric_ids() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1208,6 +1224,7 @@ fn daemon_rejects_world_readable_secrets_file() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1255,6 +1272,7 @@ fn daemon_rejects_invalid_token() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1302,6 +1320,7 @@ fn daemon_rejects_missing_token() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1349,6 +1368,7 @@ fn daemon_rejects_unauthorized_module() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1400,6 +1420,7 @@ fn daemon_accepts_authorized_client() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1458,7 +1479,12 @@ fn daemon_accepts_listed_auth_user() {
     fs::write(&cfg_path, cfg).unwrap();
     let mut child = StdCommand::cargo_bin("oc-rsync")
         .unwrap()
-        .args(["--daemon", "--config", cfg_path.to_str().unwrap()])
+        .args([
+            "--daemon",
+            "--no-detach",
+            "--config",
+            cfg_path.to_str().unwrap(),
+        ])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
@@ -1513,7 +1539,12 @@ fn daemon_rejects_unlisted_auth_user() {
     fs::write(&cfg_path, cfg).unwrap();
     let mut child = StdCommand::cargo_bin("oc-rsync")
         .unwrap()
-        .args(["--daemon", "--config", cfg_path.to_str().unwrap()])
+        .args([
+            "--daemon",
+            "--no-detach",
+            "--config",
+            cfg_path.to_str().unwrap(),
+        ])
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
@@ -1565,6 +1596,7 @@ fn daemon_parses_secrets_file_with_comments() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1619,6 +1651,7 @@ fn client_authenticates_with_password_file() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", dir.path().display()),
             "--port",
@@ -1665,6 +1698,7 @@ fn daemon_respects_host_allow_and_deny_lists() {
             .unwrap()
             .args([
                 "--daemon",
+                "--no-detach",
                 "--module",
                 "data=/tmp",
                 "--port",
@@ -1696,6 +1730,7 @@ fn daemon_respects_host_allow_and_deny_lists() {
             .unwrap()
             .args([
                 "--daemon",
+                "--no-detach",
                 "--module",
                 "data=/tmp",
                 "--port",
@@ -1746,6 +1781,7 @@ fn daemon_respects_module_host_lists() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--config",
             cfg.to_str().unwrap(),
             "--port",
@@ -1772,6 +1808,7 @@ fn daemon_respects_module_host_lists() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--config",
             cfg.to_str().unwrap(),
             "--port",
@@ -1816,6 +1853,7 @@ fn daemon_displays_motd() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             "data=/tmp",
             "--port",
@@ -1859,6 +1897,7 @@ fn daemon_suppresses_motd_when_requested() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             "data=/tmp",
             "--port",
@@ -1907,6 +1946,7 @@ fn client_respects_no_motd() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("data={}", src.display()),
             "--port",
@@ -1962,6 +2002,7 @@ fn daemon_writes_log_file() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             "data=/tmp",
             "--port",
@@ -2014,6 +2055,7 @@ fn daemon_honors_bwlimit() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             "data=/tmp",
             "--port",
@@ -2059,6 +2101,7 @@ fn daemon_hides_unlisted_modules() {
         .unwrap()
         .args([
             "--daemon",
+            "--no-detach",
             "--module",
             &format!("hidden={},list=no", hidden.display()),
             "--module",
@@ -2092,6 +2135,26 @@ fn daemon_hides_unlisted_modules() {
     let listing = String::from_utf8_lossy(&resp[..n]);
     assert!(listing.contains("visible"));
     assert!(!listing.contains("hidden"));
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[test]
+#[serial]
+fn daemon_stays_foreground_with_no_detach() {
+    if require_network().is_err() {
+        eprintln!("skipping daemon test: network access required");
+        return;
+    }
+    let (mut child, port, _dir) = match spawn_daemon() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("skipping daemon test: {e}");
+            return;
+        }
+    };
+    wait_for_daemon(port);
+    assert!(child.try_wait().unwrap().is_none());
     let _ = child.kill();
     let _ = child.wait();
 }

--- a/tools/flag_matrix.md
+++ b/tools/flag_matrix.md
@@ -85,6 +85,7 @@
 | --modify-window | Supported |  |
 | --munge-links | Ignored |  |
 | --no-OPTION | Ignored |  |
+| --no-detach | Supported |  |
 | --no-implied-dirs | Ignored |  |
 | --no-motd | Supported |  |
 | --numeric-ids | Supported |  |


### PR DESCRIPTION
## Summary
- expose daemon options to parse `--no-detach`
- avoid backgrounding when `--no-detach` is set
- document and test daemon foreground mode

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test daemon daemon_stays_foreground_with_no_detach -- --nocapture`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8249d297c83238aadbcacc29fa3f5