### PR TITLE
cli: log recursive mode via tracing

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,7 +25,7 @@ use options::{ClientOpts, ProbeOpts};
 use utils::{
     init_logging, parse_filters, parse_name_map, parse_remote_specs, parse_rsync_path, RemoteSpec,
 };
-pub use utils::{parse_iconv, parse_rsh, print_version_if_requested};
+pub use utils::{parse_iconv, parse_logging_flags, parse_rsh, print_version_if_requested};
 
 use compress::{available_codecs, Codec};
 pub use engine::EngineError;
@@ -211,8 +211,8 @@ fn run_client(mut opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
             opts.verbose
         );
     }
-    if opts.recursive && !opts.quiet {
-        println!("recursive mode enabled");
+    if opts.verbose > 0 && opts.recursive && !opts.quiet {
+        tracing::info!(target: InfoFlag::Misc.target(), "recursive mode enabled");
     }
     let (src, mut dst) = parse_remote_specs(&src_arg, &dst_arg)?;
     if opts.mkpath {
@@ -1256,7 +1256,8 @@ fn run_probe(opts: ProbeOpts, quiet: bool) -> Result<()> {
 mod tests {
     use super::*;
     use crate::utils::{parse_bool, parse_remote_spec, RemoteSpec};
-    use daemon::authenticate;
+    use ::daemon::authenticate;
+    use clap::Parser;
     use engine::SyncOptions;
     use std::path::PathBuf;
 

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -8,7 +8,7 @@ use crate::formatter;
 use crate::utils::{
     parse_duration, parse_minutes, parse_nonzero_duration, parse_size, parse_stop_at,
 };
-use clap::{ArgAction, Args, CommandFactory, Parser};
+use clap::{ArgAction, Args, CommandFactory, Parser, ValueEnum};
 use logging::{DebugFlag, InfoFlag, StderrMode};
 use protocol::SUPPORTED_PROTOCOLS;
 

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -138,7 +138,7 @@ pub(crate) fn parse_bool(s: &str) -> std::result::Result<bool, String> {
     }
 }
 
-pub(crate) fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFlag>) {
+pub fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFlag>) {
     let mut info: Vec<InfoFlag> = matches
         .get_many::<InfoFlag>("info")
         .map(|v| v.copied().collect())


### PR DESCRIPTION
## Summary
- replace `println!("recursive mode enabled")` with a `tracing::info!` guarded by verbosity
- expose `parse_logging_flags` and add missing imports for tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p oc-rsync-cli` *(fails: Argument or group 'probe' specified in 'required_unless*' for 'src' does not exist)*
- `cargo test` *(terminated: `sparse_files_preserved` running over 60s)*
- `make lint`
- `make verify-comments` *(fails: crates/cli/tests/arg_order.rs: incorrect header)*

------
https://chatgpt.com/codex/tasks/task_e_68b831d65bc883238bbb8973bceff002