### PR TITLE
chore: remove flagged comments

### DIFF
--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -69,8 +69,6 @@ pub fn decode_codecs(data: &[u8]) -> io::Result<Vec<Codec>> {
     data.iter().map(|b| Codec::from_byte(*b)).collect()
 }
 
-/// Default list of file extensions that should not be compressed, mirroring
-/// upstream rsync's `--skip-compress` setting.
 pub const DEFAULT_SKIP_COMPRESS: &[&str] = &[
     "3g2", "3gp", "7z", "aac", "ace", "apk", "avi", "bz2", "deb", "dmg", "ear", "f4v", "flac",
     "flv", "gpg", "gz", "iso", "jar", "jpeg", "jpg", "lrz", "lz", "lz4", "lzma", "lzo", "m1a",

--- a/crates/engine/tests/open_noatime.rs
+++ b/crates/engine/tests/open_noatime.rs
@@ -20,10 +20,9 @@ fn open_noatime_preserves_source_access_time() {
     let file = src.join("file.txt");
     fs::write(&file, b"hi").unwrap();
 
-    // Set atime sufficiently old to trigger relatime update on access
-    let atime = FileTime::from_unix_time(0, 0);
+    let epoch_atime = FileTime::from_unix_time(0, 0);
     let mtime = FileTime::from_system_time(SystemTime::now());
-    set_file_times(&file, atime, mtime).unwrap();
+    set_file_times(&file, epoch_atime, mtime).unwrap();
 
     let opts = SyncOptions {
         open_noatime: true,
@@ -33,5 +32,5 @@ fn open_noatime_preserves_source_access_time() {
 
     let meta = fs::metadata(&file).unwrap();
     let new_atime = FileTime::from_last_access_time(&meta);
-    assert_eq!(new_atime.unix_seconds(), atime.unix_seconds());
+    assert_eq!(new_atime.unix_seconds(), epoch_atime.unix_seconds());
 }

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1667,7 +1667,6 @@ mod tests {
         write!(file, "stdin data").unwrap();
         file.seek(SeekFrom::Start(0)).unwrap();
 
-        // Save original stdin
         let stdin_fd = unsafe { libc::dup(0) };
         assert!(stdin_fd >= 0);
 
@@ -1677,7 +1676,6 @@ mod tests {
 
         let data = read_path_or_stdin(Path::new("-")).unwrap();
 
-        // Restore stdin
         assert!(unsafe { libc::dup2(stdin_fd, 0) } >= 0);
         unsafe { libc::close(stdin_fd) };
 


### PR DESCRIPTION
## Summary
- remove in-code comments flagged by verify-comments lint
- tidy open_noatime test by using descriptive variable name

## Testing
- `cargo fmt --all`
- `make lint`
- `cargo test` *(fails: the following required arguments were not provided)*
- `cargo test --all-features` *(fails: cannot find -lacl)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68b8c21da5c883238617e48d3d713978