### PR TITLE
Support runtime branding configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "engine",
  "logging",
  "oc-rsync-cli",
+ "predicates",
  "protocol",
  "tempfile",
 ]

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -18,6 +18,7 @@ clap = { version = "4" }
 [dev-dependencies]
 assert_cmd = "2"
 tempfile = "3"
+predicates = "3"
 
 [features]
 default = []

--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -1,6 +1,6 @@
 // bin/oc-rsync/src/main.rs
 use oc_rsync_cli::options::OutBuf;
-use oc_rsync_cli::{cli_command, EngineError};
+use oc_rsync_cli::{branding, cli_command, EngineError};
 use protocol::ExitCode;
 use std::io::ErrorKind;
 use std::ptr;
@@ -69,8 +69,9 @@ fn main() {
                 _ => "syntax or usage error",
             };
             let code_num = u8::from(code);
-            eprintln!("rsync: {msg}");
-            eprintln!("rsync error: {desc} (code {code_num})");
+            let prog = branding::program_name();
+            eprintln!("{prog}: {msg}");
+            eprintln!("{prog} error: {desc} (code {code_num})");
         }
         std::process::exit(u8::from(code) as i32);
     });

--- a/bin/oc-rsync/tests/branding.rs
+++ b/bin/oc-rsync/tests/branding.rs
@@ -1,0 +1,16 @@
+// bin/oc-rsync/tests/branding.rs
+use assert_cmd::Command;
+use predicates::str::contains;
+
+#[test]
+fn errors_use_program_name() {
+    std::env::set_var("PROGRAM_NAME", "myrsync");
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .arg("--bogus")
+        .assert()
+        .failure()
+        .stderr(contains("myrsync:"))
+        .stderr(contains("myrsync error:"));
+    std::env::remove_var("PROGRAM_NAME");
+}

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -1,0 +1,58 @@
+// crates/cli/src/branding.rs
+use std::env;
+
+pub const DEFAULT_HELP_PREFIX: &str = r#"rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.
+
+rsync is a file transfer program capable of efficient remote update
+via a fast differencing algorithm.
+
+Usage: rsync [OPTION]... SRC [SRC]... DEST
+  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
+  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
+  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
+  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
+  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
+  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
+The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
+to an rsync daemon, and require SRC or DEST to start with a module name.
+
+Options
+"#;
+
+pub const DEFAULT_HELP_SUFFIX: &str = r#"
+Use "rsync --daemon --help" to see the daemon-mode command-line options.
+Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
+See https://rsync.samba.org/ for updates, bug reports, and answers
+"#;
+
+pub fn program_name() -> String {
+    env::var("PROGRAM_NAME")
+        .or_else(|_| {
+            option_env!("PROGRAM_NAME")
+                .map(str::to_string)
+                .ok_or(env::VarError::NotPresent)
+        })
+        .unwrap_or_else(|_| "rsync".to_string())
+}
+
+pub fn help_prefix() -> String {
+    env::var("OC_RSYNC_BRAND_HEADER")
+        .or_else(|_| {
+            option_env!("OC_RSYNC_BRAND_HEADER")
+                .map(str::to_string)
+                .ok_or(env::VarError::NotPresent)
+        })
+        .unwrap_or_else(|_| DEFAULT_HELP_PREFIX.replace("rsync", &program_name()))
+}
+
+pub fn help_suffix() -> String {
+    env::var("OC_RSYNC_BRAND_FOOTER")
+        .or_else(|_| {
+            option_env!("OC_RSYNC_BRAND_FOOTER")
+                .map(str::to_string)
+                .ok_or(env::VarError::NotPresent)
+        })
+        .unwrap_or_else(|_| DEFAULT_HELP_SUFFIX.replace("rsync", &program_name()))
+}

--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -3,11 +3,9 @@ use clap::Command;
 use std::env;
 use textwrap::{wrap, Options as WrapOptions};
 
+use crate::branding::{self, DEFAULT_HELP_PREFIX, DEFAULT_HELP_SUFFIX};
+
 const RSYNC_HELP: &str = include_str!("../resources/rsync-help-80.txt");
