### PR TITLE
ci: check cli output against fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           name: oc-rsync-${{ matrix.target }}
           path: dist
 
-  upstream-rsync:
+  cli-fixtures:
     needs: lint-test
     runs-on: ubuntu-latest
     steps:
@@ -136,25 +136,18 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libssl-dev zlib1g-dev libacl1-dev
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libacl1-dev
       - name: Build oc-rsync
         run: cargo build --release --bin oc-rsync
-      - name: Fetch upstream rsync
-        run: scripts/fetch-rsync.sh
-      - name: Build upstream rsync
+      - name: Validate --help output
         run: |
-          cd rsync-3.4.1
-          ./configure
-          make
-      - name: Diff --version
+          ./target/release/oc-rsync --help > /tmp/oc-rsync-help.txt
+          diff -u tests/fixtures/oc-rsync-help.txt /tmp/oc-rsync-help.txt
+      - name: Validate --version output
         run: |
-          diff <(./target/release/oc-rsync --version) <(rsync-3.4.1/rsync --version) || true
-      - name: Diff --help
-        run: |
-          diff <(./target/release/oc-rsync --help) <(rsync-3.4.1/rsync --help) || true
-      - name: Check option tables
-        run: scripts/check-option-table.sh
+          ./target/release/oc-rsync --version > /tmp/oc-rsync-version.txt
+          diff -u tests/fixtures/oc-rsync-version.txt /tmp/oc-rsync-version.txt
 
   windows:
     needs: lint-test

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -43,3 +43,13 @@ CLI crate. Regenerate them in the C locale with:
 LC_ALL=C LANG=C COLUMNS=80  cargo run --bin oc-rsync -- --help > crates/cli/resources/rsync-help-80.txt
 LC_ALL=C LANG=C COLUMNS=120 cargo run --bin oc-rsync -- --help > tests/fixtures/rsync-help-120.txt
 ```
+
+## `oc-rsync-help.txt` and `oc-rsync-version.txt`
+
+These fixtures capture the current `oc-rsync` command's `--help` and `--version`
+outputs. Regenerate them with:
+
+```sh
+LC_ALL=C LANG=C COLUMNS=80 cargo run --bin oc-rsync -- --help > tests/fixtures/oc-rsync-help.txt
+LC_ALL=C LANG=C cargo run --bin oc-rsync -- --version > tests/fixtures/oc-rsync-version.txt
+```

--- a/tests/fixtures/oc-rsync-help.txt
+++ b/tests/fixtures/oc-rsync-help.txt
@@ -1,0 +1,170 @@
+rsync  version 3.2.7  protocol version 31
+Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.
+Web site: https://rsync.samba.org/
+Capabilities:
+    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
+    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
+    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
+    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
+Optimizations:
+    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
+Checksum list:
+    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
+Compress list:
+    zstd lz4 zlibx zlib none
+Daemon auth list:
+    sha512 sha256 sha1 md5 md4
+
+oc-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.
+
+oc-rsync is a file transfer program capable of efficient remote update
+via a fast differencing algorithm.
+
+Usage: oc-rsync [OPTION]... SRC [SRC]... DEST
+  or   oc-rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
+  or   oc-rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
+  or   oc-rsync [OPTION]... SRC [SRC]... oc-rsync://[USER@]HOST[:PORT]/DEST
+  or   oc-rsync [OPTION]... [USER@]HOST:SRC [DEST]
+  or   oc-rsync [OPTION]... [USER@]HOST::SRC [DEST]
+  or   oc-rsync [OPTION]... oc-rsync://[USER@]HOST[:PORT]/SRC [DEST]
+The ':' usages connect via remote shell, while '::' & 'oc-rsync://' usages connect
+to an oc-rsync daemon, and require SRC or DEST to start with a module name.
+
+Options
+--verbose, -v            
+--info=FLAGS             
+--debug=FLAGS            
+--quiet, -q              
+--no-motd                
+--checksum, -c           
+--archive, -a            
+--recursive, -r          
+--relative, -R           
+--no-implied-dirs        
+--backup, -b             
+--backup-dir=DIR         
+--suffix=SUFFIX          
+--update, -u             
+--inplace                
+--append                 
+--append-verify          
+--dirs, -d               
+--mkpath                 create destination's missing path components
+--links, -l              
+--copy-links, -L         
+--copy-unsafe-links      
+--safe-links             
+--munge-links            munge symlinks to make them safe & unusable
+--copy-dirlinks, -k      
+--keep-dirlinks, -K      
+--hard-links, -H         
+--perms, -p              
+--executability, -E      
+--chmod=CHMOD            
+--owner, -o              
+--group, -g              
+--devices                
+--copy-devices           
+--write-devices          write to devices as files (implies --inplace)
+--specials               
+-D                       
+--no-D                   
+--times, -t              
+--atimes, -U             
+--crtimes, -N            
+--omit-dir-times, -O     
+--omit-link-times, -J    
+--fake-super             
+--sparse, -S             
+--preallocate            allocate dest files before writing them
+--dry-run, -n            
+--whole-file, -W         
+--checksum-choice=STR    
+--one-file-system, -x    
+--block-size=SIZE, -B    
+--rsh=COMMAND, -e        
+--rsync-path=PATH        
+--existing               
+--ignore-existing        
+--remove-source-files    
+--delete                 
+--delete-before          
+--delete-during          
+--delete-delay           
+--delete-after           
+--delete-excluded        
+--ignore-missing-args    
+--delete-missing-args    
+--ignore-errors          
+--force                  force deletion of dirs even if not empty
+--max-delete=NUM         
+--max-size=SIZE          
+--min-size=SIZE          
+--max-alloc=SIZE         
+--partial                
+--partial-dir=DIR        
+--delay-updates          
+--prune-empty-dirs, -m   
+--numeric-ids            
+--usermap=FROM:TO        
+--groupmap=FROM:TO       
+--chown=USER:GROUP       
+--timeout=SECONDS        
+--connect-timeout=SECONDS  
+--ignore-times, -I       
+--size-only              
+--modify-window=SECONDS  
+--temp-dir=DIR, -T       
+--fuzzy, -y              
+--compare-dest=DIR       
+--copy-dest=DIR          
+--link-dest=DIR          
+--compress, -z           
+--compress-choice=STR    
+--compress-level=NUM     
+--skip-compress=LIST     
+--cvs-exclude, -C        auto-ignore files in the same way CVS does
+--filter=RULE, -f        
+--filter-file=FILE       
+-F                       
+--exclude=PATTERN        
+--exclude-from=FILE      
+--include=PATTERN        
+--include-from=FILE      
+--files-from=FILE        
+--from0, -0              
+--secluded-args, -s      use the protocol to safely send the args
+--trust-sender           
+--copy-as=USER[:GROUP]   
+--address=ADDRESS        
+--port=PORT              
+--sockopts=OPTIONS       
+--blocking-io            
+--stats                  
+--8-bit-output, -8       
+--human-readable         
+--progress               
+-P                       
+--itemize-changes, -i    output a change-summary for all updates
+--remote-option=OPT, -M  send OPTION to the remote side only
+--out-format=FORMAT      
+--log-file=FILE          
+--log-file-format=FMT    
+--password-file=FILE     
+--early-input=FILE       
+--list-only              
+--bwlimit=RATE           
+--fsync                  
+--write-batch=FILE       
+--read-batch=FILE        read a batched update from FILE
+--protocol=VER           force an older protocol version
+--iconv=CONVERT_SPEC     request charset conversion of filenames
+--checksum-seed=NUM      set block/file checksum seed (advanced)
+--ipv4, -4               
+--ipv6, -6               
+
+Use "oc-rsync --daemon --help" to see the daemon-mode command-line options.
+Please see the oc-rsync(1) and oc-rsyncd.conf(5) manpages for full documentation.
+For project updates and documentation, visit https://github.com/oc-rsync/oc-rsync.

--- a/tests/fixtures/oc-rsync-version.txt
+++ b/tests/fixtures/oc-rsync-version.txt
@@ -1,0 +1,22 @@
+oc-rsync 0.1.0 (protocol 32)
+rsync unknown
+unknown unofficial
+Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.
+Web site: https://rsync.samba.org/
+Capabilities:
+    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
+    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
+    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
+    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
+Optimizations:
+    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
+Checksum list:
+    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
+Compress list:
+    zstd lz4 zlibx zlib none
+Daemon auth list:
+    sha512 sha256 sha1 md5 md4
+
+rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.


### PR DESCRIPTION
## Summary
- validate `oc-rsync` `--help` and `--version` outputs against committed goldens
- document regeneration steps for new fixtures

## Testing
- `cargo test` *(fails: 22 passed, 91 failed)*
- `make verify-comments` *(fails: crates/compress/src/lib.rs: additional comments, etc.)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b8c1f1eac48323bfa63cffab678b44