### PR TITLE
CI: enforce function coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Test with coverage
-        run: cargo llvm-cov --all-features --fail-under-lines 95
+        run: cargo llvm-cov --all-features --fail-under-lines 95 --fail-under-functions 95
       - name: Validate interop matrix docs
         run: scripts/check-run-matrix-docs.sh
       - name: Cross-compile check


### PR DESCRIPTION
## Summary
- enforce 95% function coverage in CI

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: archive_matches_combination_and_rsync, archive_respects_no_options)*
- `make verify-comments` *(fails: crates/transport/tests/reject.rs additional comments)*
- `make lint`
- `cargo llvm-cov --all-features --fail-under-lines 95 --fail-under-functions 95` *(fails: archive_matches_combination_and_rsync, archive_respects_no_options)*

------
https://chatgpt.com/codex/tasks/task_e_68b87ee398bc83238a4233443db9d725