### PR TITLE
ci: build upstream rsync and check option drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,3 +80,33 @@ jobs:
           name: oc-rsync-${{ matrix.target }}
           path: dist
 
+  upstream-rsync:
+    needs: lint-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev zlib1g-dev libacl1-dev
+      - name: Build oc-rsync
+        run: cargo build --release --bin oc-rsync
+      - name: Fetch upstream rsync
+        run: scripts/fetch-rsync.sh
+      - name: Build upstream rsync
+        run: |
+          cd rsync-3.4.1
+          ./configure
+          make
+      - name: Diff --version
+        run: |
+          diff <(./target/release/oc-rsync --version) <(rsync-3.4.1/rsync --version) || true
+      - name: Diff --help
+        run: |
+          diff <(./target/release/oc-rsync --help) <(rsync-3.4.1/rsync --help) || true
+      - name: Check option tables
+        run: scripts/check-option-table.sh
+

--- a/scripts/check-option-table.sh
+++ b/scripts/check-option-table.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+cd "$ROOT_DIR"
+
+scripts/fetch-rsync.sh > /dev/null
+
+diff -u rsync-3.4.1/rsync.1 docs/spec/rsync.1
+diff -u rsync-3.4.1/rsyncd.conf.5 docs/spec/rsyncd.conf.5

--- a/scripts/fetch-manpages.sh
+++ b/scripts/fetch-manpages.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$SCRIPT_DIR/.."
+cd "$ROOT_DIR"
+
+scripts/fetch-rsync.sh
+cp rsync-3.4.1/rsync.1 docs/spec/rsync.1
+cp rsync-3.4.1/rsyncd.conf.5 docs/spec/rsyncd.conf.5


### PR DESCRIPTION
## Summary
- build rsync 3.4.1 from source and diff oc-rsync CLI output
- fetch upstream manpages and fail CI if option table drifts

## Testing
- `cargo test` *(fails: sync_keep_dirlinks_preserves_symlinked_dir, sync_preserves_executability)*
- `make verify-comments` *(fails: tests/daemon_journald.rs incorrect header)*
- `make lint`
- `scripts/check-option-table.sh` *(fails: curl 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b8493751a08323ba48abfa04e9032c