### PR TITLE
feat(cli): allow multiple sources

### DIFF
--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -18,7 +18,7 @@ use logging::parse_escapes;
 use protocol::{negotiate_version, CharsetConv};
 use transport::{parse_sockopts, AddressFamily, SockOpt, TcpTransport, Transport};
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct DaemonOpts {
     #[arg(long)]
     pub daemon: bool,

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -20,7 +20,7 @@ pub enum OutBuf {
     B,
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub(crate) struct ClientOpts {
     #[command(flatten)]
     pub daemon: DaemonOpts,
@@ -624,10 +624,14 @@ pub(crate) struct ClientOpts {
     pub sender: bool,
     #[arg(long = "rsync-path", value_name = "PATH", alias = "rsync_path")]
     pub rsync_path: Option<String>,
-    #[arg(value_name = "SRC", required_unless_present_any = ["daemon", "server", "probe"])]
-    pub src: Option<String>,
-    #[arg(value_name = "DST", required_unless_present_any = ["daemon", "server", "probe"])]
-    pub dst: Option<String>,
+    #[arg(
+        value_name = "SRC",
+        required_unless_present_any = ["daemon", "server", "probe"],
+        num_args = 1..
+    )]
+    pub srcs: Vec<String>,
+    #[arg(value_name = "DST", required = true, last = true)]
+    pub dst: String,
     #[arg(short = 'f', long, value_name = "RULE", help_heading = "Selection")]
     pub filter: Vec<String>,
     #[arg(long, value_name = "FILE", help_heading = "Selection")]
@@ -660,12 +664,13 @@ pub(crate) struct ClientOpts {
 pub(crate) struct ProbeOpts {
     #[arg(long)]
     pub probe: bool,
+    #[arg(long, value_name = "ADDR", requires = "probe")]
     pub addr: Option<String>,
     #[arg(long, default_value_t = SUPPORTED_PROTOCOLS[0], value_name = "VER")]
     pub peer_version: u32,
 }
 pub fn cli_command() -> clap::Command {
-    let cmd = ClientOpts::command();
-    let cmd = ProbeOpts::augment_args(cmd);
+    let cmd = ProbeOpts::command();
+    let cmd = ClientOpts::augment_args(cmd);
     formatter::apply(cmd)
 }

--- a/crates/cli/tests/multiple_sources.rs
+++ b/crates/cli/tests/multiple_sources.rs
@@ -1,0 +1,81 @@
+// crates/cli/tests/multiple_sources.rs
+use assert_cmd::Command;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command as StdCommand, Stdio};
+use tempfile::tempdir;
+
+macro_rules! require_rsync {
+    () => {
+        let rsync = StdCommand::new("rsync")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .ok();
+        if rsync.is_none() {
+            eprintln!("skipping test: rsync not installed");
+            return;
+        }
+        assert!(rsync.is_some());
+    };
+}
+
+fn collect(root: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
+    fn walk(base: &Path, dir: &Path, map: &mut BTreeMap<PathBuf, Vec<u8>>) {
+        for entry in fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                walk(base, &path, map);
+            } else {
+                let rel = path.strip_prefix(base).unwrap().to_path_buf();
+                let data = fs::read(&path).unwrap();
+                map.insert(rel, data);
+            }
+        }
+    }
+    let mut map = BTreeMap::new();
+    walk(root, root, &mut map);
+    map
+}
+
+#[test]
+fn multiple_source_parity() {
+    require_rsync!();
+    let dir = tempdir().unwrap();
+    let src1 = dir.path().join("src1");
+    let src2 = dir.path().join("src2");
+    let dst_up = dir.path().join("dst_up");
+    let dst_ours = dir.path().join("dst_ours");
+    fs::create_dir_all(&src1).unwrap();
+    fs::create_dir_all(&src2).unwrap();
+    fs::write(src1.join("a.txt"), b"a").unwrap();
+    fs::write(src2.join("b.txt"), b"b").unwrap();
+
+    StdCommand::new("rsync")
+        .args([
+            "-r",
+            &format!("{}/", src1.display()),
+            &format!("{}/", src2.display()),
+        ])
+        .arg(&dst_up)
+        .status()
+        .unwrap();
+
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "-r",
+            &format!("{}/", src1.display()),
+            &format!("{}/", src2.display()),
+            dst_ours.to_str().unwrap(),
+        ])
+        .status()
+        .unwrap();
+
+    let up = collect(&dst_up);
+    let ours = collect(&dst_ours);
+    assert_eq!(up, ours);
+}


### PR DESCRIPTION
## Summary
- support multiple source arguments in CLI options
- iterate over sources when running sync operations
- add regression test for multi-source parity with upstream

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo test` *(fails: required arguments not provided)*


------
https://chatgpt.com/codex/tasks/task_e_68b874985f34832387bd48068612cf9e