### PR TITLE
Fix positional argument parsing and add regression tests

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -77,12 +77,11 @@ pub fn run(matches: &clap::ArgMatches) -> Result<()> {
 }
 
 fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
-    let srcs = if opts.srcs.is_empty() {
-        return Err(EngineError::Other("missing SRC".into()));
-    } else {
-        opts.srcs.clone()
-    };
-    let dst_arg = opts.dst.clone();
+    if opts.paths.len() < 2 {
+        return Err(EngineError::Other("missing SRC or DST".into()));
+    }
+    let dst_arg = opts.paths.last().unwrap().clone();
+    let srcs = opts.paths[..opts.paths.len() - 1].to_vec();
     if srcs.len() > 1 {
         if let RemoteSpec::Local(ps) = parse_remote_spec(&dst_arg)? {
             if !ps.path.is_dir() {

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -22,6 +22,7 @@ pub enum OutBuf {
 
 #[allow(non_snake_case)]
 #[derive(Parser, Debug, Clone)]
+#[command(trailing_var_arg = true)]
 pub(crate) struct ClientOpts {
     #[command(flatten)]
     pub daemon: DaemonOpts,
@@ -658,11 +659,9 @@ pub(crate) struct ClientOpts {
     #[arg(
         value_name = "SRC",
         required_unless_present_any = ["daemon", "server", "probe"],
-        num_args = 1..
+        num_args = 2..,
     )]
-    pub srcs: Vec<String>,
-    #[arg(value_name = "DST", required = true, last = true)]
-    pub dst: String,
+    pub paths: Vec<String>,
     #[arg(short = 'f', long, value_name = "RULE", help_heading = "Selection")]
     pub filter: Vec<String>,
     #[arg(long, value_name = "FILE", help_heading = "Selection")]

--- a/tests/positional_args.rs
+++ b/tests/positional_args.rs
@@ -1,0 +1,58 @@
+// tests/positional_args.rs
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn files_from_and_exclude_accept_src_and_dst() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("keep.txt"), "hi").unwrap();
+    let list = tmp.path().join("list.txt");
+    fs::write(&list, "keep.txt\n").unwrap();
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--dry-run",
+            "--recursive",
+            "--files-from",
+            list.to_str().unwrap(),
+            "--exclude",
+            "*.log",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn exclude_then_files_from_accepts_src_and_dst() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("keep.txt"), "hi").unwrap();
+    let list = tmp.path().join("list.txt");
+    fs::write(&list, "keep.txt\n").unwrap();
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--dry-run",
+            "--recursive",
+            "--exclude",
+            "*.log",
+            "--files-from",
+            list.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary
- parse SRC and DST from a single positional vector with trailing var arg
- guard against missing destination in client execution
- add regression tests for `--files-from` and `--exclude` combos

## Testing
- `cargo test --quiet` (failed: default_umask_masks_permissions, dry_run_parity_destination_untouched, progress_flag_human_readable, progress_flag_shows_output, progress_parity, progress_parity_p)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test positional_args --quiet`
- `cargo test --test cli --quiet` (failed: default_umask_masks_permissions, dry_run_parity_destination_untouched, progress_flag_human_readable, progress_flag_shows_output, progress_parity, progress_parity_p)
- `make lint`
- `make verify-comments`

------
https://chatgpt.com/codex/tasks/task_e_68b8ca3d7b908323ae1cf9f01bdea34e