### PR TITLE
Use curl fail and location flags for fetch script

### DIFF
--- a/scripts/fetch-rsync.sh
+++ b/scripts/fetch-rsync.sh
@@ -8,7 +8,7 @@ SHA256="2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52"
 
 if [ ! -f "$TARBALL" ]; then
   echo "Downloading $TARBALL..."
-  curl -L "$URL" -o "$TARBALL"
+  curl --fail --location --silent --show-error "$URL" -o "$TARBALL"
 fi
 
 echo "Verifying $TARBALL..."


### PR DESCRIPTION
## Summary
- fetch-rsync.sh: use `curl --fail --location` to download the tarball, add silent/error flags for better logs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: 19 passed, 93 failed)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b88ff7d5fc8323824274984c2d50a4