### PR TITLE
Add version banner module and tests

### DIFF
--- a/bin/oc-rsync/src/version.rs
+++ b/bin/oc-rsync/src/version.rs
@@ -1,0 +1,29 @@
+// bin/oc-rsync/src/version.rs
+use protocol::SUPPORTED_PROTOCOLS;
+
+pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOLS[0];
+
+pub fn render_version_lines() -> Vec<String> {
+    vec![
+        format!(
+            "oc-rsync {} (protocol {})",
+            env!("CARGO_PKG_VERSION"),
+            RSYNC_PROTOCOL
+        ),
+        format!(
+            "rsync {}",
+            option_env!("RSYNC_UPSTREAM_VER").unwrap_or("unknown")
+        ),
+        format!(
+            "{} {}",
+            option_env!("BUILD_REVISION").unwrap_or("unknown"),
+            option_env!("OFFICIAL_BUILD").unwrap_or("unofficial")
+        ),
+    ]
+}
+
+#[allow(dead_code)]
+pub fn version_banner() -> String {
+    format!("{}\n", render_version_lines().join("\n"))
+}
+

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -22,3 +22,9 @@ fn banner_is_static() {
     ];
     assert_eq!(version::render_version_lines(), expected);
 }
+
+#[test]
+fn banner_renders_correctly() {
+    let expected = format!("{}\n", version::render_version_lines().join("\n"));
+    assert_eq!(version::version_banner(), expected);
+}

--- a/tests/daemon_journald.rs
+++ b/tests/daemon_journald.rs
@@ -1,3 +1,4 @@
+// tests/daemon_journald.rs
 #![cfg(unix)]
 
 use daemon::init_logging;

--- a/tests/daemon_syslog.rs
+++ b/tests/daemon_syslog.rs
@@ -1,3 +1,4 @@
+// tests/daemon_syslog.rs
 #![cfg(unix)]
 
 use daemon::init_logging;


### PR DESCRIPTION
## Summary
- implement version rendering logic for oc-rsync binary
- test version banner formatting
- fix missing header comments in daemon log tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: sync_keep_dirlinks_preserves_symlinked_dir, sync_preserves_executability)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8487025348323ae096cfd9251fe4c