### PR TITLE
Yield after rejecting TCP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,7 @@ dependencies = [
  "protocol",
  "socket2",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -10,6 +10,7 @@ nix = { version = "0.28", default-features = false, features = ["poll"] }
 socket2 = { version = "0.5", features = ["all"] }
 checksums = { path = "../checksums" }
 ipnet = "2"
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -62,7 +62,9 @@ impl TcpTransport {
             if host_allowed(&addr.ip(), hosts_allow, hosts_deny) {
                 return Ok((stream, addr));
             }
+            tracing::warn!(%addr, "rejected connection");
             let _ = stream.shutdown(std::net::Shutdown::Both);
+            std::thread::sleep(Duration::from_millis(1));
         }
     }
 

--- a/crates/transport/tests/reject.rs
+++ b/crates/transport/tests/reject.rs
@@ -1,0 +1,30 @@
+// crates/transport/tests/reject.rs
+use std::net::{Ipv4Addr, Ipv6Addr, TcpStream};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use transport::{tcp::TcpTransport, AddressFamily};
+
+#[test]
+fn rejects_sleep_prevents_spin() {
+    // Bind an IPv6 listener so we can connect via IPv4 and IPv6.
+    let (listener, port) = TcpTransport::listen(None, 0, Some(AddressFamily::V6)).expect("listen");
+    let accept_listener = listener.try_clone().expect("clone");
+
+    let handle = thread::spawn(move || {
+        TcpTransport::accept(&accept_listener, &[], &["127.0.0.1".to_string()]).expect("accept");
+    });
+
+    // Ensure the accept thread is ready.
+    thread::sleep(Duration::from_millis(10));
+
+    let start = Instant::now();
+    for _ in 0..5 {
+        let _ = TcpStream::connect((Ipv4Addr::LOCALHOST, port));
+    }
+    // Final allowed connection via IPv6 to exit the accept loop.
+    let _ = TcpStream::connect((Ipv6Addr::LOCALHOST, port));
+    handle.join().unwrap();
+
+    assert!(start.elapsed() >= Duration::from_millis(5));
+}


### PR DESCRIPTION
## Summary
- avoid busy loop in `TcpTransport::accept` by sleeping briefly and logging when a client is rejected
- add integration test guarding against high-CPU rejection loops
- pull in `tracing` for connection rejection logging

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: default_umask_masks_permissions)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b874bad6e88323be522a11c0ef33d4