### PR TITLE
test: verify dirlink preservation

### DIFF
--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -104,8 +104,9 @@ fn sync_keep_dirlinks_preserves_symlinked_dir() {
 
     let meta = fs::symlink_metadata(dst.join("sub")).unwrap();
     assert!(meta.file_type().is_symlink());
+    assert_eq!(fs::read_link(dst.join("sub")).unwrap(), target);
     assert!(target.join("file").exists());
-    assert!(!dst.join("sub/file").exists());
+    assert!(dst.join("sub/file").exists());
 }
 
 #[cfg(all(unix, feature = "xattr"))]


### PR DESCRIPTION
## Summary
- ensure `sync_keep_dirlinks_preserves_symlinked_dir` checks that `dst/sub` remains a symlink to `target`
- confirm file exists through the symlink

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo test --test local_sync_tree` *(fails: sync_preserves_executability)*
- `cargo test --test local_sync_tree sync_keep_dirlinks_preserves_symlinked_dir`


------
https://chatgpt.com/codex/tasks/task_e_68b86f6330c88323899fd33d9cefdb2a