### PR TITLE
feat: add default skip compress list

### DIFF
--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -51,10 +51,16 @@ fn encode_decode_roundtrip_and_error() {
 }
 
 #[test]
-fn should_compress_skips_matching_extensions() {
+fn should_compress_respects_default_list() {
     assert!(should_compress(Path::new("file.txt"), &[]));
+    assert!(!should_compress(Path::new("archive.gz"), &[]));
+    assert!(!should_compress(Path::new("IMAGE.JpG"), &[]));
+}
+
+#[test]
+fn should_compress_handles_mixed_case_patterns() {
     assert!(!should_compress(
-        Path::new("archive.gz"),
-        &["gz".to_string()]
+        Path::new("file.TXT"),
+        &["tXt".to_string()]
     ));
 }


### PR DESCRIPTION
## Summary
- handle skip-compress patterns case-insensitively
- ship default skip-compress extensions list from rsync
- test default skip list and case-insensitive patterns

## Testing
- `cargo test` *(fails: archive_implies_recursive, checksum_forces_transfer_cli, ...)*
- `make verify-comments` *(fails: crates/compress/src/lib.rs: additional comments, src/lib.rs: additional comments, tests/sync_config.rs: incorrect header)*
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68b896808564832381eb6a60d9e03cf5