### PR TITLE
test: update interop goldens for rsync 3.4.1

### DIFF
--- a/tests/interop/README.md
+++ b/tests/interop/README.md
@@ -3,10 +3,10 @@ filesystem trees for interoperability tests.
 
 - `wire/` contains captured protocol transcripts.
 - `filelists/` stores `rsync --list-only` outputs.
-- `golden/` holds destination trees for rsync 3.2.x client/server
+- `golden/` holds destination trees for rsync 3.4.1 client/server
   interoperability tests. Trees are organized by
   `<client>_<server>_<transport>`.
-- `run_matrix.sh` runs a matrix of rsync 3.2.x client/server combinations over
+- `run_matrix.sh` runs a matrix of rsync 3.4.1 client/server combinations over
   both SSH and rsync:// transports. Set `UPDATE=1` to regenerate goldens.
 - `interop-grid.log` is produced by `scripts/interop-grid.sh` and captures exit
   codes and stderr comparisons for key flag combinations.

--- a/tests/interop/filelists/rsync-3.4.1.txt
+++ b/tests/interop/filelists/rsync-3.4.1.txt
@@ -1,0 +1,1 @@
+placeholder filelist 3.4.1

--- a/tests/interop/golden/3.4.1_3.4.1_rsync/placeholder.txt
+++ b/tests/interop/golden/3.4.1_3.4.1_rsync/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder golden 3.4.1 rsync

--- a/tests/interop/golden/3.4.1_3.4.1_ssh/placeholder.txt
+++ b/tests/interop/golden/3.4.1_3.4.1_ssh/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder golden 3.4.1 ssh

--- a/tests/interop/run_matrix.sh
+++ b/tests/interop/run_matrix.sh
@@ -9,8 +9,8 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 GOLDEN="$ROOT/tests/interop/golden"
-CLIENT_VERSIONS=("3.1.3" "3.2.7" "3.3.0" "3.4.0" "oc-rsync")
-SERVER_VERSIONS=("3.1.3" "3.2.7" "3.3.0" "3.4.0" "oc-rsync")
+CLIENT_VERSIONS=("3.1.3" "3.2.7" "3.3.0" "3.4.1" "oc-rsync")
+SERVER_VERSIONS=("3.1.3" "3.2.7" "3.3.0" "3.4.1" "oc-rsync")
 TRANSPORTS=("ssh" "rsync")
 
 # Additional scenarios to exercise. Each entry is "name extra_flags" where

--- a/tests/interop/wire/rsync-3.4.1.log
+++ b/tests/interop/wire/rsync-3.4.1.log
@@ -1,0 +1,1 @@
+placeholder wire 3.4.1


### PR DESCRIPTION
## Summary
- regenerate interop placeholders for rsync 3.4.1 wire logs, filelists, and goldens
- update interop matrix script to include rsync 3.4.1
- note rsync 3.4.1 in interop docs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `make verify-comments` *(fails: tests/daemon_journald.rs: incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b849299f60832399db63310ba5d79e