### PR TITLE
Add only-write-batch option

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -437,6 +437,13 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
     };
     let uid_map = parse_name_map(&opts.usermap, IdKind::User)?;
     let gid_map = parse_name_map(&opts.groupmap, IdKind::Group)?;
+    let (write_batch, only_write_batch) =
+        match (opts.write_batch.clone(), opts.only_write_batch.clone()) {
+            (Some(p), None) => (Some(p), false),
+            (None, Some(p)) => (Some(p), true),
+            (None, None) => (None, false),
+            _ => unreachable!(),
+        };
     let mut sync_opts = SyncOptions {
         delete: delete_mode,
         delete_excluded: opts.delete_excluded,
@@ -575,7 +582,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         secluded_args: opts.secluded_args,
         sockopts: opts.sockopts.clone(),
         remote_options: remote_opts.clone(),
-        write_batch: opts.write_batch.clone(),
+        write_batch,
+        only_write_batch,
         read_batch: opts.read_batch.clone(),
         copy_devices: opts.copy_devices,
         write_devices: opts.write_devices,

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -538,15 +538,23 @@ pub(crate) struct ClientOpts {
         long = "write-batch",
         value_name = "FILE",
         help_heading = "Misc",
-        conflicts_with = "read_batch"
+        conflicts_with_all = ["read_batch", "only_write_batch"]
     )]
     pub write_batch: Option<PathBuf>,
+    #[arg(
+        long = "only-write-batch",
+        value_name = "FILE",
+        help_heading = "Misc",
+        help = "like --write-batch but w/o updating dest",
+        conflicts_with_all = ["write_batch", "read_batch"]
+    )]
+    pub only_write_batch: Option<PathBuf>,
     #[arg(
         long = "read-batch",
         value_name = "FILE",
         help_heading = "Misc",
         help = "read a batched update from FILE",
-        conflicts_with = "write_batch"
+        conflicts_with_all = ["write_batch", "only_write_batch"]
     )]
     pub read_batch: Option<PathBuf>,
     #[arg(long = "copy-devices", help_heading = "Misc")]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -299,7 +299,7 @@ fn atomic_rename(src: &Path, dst: &Path) -> Result<()> {
 }
 
 fn remove_file_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
-    if opts.dry_run {
+    if opts.dry_run || opts.only_write_batch {
         return Ok(());
     }
     match fs::remove_file(path) {
@@ -316,7 +316,7 @@ fn remove_file_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
 }
 
 fn remove_dir_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
-    if opts.dry_run {
+    if opts.dry_run || opts.only_write_batch {
         return Ok(());
     }
     let res = if opts.force {
@@ -1170,9 +1170,16 @@ impl Sender {
             }
             Ok(op)
         });
-        recv.apply(path, dest, rel, ops)?;
-        drop(atime_guard);
-        recv.copy_metadata(path, dest)?;
+        if !self.opts.only_write_batch {
+            recv.apply(path, dest, rel, ops)?;
+            drop(atime_guard);
+            recv.copy_metadata(path, dest)?;
+        } else {
+            drop(atime_guard);
+            for op in ops {
+                let _ = op;
+            }
+        }
         Ok(true)
     }
 }
