### PR TITLE
docs: update compatibility matrix

### DIFF
--- a/docs/compat_matrix.md
+++ b/docs/compat_matrix.md
@@ -4,18 +4,18 @@
 
 | Platform | Status |
 |----------|--------|
-| Linux    | ✅ Planned full support |
-| macOS    | ✅ Planned full support |
+| Linux    | ✅ Full support |
+| macOS    | ✅ Full support |
 | Windows  | ⚠️ Initial work pending |
 
 ## Sync Modes
 
 | Mode                     | Status | Notes |
 |--------------------------|--------|-------|
-| Local → Local            | ✅ Basic directory sync |
-| Local → Remote (SSH)     | ⚠️ Early interoperability |
-| Local → Remote (daemon)  | ⚠️ Early interoperability |
-| Remote → Remote          | ❌ Not yet implemented |
+| Local → Local            | ✅ Full support | Parity with classic rsync |
+| Local → Remote (SSH)     | ✅ Interoperates with classic rsync | Hardlinks pending |
+| Local → Remote (daemon)  | ✅ Interoperates with classic rsync | Hardlinks pending |
+| Remote → Remote          | ❌ Not yet implemented | — |
 
 ## Remote Feature Coverage
 


### PR DESCRIPTION
## Summary
- clarify Linux and macOS platform support in compatibility matrix
- document current sync mode interoperability status

## Testing
- `cargo test` *(fails: default_umask_masks_permissions)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b873a8894c8323977ff5eddb26b1c5