### PR TITLE
Update rsync version snapshot to 3.4.1

### DIFF
--- a/crates/cli/resources/rsync-version.txt
+++ b/crates/cli/resources/rsync-version.txt
@@ -1,5 +1,5 @@
-rsync  version 3.2.7  protocol version 31
-Copyright (C) 1996-2022 by Andrew Tridgell, Wayne Davison, and others.
+rsync  version 3.4.1  protocol version 32
+Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.
 Web site: https://rsync.samba.org/
 Capabilities:
     64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,

--- a/tests/fixtures/rsync-version.txt
+++ b/tests/fixtures/rsync-version.txt
@@ -1,5 +1,5 @@
-rsync  version 3.2.7  protocol version 31
-Copyright (C) 1996-2022 by Andrew Tridgell, Wayne Davison, and others.
+rsync  version 3.4.1  protocol version 32
+Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.
 Web site: https://rsync.samba.org/
 Capabilities:
     64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,


### PR DESCRIPTION
## Summary
- refresh rsync version text to upstream 3.4.1 (protocol 32) for CLI resources and tests

## Testing
- `cargo fmt --all`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments` *(fails: crates/compress/src/lib.rs: additional comments)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo test` *(fails: test result: FAILED. 19 passed; 93 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b89e304ebc83239449fed37741d645