### PR TITLE
Add GPL warranty notice to version output

### DIFF
--- a/bin/oc-rsync/src/version.rs
+++ b/bin/oc-rsync/src/version.rs
@@ -56,6 +56,16 @@ pub fn render_version_lines() -> Vec<String> {
     lines.extend(COMPRESS.iter().map(|s| (*s).to_string()));
     lines.push("Daemon auth list:".to_string());
     lines.extend(DAEMON_AUTH.iter().map(|s| (*s).to_string()));
+    lines.push(String::new());
+    lines.push(
+        "rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you"
+            .to_string(),
+    );
+    lines.push(
+        "are welcome to redistribute it under certain conditions.  See the GNU"
+            .to_string(),
+    );
+    lines.push("General Public Licence for details.".to_string());
     lines
 }
 

--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -47,6 +47,12 @@ pub fn render_version_lines() -> Vec<String> {
     lines.extend(COMPRESS.iter().map(|s| (*s).to_string()));
     lines.push("Daemon auth list:".to_string());
     lines.extend(DAEMON_AUTH.iter().map(|s| (*s).to_string()));
+    lines.push(String::new());
+    lines.push(
+        "rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you".to_string(),
+    );
+    lines.push("are welcome to redistribute it under certain conditions.  See the GNU".to_string());
+    lines.push("General Public Licence for details.".to_string());
     lines
 }
 

--- a/crates/cli/tests/fixtures/rsync-version.txt
+++ b/crates/cli/tests/fixtures/rsync-version.txt
@@ -14,3 +14,7 @@ Compress list:
     zstd lz4 zlibx zlib none
 Daemon auth list:
     sha512 sha256 sha1 md5 md4
+
+rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.


### PR DESCRIPTION
## Summary
- append GPL warranty notice after `Daemon auth list` in version outputs
- update rsync version fixture to match upstream notice

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments` *(fails: crates/compress/src/lib.rs: additional comments; crates/engine/tests/open_noatime.rs: additional comments; crates/filters/src/lib.rs: additional comments)*
- `make lint`
- `cargo test --test blocking_io`


------
https://chatgpt.com/codex/tasks/task_e_68b8b37bce9883239c356c44845d01fd