### PR TITLE
Add Debian and RPM packaging to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libacl1-dev
+          sudo apt-get install -y libacl1-dev dpkg-dev rpm
       - name: Install aarch64 toolchain
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: sudo apt-get install -y gcc-aarch64-linux-gnu
@@ -91,6 +91,19 @@ jobs:
           sha256sum dist/oc-rsync-${{ matrix.target }} > dist/oc-rsync-${{ matrix.target }}.sha256
           cargo install cargo-sbom || true
           cargo sbom --output dist/oc-rsync-${{ matrix.target }}-sbom.json
+      - name: Build packages
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          cargo install cargo-deb cargo-generate-rpm || true
+          cargo deb --no-build --target ${{ matrix.target }}
+          cargo generate-rpm --target ${{ matrix.target }}
+          deb=$(find target/debian -name '*.deb' -print -quit)
+          rpm=$(find target/generate-rpm -name '*.rpm' -print -quit)
+          cp "$deb" dist/
+          cp "$rpm" dist/
+          sha256sum "dist/$(basename "$deb")" > "dist/$(basename "$deb").sha256"
+          sha256sum "dist/$(basename "$rpm")" > "dist/$(basename "$rpm").sha256"
       - uses: actions/upload-artifact@v4
         with:
           name: oc-rsync-${{ matrix.target }}


### PR DESCRIPTION
## Summary
- build .deb and .rpm packages during release workflow
- install system tools needed for packaging

## Testing
- `cargo test` *(fails: 22 passed, 91 failed)*
- `make verify-comments` *(fails: additional comments in some files)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b8c23856488323898328ce311739d9