### PR TITLE
Add support for additional socket options

### DIFF
--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -8,7 +8,7 @@ use crate::formatter;
 use crate::utils::{
     parse_duration, parse_minutes, parse_nonzero_duration, parse_size, parse_stop_at,
 };
-use clap::{ArgAction, Args, CommandFactory, Parser};
+use clap::{ArgAction, Args, CommandFactory, Parser, ValueEnum};
 use logging::{DebugFlag, InfoFlag, StderrMode};
 use protocol::SUPPORTED_PROTOCOLS;
 

--- a/crates/cli/tests/arg_order.rs
+++ b/crates/cli/tests/arg_order.rs
@@ -1,3 +1,4 @@
+// crates/cli/tests/arg_order.rs
 use oc_rsync_cli::{cli_command, ARG_ORDER};
 
 const SKIP_ARGS: &[&str] = &[

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -109,6 +109,10 @@ impl TcpTransport {
                     }
                 }
                 SockOpt::IpHopLimit(v) => sock.set_unicast_hops_v6(*v)?,
+                SockOpt::Linger(dur) => sock.set_linger(*dur)?,
+                SockOpt::Broadcast(v) => sock.set_broadcast(*v)?,
+                SockOpt::RcvTimeout(d) => sock.set_read_timeout(Some(*d))?,
+                SockOpt::SndTimeout(d) => sock.set_write_timeout(Some(*d))?,
             }
         }
         Ok(())

--- a/crates/transport/tests/sockopts.rs
+++ b/crates/transport/tests/sockopts.rs
@@ -1,5 +1,10 @@
 // crates/transport/tests/sockopts.rs
-use transport::{parse_sockopts, SockOpt};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::time::Duration;
+
+use socket2::SockRef;
+use transport::{parse_sockopts, tcp::TcpTransport, SockOpt};
 
 #[test]
 fn parse_ip_ttl() {
@@ -74,6 +79,36 @@ fn parse_ip_tos_hex() {
 }
 
 #[test]
+fn parse_linger() {
+    let opts = parse_sockopts(&["SO_LINGER=5".into()]).unwrap();
+    assert_eq!(opts, vec![SockOpt::Linger(Some(Duration::from_secs(5)))]);
+}
+
+#[test]
+fn parse_broadcast_default() {
+    let opts = parse_sockopts(&["SO_BROADCAST".into()]).unwrap();
+    assert_eq!(opts, vec![SockOpt::Broadcast(true)]);
+}
+
+#[test]
+fn parse_broadcast_off() {
+    let opts = parse_sockopts(&["SO_BROADCAST=0".into()]).unwrap();
+    assert_eq!(opts, vec![SockOpt::Broadcast(false)]);
+}
+
+#[test]
+fn parse_rcvtimeout() {
+    let opts = parse_sockopts(&["SO_RCVTIMEO=10".into()]).unwrap();
+    assert_eq!(opts, vec![SockOpt::RcvTimeout(Duration::from_secs(10))]);
+}
+
+#[test]
+fn parse_sndtimeout() {
+    let opts = parse_sockopts(&["SO_SNDTIMEO=12".into()]).unwrap();
+    assert_eq!(opts, vec![SockOpt::SndTimeout(Duration::from_secs(12))]);
+}
+
+#[test]
 fn parse_ip_unknown() {
     assert!(parse_sockopts(&["ip:foo=1".into()]).is_err());
 }
@@ -96,4 +131,32 @@ fn parse_rcvbuf_missing() {
 #[test]
 fn parse_tcp_nodelay_invalid() {
     assert!(parse_sockopts(&["TCP_NODELAY=foo".into()]).is_err());
+}
+
+#[test]
+fn apply_sockopts_linger_broadcast_timeouts() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    thread::spawn(move || {
+        let _ = listener.accept().unwrap();
+    });
+
+    let stream = TcpStream::connect(addr).unwrap();
+    let inspect = stream.try_clone().unwrap();
+    let transport = TcpTransport::from_stream(stream);
+
+    let opts = vec![
+        SockOpt::Linger(Some(Duration::from_secs(5))),
+        SockOpt::Broadcast(true),
+        SockOpt::RcvTimeout(Duration::from_secs(10)),
+        SockOpt::SndTimeout(Duration::from_secs(12)),
+    ];
+    transport.apply_sockopts(&opts).unwrap();
+
+    let sock = SockRef::from(&inspect);
+    assert_eq!(sock.linger().unwrap(), Some(Duration::from_secs(5)));
+    assert!(sock.broadcast().unwrap());
+    assert_eq!(sock.read_timeout().unwrap(), Some(Duration::from_secs(10)));
+    assert_eq!(sock.write_timeout().unwrap(), Some(Duration::from_secs(12)));
 }


### PR DESCRIPTION
## Summary
- extend `SockOpt` and parser with broadcast, linger, recv/send timeouts
- apply new socket options in TCP transport
- test parsing and application of new socket options

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p transport sockopts`
- `make verify-comments`
- `make lint`
- `cargo test -p transport` *(fails: idle_time_refills_debt assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68b831dc18bc83238abaccedb88c368d