### PR TITLE
docs: split feature matrix tables

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -11,6 +11,9 @@ Classic `rsync` protocol versions 29–32 are supported.
 | --- | --- | --- |
 | File list path-delta encoding with uid/gid tables | ✅ | Exercised via `filelist` tests |
 | Challenge-response token authentication | ✅ | Protocol handshake verifies tokens |
+
+## CLI options
+
 | Option | Supported | Parity (Y/N) | Message-parity (Y/N) | Parser-parity (Y/N) | Tests | Source | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `--8-bit-output` | ✅ | Y | Y | Y | [tests/eight_bit_output.rs](../tests/eight_bit_output.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |


### PR DESCRIPTION
## Summary
- split feature matrix into separate tables for internal features and CLI options
- verify Markdown renders two tables

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b873ad5d308323b9aeeae1a743454a