### PR TITLE
test: add progress parity checks

### DIFF
--- a/tests/snapshots/cli__progress_parity_p.snap
+++ b/tests/snapshots/cli__progress_parity_p.snap
@@ -1,0 +1,6 @@
+---
+source: tests/cli.rs
+assertion_line: 879
+expression: norm
+---
+              5 100% XKB/s 00:00:00


### PR DESCRIPTION
## Summary
- capture upstream rsync progress output for `--progress` and `-P`
- test oc-rsync progress lines and streams for parity with upstream

## Testing
- `make lint`
- `make verify-comments` *(fails: crates/compress/src/lib.rs: additional comments)*
- `cargo test --test cli progress_flag_shows_output -- --nocapture`
- `cargo test --test cli progress_flag_human_readable -- --nocapture`
- `cargo test --test cli progress_parity -- --nocapture` *(fails: progress output stream mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a656bcc48323b06a712357716080