-
-const HELP_PREFIX: &str = "rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you\nare welcome to redistribute it under certain conditions.  See the GNU\nGeneral Public Licence for details.\n\nrsync is a file transfer program capable of efficient remote update\nvia a fast differencing algorithm.\n\nUsage: rsync [OPTION]... SRC [SRC]... DEST\n  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST\n  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST\n  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST\n  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]\n  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]\n  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]\nThe ':' usages connect via remote shell, while '::' & 'rsync://' usages connect\nto an rsync daemon, and require SRC or DEST to start with a module name.\n\nOptions\n";
-
-const HELP_SUFFIX: &str = "\nUse \"rsync --daemon --help\" to see the daemon-mode command-line options.\nPlease see the rsync(1) and rsyncd.conf(5) manpages for full documentation.\nSee https://rsync.samba.org/ for updates, bug reports, and answers\n";
 
 pub const ARG_ORDER: &[&str] = &[
     "verbose",
@@ -157,10 +155,17 @@ pub fn apply(mut cmd: Command) -> Command {
 
 pub fn render_help(cmd: &Command) -> String {
     let width = columns();
+    let help_prefix = branding::help_prefix();
+    let help_suffix = branding::help_suffix();
     if width == 80 {
-        return RSYNC_HELP.trim_end().to_owned();
+        let mut out = RSYNC_HELP.trim_end().to_owned();
+        if help_prefix != DEFAULT_HELP_PREFIX || help_suffix != DEFAULT_HELP_SUFFIX {
+            out = out.replacen(DEFAULT_HELP_PREFIX, &help_prefix, 1);
+            out = out.replacen(DEFAULT_HELP_SUFFIX, &help_suffix, 1);
+        }
+        return out;
     }
-    let banner_end = RSYNC_HELP.find(HELP_PREFIX).unwrap_or(0);
+    let banner_end = RSYNC_HELP.find(DEFAULT_HELP_PREFIX).unwrap_or(0);
     let version_banner = &RSYNC_HELP[..banner_end];
     let spec_width = 23;
     let desc_width = if width > spec_width + 2 {
@@ -172,7 +177,7 @@ pub fn render_help(cmd: &Command) -> String {
 
     let mut out = String::new();
     out.push_str(version_banner);
-    out.push_str(HELP_PREFIX);
+    out.push_str(&help_prefix);
 
     let args: Vec<_> = cmd.get_arguments().collect();
     for id in ARG_ORDER {
@@ -255,7 +260,7 @@ pub fn render_help(cmd: &Command) -> String {
         }
     }
 
-    out.push_str(HELP_SUFFIX);
+    out.push_str(&help_suffix);
     while out.ends_with('\n') {
         out.pop();
     }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use clap::parser::ValueSource;
 use clap::{ArgMatches, FromArgMatches};
 
+pub mod branding;
 pub mod daemon;
 mod formatter;
 pub mod options;

--- a/crates/cli/tests/branding.rs
+++ b/crates/cli/tests/branding.rs
@@ -1,0 +1,13 @@
+// crates/cli/tests/branding.rs
+use oc_rsync_cli::{cli_command, render_help};
+
+#[test]
+fn help_uses_program_name() {
+    std::env::set_var("PROGRAM_NAME", "myrsync");
+    std::env::set_var("COLUMNS", "80");
+    let cmd = cli_command();
+    let help = render_help(&cmd);
+    assert!(help.contains("Usage: myrsync"));
+    std::env::remove_var("PROGRAM_NAME");
+    std::env::remove_var("COLUMNS");
+}


### PR DESCRIPTION
## Summary
- load help banner prefix/suffix from runtime branding
- expose branding helper for program name
- ensure CLI error messages use the branded program name
- cover branding in help and error output tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: many tests failing: rsync: the following required arguments were not provided)*
- `make verify-comments` *(fails: src/lib.rs: additional comments; tests/sync_config.rs: incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b896fa9bd8832385e706e6f835d05a