### PR TITLE
Handle narrow help widths

### DIFF
--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -174,7 +174,8 @@ pub fn render_help(cmd: &Command) -> String {
     } else {
         0
     };
-    let wrap_opts = WrapOptions::new(desc_width).break_words(false);
+    let wrap_opts =
+        (desc_width > 0).then(|| WrapOptions::new(desc_width.max(1)).break_words(false));
 
     let mut out = String::new();
     out.push_str(version_banner);
@@ -220,8 +221,8 @@ pub fn render_help(cmd: &Command) -> String {
         let help = arg.get_help().map(|s| s.to_string()).unwrap_or_default();
         let mut lines = help.split('\n');
         if let Some(first) = lines.next() {
-            let wrapped: Vec<String> = if desc_width > 0 {
-                wrap(first, &wrap_opts)
+            let wrapped: Vec<String> = if let Some(opts) = &wrap_opts {
+                wrap(first, opts)
                     .into_iter()
                     .map(|c| c.into_owned())
                     .collect()
@@ -242,8 +243,8 @@ pub fn render_help(cmd: &Command) -> String {
         }
         for paragraph in lines {
             if !paragraph.is_empty() {
-                let wrapped: Vec<String> = if desc_width > 0 {
-                    wrap(paragraph, &wrap_opts)
+                let wrapped: Vec<String> = if let Some(opts) = &wrap_opts {
+                    wrap(paragraph, opts)
                         .into_iter()
                         .map(|c| c.into_owned())
                         .collect()

--- a/crates/cli/tests/help.rs
+++ b/crates/cli/tests/help.rs
@@ -20,3 +20,11 @@ fn help_columns_120() {
     let expected = include_str!("../../../tests/fixtures/rsync-help-120.txt").trim_end();
     assert_eq!(out, expected);
 }
+
+#[test]
+#[serial]
+fn help_columns_small() {
+    env::set_var("COLUMNS", "25");
+    let out = render_help(&cli_command());
+    assert!(!out.is_empty());
+}


### PR DESCRIPTION
## Summary
- avoid textwrap panic by only creating `WrapOptions` when the description column is wider than zero
- add regression test ensuring help text renders when `COLUMNS` ≤25

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: version_matches_upstream_blocking, version_matches_upstream_nonblocking, numerous CLI parity tests)*
- `make verify-comments` *(fails: additional comments in crates/compress/src/lib.rs, crates/engine/tests/open_noatime.rs, crates/filters/src/lib.rs)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8a61ebba0832381b90ad5c99c88ae