### PR TITLE
Customize version banner

### DIFF
--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -5,8 +5,9 @@ use crate::branding;
 
 pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOLS[0];
 
-const COPYRIGHT: &str = "Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.";
-const WEBSITE: &str = "Web site: https://rsync.samba.org/";
+const COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
+const WEBSITE: &str = "Web site: https://github.com/oc-rsync/oc-rsync";
+const COMPATIBILITY: &str = "compatible with rsync 3.4.1; proto 32";
 const CAPABILITIES: &[&str] = &[
     "    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,",
     "    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,",
@@ -26,10 +27,7 @@ pub fn render_version_lines() -> Vec<String> {
         env!("CARGO_PKG_VERSION"),
         RSYNC_PROTOCOL
     ));
-    lines.push(format!(
-        "rsync {}",
-        option_env!("RSYNC_UPSTREAM_VER").unwrap_or("unknown")
-    ));
+    lines.push(COMPATIBILITY.to_string());
     lines.push(format!(
         "{} {}",
         option_env!("BUILD_REVISION").unwrap_or("unknown"),
@@ -48,9 +46,10 @@ pub fn render_version_lines() -> Vec<String> {
     lines.push("Daemon auth list:".to_string());
     lines.extend(DAEMON_AUTH.iter().map(|s| (*s).to_string()));
     lines.push(String::new());
-    lines.push(
-        "rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you".to_string(),
-    );
+    lines.push(format!(
+        "{} comes with ABSOLUTELY NO WARRANTY.  This is free software, and you",
+        branding::program_name()
+    ));
     lines.push("are welcome to redistribute it under certain conditions.  See the GNU".to_string());
     lines.push("General Public Licence for details.".to_string());
     lines

--- a/crates/cli/tests/fixtures/oc-rsync-version-tail.txt
+++ b/crates/cli/tests/fixtures/oc-rsync-version-tail.txt
@@ -1,0 +1,19 @@
+Copyright (C) 2024-2025 oc-rsync contributors.
+Web site: https://github.com/oc-rsync/oc-rsync
+Capabilities:
+    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
+    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
+    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
+    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
+Optimizations:
+    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
+Checksum list:
+    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
+Compress list:
+    zstd lz4 zlibx zlib none
+Daemon auth list:
+    sha512 sha256 sha1 md5 md4
+
+oc-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -10,10 +10,7 @@ fn banner_is_static() {
             env!("CARGO_PKG_VERSION"),
             SUPPORTED_PROTOCOLS[0],
         ),
-        format!(
-            "rsync {}",
-            option_env!("RSYNC_UPSTREAM_VER").unwrap_or("unknown")
-        ),
+        "compatible with rsync 3.4.1; proto 32".to_string(),
         format!(
             "{} {}",
             option_env!("BUILD_REVISION").unwrap_or("unknown"),
@@ -21,9 +18,8 @@ fn banner_is_static() {
         ),
     ];
     expected.extend(
-        include_str!("fixtures/rsync-version.txt")
+        include_str!("fixtures/oc-rsync-version-tail.txt")
             .lines()
-            .skip(1)
             .map(|l| l.to_string()),
     );
     assert_eq!(version::render_version_lines(), expected);
@@ -33,10 +29,11 @@ fn banner_is_static() {
 fn banner_matches_rsync() {
     let upstream: Vec<_> = include_str!("fixtures/rsync-version.txt")
         .lines()
-        .skip(1)
+        .skip(3)
+        .take_while(|l| !l.is_empty())
         .collect();
     let ours = version::render_version_lines();
-    assert_eq!(&ours[3..], upstream);
+    assert_eq!(&ours[5..5 + upstream.len()], upstream);
 }
 
 #[test]

--- a/tests/blocking_io.rs
+++ b/tests/blocking_io.rs
@@ -10,6 +10,8 @@ fn sanitize(output: &[u8]) -> String {
             !(line.starts_with("oc-rsync")
                 || line.starts_with("rsync ")
                 || line.contains("official")
+                || line.starts_with("compatible with")
+                || line.starts_with("Web site:")
                 || line.starts_with("Copyright")
                 || line.starts_with("are welcome")
                 || line.starts_with("General Public"))


### PR DESCRIPTION
## Summary
- switch version banner to oc-rsync copyright and repository link
- add explicit compatibility line `compatible with rsync 3.4.1; proto 32`
- adjust tests to ignore new banner details

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(failed: many CLI parity tests not yet satisfied)*
- `cargo test --all-features` *(failed: could not find -lacl)*
- `make verify-comments` *(failed: crates/compress/src/lib.rs, crates/engine/tests/open_noatime.rs, crates/filters/src/lib.rs)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8c1fd708483239a823dbe1ca3fc55