### PR TITLE
feat(compress): add codec feature flags

### DIFF
--- a/crates/compress/Cargo.toml
+++ b/crates/compress/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-flate2 = "1"
-zstd = "0.13"
+flate2 = { version = "1", optional = true }
+zstd = { version = "0.13", optional = true }
 
 [features]
-default = []
+default = ["zlib", "zstd"]
+zlib = ["dep:flate2"]
+zstd = ["dep:zstd"]
 # AVX-512 implementations (requires nightly Rust)
 nightly = []

--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -1,13 +1,22 @@
 // crates/compress/tests/codecs.rs
-use compress::{
-    decode_codecs, encode_codecs, negotiate_codec, should_compress, Codec, Compressor,
-    Decompressor, Zlib, Zstd,
-};
+use compress::{decode_codecs, encode_codecs, negotiate_codec, should_compress, Codec};
+
+#[cfg(any(feature = "zlib", feature = "zstd"))]
+use compress::{Compressor, Decompressor};
+
+#[cfg(feature = "zlib")]
+use compress::Zlib;
+
+#[cfg(feature = "zstd")]
+use compress::Zstd;
+
 use std::io;
 use std::path::Path;
 
+#[cfg(any(feature = "zlib", feature = "zstd"))]
 const DATA: &[u8] = b"The quick brown fox jumps over the lazy dog";
 
+#[cfg(feature = "zlib")]
 #[test]
 fn zlib_roundtrip() {
     let codec = Zlib::default();
@@ -16,6 +25,7 @@ fn zlib_roundtrip() {
     assert_eq!(DATA, decompressed.as_slice());
 }
 
+#[cfg(feature = "zstd")]
 #[test]
 fn zstd_roundtrip() {
     let codec = Zstd::default();

--- a/tests/sync_config.rs
+++ b/tests/sync_config.rs
@@ -1,3 +1,4 @@
+// tests/sync_config.rs
 use filetime::{set_file_times, FileTime};
 use oc_rsync::{synchronize, synchronize_with_config, SyncConfig};
 use std::{fs, path::Path};


### PR DESCRIPTION
## Summary
- gate zlib and zstd support behind cargo features
- list only enabled codecs in `available_codecs`
- add tests for feature-gated codec availability

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: many CLI integration tests, e.g. `chmod_masks_file_type_bits`)*
- `cargo test -p compress`
- `cargo test -p compress --no-default-features`
- `cargo test -p compress --no-default-features --features zlib`
- `cargo test -p compress --no-default-features --features zstd`
- `make verify-comments` *(fails: src/lib.rs additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b896bcfb2483239c4a3ce724057f06