### PR TITLE
Add release workflow for tagged builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+  LC_ALL: C
+  LANG: C
+  COLUMNS: 80
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libacl1-dev
+      - name: Format
+        run: cargo fmt --all --check
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+      - name: Verify comments
+        run: make verify-comments
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+      - name: Test with coverage
+        run: cargo llvm-cov --all-features --fail-under-lines 95
+      - name: Validate interop matrix docs
+        run: scripts/check-run-matrix-docs.sh
+      - name: Cross-compile check
+        run: |
+          rustup target add x86_64-apple-darwin x86_64-pc-windows-msvc
+          cargo check --workspace --target x86_64-apple-darwin
+          cargo check --workspace --target x86_64-pc-windows-msvc
+
+  build:
+    needs: lint-test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - uses: Swatinem/rust-cache@v2
+      - name: Install system dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libacl1-dev
+      - name: Install aarch64 toolchain
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: sudo apt-get install -y gcc-aarch64-linux-gnu
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} --bin oc-rsync
+      - name: Package artifacts
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/oc-rsync* dist/oc-rsync-${{ matrix.target }}
+          sha256sum dist/oc-rsync-${{ matrix.target }} > dist/oc-rsync-${{ matrix.target }}.sha256
+          cargo install cargo-sbom || true
+          cargo sbom --output dist/oc-rsync-${{ matrix.target }}-sbom.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oc-rsync-${{ matrix.target }}
+          path: dist
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Bundle documentation
+        run: |
+          mkdir -p dist/docs
+          cp man/oc-rsync.1 man/oc-rsyncd.8 man/oc-rsyncd.conf.5 dist/docs/
+          cp packaging/oc-rsyncd.conf dist/docs/
+          tar -czf dist/oc-rsync-docs.tar.gz -C dist/docs .
+          sha256sum dist/oc-rsync-docs.tar.gz > dist/oc-rsync-docs.tar.gz.sha256
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*


### PR DESCRIPTION
## Summary
- add release workflow to build binaries for Linux, macOS, and Windows
- generate SBOMs and checksums and bundle documentation assets

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: Unexpected failure in archive tests)*
- `make verify-comments` *(fails: crates/transport/tests/reject.rs: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87ea30cc08323913082914c5f2edd