### PR TITLE
Return error for duplicate channel registration

### DIFF
--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -44,7 +44,7 @@ pub mod demux;
 pub mod mux;
 pub mod server;
 pub use demux::Demux;
-pub use mux::Mux;
+pub use mux::{ChannelError, Mux};
 pub use server::Server;
 
 pub const V32: u32 = 32;

--- a/crates/protocol/tests/exit_codes.rs
+++ b/crates/protocol/tests/exit_codes.rs
@@ -51,7 +51,7 @@ fn forward_exit_codes_over_mux_demux() {
     let mut mux = Mux::new(Duration::from_millis(50));
     let mut demux = Demux::new(Duration::from_millis(50));
 
-    let tx = mux.register_channel(1);
+    let tx = mux.register_channel(1).unwrap();
     let rx = demux.register_channel(1);
 
     let codes = [ExitCode::Ok, ExitCode::Partial, ExitCode::CmdNotFound];
@@ -78,7 +78,7 @@ fn forward_unknown_exit_code_over_mux_demux() {
     let mut mux = Mux::new(Duration::from_millis(50));
     let mut demux = Demux::new(Duration::from_millis(50));
 
-    let tx = mux.register_channel(1);
+    let tx = mux.register_channel(1).unwrap();
     let rx = demux.register_channel(1);
 
     let byte = 99u8;
@@ -100,7 +100,7 @@ fn mux_send_exit_codes_channel0() {
     let mut mux = Mux::new(Duration::from_millis(50));
     let mut demux = Demux::new(Duration::from_millis(50));
 
-    mux.register_channel(0);
+    mux.register_channel(0).unwrap();
     demux.register_channel(0);
 
     let codes = [

--- a/crates/protocol/tests/mux_demux.rs
+++ b/crates/protocol/tests/mux_demux.rs
@@ -9,8 +9,8 @@ fn multiplex_multiple_channels() {
     let mut mux = Mux::new(Duration::from_millis(50));
     let mut demux = Demux::new(Duration::from_millis(100));
 
-    let tx1 = mux.register_channel(1);
-    let tx2 = mux.register_channel(2);
+    let tx1 = mux.register_channel(1).unwrap();
+    let tx2 = mux.register_channel(2).unwrap();
     let rx1 = demux.register_channel(1);
     let rx2 = demux.register_channel(2);
 
@@ -39,7 +39,7 @@ fn keepalive_and_timeout() {
     let mut mux = Mux::new(keepalive);
     let mut demux = Demux::new(timeout);
 
-    let _tx = mux.register_channel(0);
+    let _tx = mux.register_channel(0).unwrap();
     let _rx = demux.register_channel(0);
 
     sleep(Duration::from_millis(20));
@@ -57,8 +57,8 @@ fn keepalive_and_timeout() {
 fn round_robin_fairness() {
     let mut mux = Mux::new(Duration::from_secs(1));
 
-    let tx1 = mux.register_channel(1);
-    let tx2 = mux.register_channel(2);
+    let tx1 = mux.register_channel(1).unwrap();
+    let tx2 = mux.register_channel(2).unwrap();
 
     tx1.send(Message::Data(b"a1".to_vec())).unwrap();
     tx1.send(Message::Data(b"a2".to_vec())).unwrap();
@@ -95,7 +95,7 @@ fn error_xfer_sets_remote_error() {
     let mut mux = Mux::new(Duration::from_millis(50));
     let mut demux = Demux::new(Duration::from_millis(50));
 
-    mux.register_channel(0);
+    mux.register_channel(0).unwrap();
     let _rx = demux.register_channel(0);
 
     mux.send_error_xfer(0, "oops").unwrap();
@@ -110,7 +110,7 @@ fn progress_attrs_and_xattrs() {
     let mut mux = Mux::new(Duration::from_millis(50));
     let mut demux = Demux::new(Duration::from_millis(50));
 
-    mux.register_channel(0);
+    mux.register_channel(0).unwrap();
     let rx = demux.register_channel(0);
 
     mux.send_progress(0, 123).unwrap();
@@ -141,7 +141,7 @@ fn collect_log_messages() {
     let mut mux = Mux::new(Duration::from_millis(50));
     let mut demux = Demux::new(Duration::from_millis(50));
 
-    mux.register_channel(0);
+    mux.register_channel(0).unwrap();
     let _rx = demux.register_channel(0);
 
     mux.send_info(0, "info").unwrap();
@@ -171,7 +171,7 @@ fn collect_progress_and_stats_messages() {
     let mut mux = Mux::new(Duration::from_millis(50));
     let mut demux = Demux::new(Duration::from_millis(50));
 
-    mux.register_channel(0);
+    mux.register_channel(0).unwrap();
     let _rx = demux.register_channel(0);
 
     mux.send_progress(0, 123).unwrap();
@@ -196,8 +196,8 @@ fn collect_progress_and_stats_messages() {
 fn poll_with_dynamic_channel_removal() {
     let mut mux = Mux::new(Duration::from_millis(50));
 
-    let tx1 = mux.register_channel(1);
-    let tx2 = mux.register_channel(2);
+    let tx1 = mux.register_channel(1).unwrap();
+    let tx2 = mux.register_channel(2).unwrap();
 
     tx1.send(Message::Data(b"one".to_vec())).unwrap();
     tx2.send(Message::Data(b"two".to_vec())).unwrap();

--- a/crates/protocol/tests/mux_register.rs
+++ b/crates/protocol/tests/mux_register.rs
@@ -1,0 +1,25 @@
+// crates/protocol/tests/mux_register.rs
+use std::time::Duration;
+
+use protocol::{mux::ChannelError, Message, Mux};
+
+#[test]
+fn duplicate_channel_id_errors() {
+    let mut mux = Mux::new(Duration::from_millis(50));
+
+    let tx1 = mux
+        .register_channel(1)
+        .expect("first registration succeeds");
+    assert_eq!(
+        mux.register_channel(1),
+        Err(ChannelError::DuplicateId(1)),
+        "second registration should fail",
+    );
+
+    tx1.send(Message::Data(b"hi".to_vec())).unwrap();
+
+    let frame = mux.poll().expect("frame from existing channel");
+    assert_eq!(frame.header.channel, 1);
+    let msg = Message::from_frame(frame, None).unwrap();
+    assert_eq!(msg, Message::Data(b"hi".to_vec()));
+}

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -221,7 +221,7 @@ fn demux_error_routing() {
     use std::time::Duration;
 
     let mut mux = Mux::new(Duration::from_secs(1));
-    let tx = mux.register_channel(0);
+    let tx = mux.register_channel(0).unwrap();
     tx.send(Message::ErrorXfer("ex".into())).unwrap();
     tx.send(Message::Error("er".into())).unwrap();
     tx.send(Message::ErrorSocket("so".into())).unwrap();


### PR DESCRIPTION
## Summary
- add `ChannelError` and have `Mux::register_channel` reject duplicate IDs
- re-export new error type
- test duplicate channel registration

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: version_matches_upstream_blocking, version_matches_upstream_nonblocking)*
- `make verify-comments` *(fails: additional comments in crates/compress/src/lib.rs, crates/engine/tests/open_noatime.rs, crates/filters/src/lib.rs)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8a625c49c8323bb5f79ee5c20cbf3