@@ -1746,6 +1753,7 @@ pub struct SyncOptions {
     pub sockopts: Vec<String>,
     pub remote_options: Vec<String>,
     pub write_batch: Option<PathBuf>,
+    pub only_write_batch: bool,
     pub read_batch: Option<PathBuf>,
     pub copy_devices: bool,
     pub write_devices: bool,
@@ -1846,6 +1854,7 @@ impl Default for SyncOptions {
             sockopts: Vec::new(),
             remote_options: Vec::new(),
             write_batch: None,
+            only_write_batch: false,
             read_batch: None,
             copy_devices: false,
             write_devices: false,
@@ -2006,7 +2015,7 @@ fn delete_extraneous(
                                 escape_path(rel, opts.eight_bit_output)
                             );
                         }
-                        let res = if opts.dry_run {
+                        let res = if opts.dry_run || opts.only_write_batch {
                             None
                         } else if opts.backup {
                             let backup_path = if let Some(ref dir) = opts.backup_dir {
@@ -2058,7 +2067,7 @@ fn delete_extraneous(
                             escape_path(rel, opts.eight_bit_output)
                         );
                     }
-                    let res = if opts.dry_run {
+                    let res = if opts.dry_run || opts.only_write_batch {
                         None
                     } else if opts.backup {
                         let backup_path = if let Some(ref dir) = opts.backup_dir {
@@ -2243,7 +2252,7 @@ pub fn sync(
         }
         return Ok(stats);
     }
-    if !dst.exists() {
+    if !dst.exists() && !opts.only_write_batch {
         fs::create_dir_all(dst).map_err(|e| {
             std::io::Error::new(
                 e.kind(),
@@ -2291,7 +2300,7 @@ pub fn sync(
         }
         return Ok(stats);
     }
-    if matches!(opts.delete, Some(DeleteMode::Before)) {
+    if matches!(opts.delete, Some(DeleteMode::Before)) && !opts.only_write_batch {
         delete_extraneous(&src_root, dst, &matcher, opts, &mut stats)?;
     }
     sender.start();
@@ -2670,15 +2679,17 @@ pub fn sync(
         }
     }
     sender.finish();
-    receiver.finalize()?;
-    if matches!(
-        opts.delete,
-        Some(DeleteMode::After) | Some(DeleteMode::During)
-    ) {
-        delete_extraneous(&src_root, dst, &matcher, opts, &mut stats)?;
-    }
-    for (src_dir, dest_dir) in dir_meta.into_iter().rev() {
-        receiver.copy_metadata(&src_dir, &dest_dir)?;
+    if !opts.only_write_batch {
+        receiver.finalize()?;
+        if matches!(
+            opts.delete,
+            Some(DeleteMode::After) | Some(DeleteMode::During)
+        ) {
+            delete_extraneous(&src_root, dst, &matcher, opts, &mut stats)?;
+        }
+        for (src_dir, dest_dir) in dir_meta.into_iter().rev() {
+            receiver.copy_metadata(&src_dir, &dest_dir)?;
+        }
     }
     if let Some(mut f) = batch_file {
         let _ = writeln!(

--- a/docs/cli/flags.md
+++ b/docs/cli/flags.md
@@ -87,11 +87,11 @@
 |  | --config=FILE | specify alternate rsyncd.conf file | yes | Used for client config file | yes |
 | -n | --dry-run | perform a trial run with no changes made | yes |  | no |
 |  | --fsync | fsync every written file | no |  | no |
-|  | --only-write-batch=FILE | like --write-batch but w/o updating dest | no |  | no |
-|  | --read-batch=FILE | read a batched update from FILE | no |  | no |
+|  | --only-write-batch=FILE | like --write-batch but w/o updating dest | yes |  | no |
+|  | --read-batch=FILE | read a batched update from FILE | yes |  | no |
 |  | --stop-after=MINS | Stop rsync after MINS minutes have elapsed | no |  | no |
 |  | --stop-at=y-m-dTh:m | Stop rsync at the specified point in time | no |  | no |
-|  | --write-batch=FILE | write a batched update to FILE | no |  | no |
+|  | --write-batch=FILE | write a batched update to FILE | yes |  | no |
 | -D |  | same as --devices --specials | no |  | no |
 | -P |  | same as --partial --progress | yes |  | no |
 

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -119,7 +119,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--omit-dir-times` | ✅ | Y | Y | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--omit-link-times` | ✅ | Y | Y | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--one-file-system` | ✅ | Y | Y | Y | [crates/walk/tests/walk.rs](../crates/walk/tests/walk.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--only-write-batch` | ❌ | N | N | N | — | — | not yet implemented |
+| `--only-write-batch` | ✅ | Y | Y | Y | [tests/write_batch.rs](../tests/write_batch.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | like --write-batch but w/o updating dest |
 | `--open-noatime` | ❌ | N | N | N | — | — | not yet implemented |
 | `--out-format` | ❌ | N | N | N | — | — | not yet implemented |
 | `--outbuf` | ❌ | N | N | N | — | — | not yet implemented |

--- a/tests/write_batch.rs
+++ b/tests/write_batch.rs
@@ -63,3 +63,26 @@ fn replays_batch_file() {
     assert!(dst2.join("src/f").exists());
     assert!(!dst2.join("src/g").exists());
 }
+
+#[test]
+fn only_write_batch_does_not_sync() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(src.join("f"), b"data").unwrap();
+    let dst = dir.path().join("dst");
+    let batch = dir.path().join("batch.txt");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--only-write-batch",
+            batch.to_str().unwrap(),
+            "-r",
+            src.to_str().unwrap(),
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(batch.exists());
+    assert!(!dst.exists());
+}


### PR DESCRIPTION
## Summary
- add `--only-write-batch` CLI flag
- skip applying filesystem changes when only writing batch
- document and test batch creation without syncing

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: tests/delete_policy.rs::ignore_errors_allows_deletion_failure)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b824a426388323a1bd07c5d085bcb9