### PR TITLE
docs: sync feature matrix with formatter ARG_ORDER

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -27,6 +27,7 @@ This document is synchronized with [feature_matrix.md](feature_matrix.md) and li
 - `--open-noatime`: parity with upstream not yet verified; effective only on platforms supporting `O_NOATIME`. Tests: [crates/engine/tests/open_noatime.rs](../crates/engine/tests/open_noatime.rs)<br>[tests/cli_flags.rs](../tests/cli_flags.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/engine/src/lib.rs](../crates/engine/src/lib.rs).
 - `--outbuf`: parity with upstream not yet verified; set stdout buffering. Tests: [tests/cli_flags.rs](../tests/cli_flags.rs). Source: [bin/oc-rsync/src/main.rs](../bin/oc-rsync/src/main.rs).
 - `--progress`: parity with upstream not yet verified. Tests: [tests/cli.rs#L309](../tests/cli.rs#L309). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
+- `-P`: parity with upstream not yet verified; shorthand for `--partial --progress`. Tests: [tests/cli.rs](../tests/cli.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--protocol`: parity with upstream not yet verified. Tests: [tests/cli_flags.rs](../tests/cli_flags.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--relative`: parity with upstream not yet verified. Tests: [tests/cli.rs](../tests/cli.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--secluded-args`: parity with upstream not yet verified. Tests: [tests/secluded_args.rs](../tests/secluded_args.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -42,7 +42,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--zc` | ✅ | Y | Y | Y | [tests/golden/cli_parity/compress-choice.sh](../tests/golden/cli_parity/compress-choice.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | alias for `--compress-choice` |
 | `--zl` | ✅ | Y | Y | Y | [tests/golden/cli_parity/compress-level.sh](../tests/golden/cli_parity/compress-level.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | alias for `--compress-level` |
 | `--config` | ✅ | N | N | N | [tests/daemon_config.rs](../tests/daemon_config.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--contimeout` | ✅ | Y | Y | Y | [tests/timeout.rs](../tests/timeout.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `--connect-timeout` | ✅ | Y | Y | Y | [tests/timeout.rs](../tests/timeout.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | alias `--contimeout` |
 | `--copy-as` | ✅ | N | N | N | [tests/copy_as.rs](../tests/copy_as.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires root or CAP_CHOWN |
 | `--copy-dest` | ✅ | Y | Y | Y | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--copy-devices` | ✅ | Y | Y | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
@@ -62,6 +62,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--delete-during` | ✅ | Y | Y | Y | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--delete-excluded` | ✅ | Y | Y | Y | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--delete-missing-args` | ✅ | Y | Y | Y | [tests/delete_policy.rs](../tests/delete_policy.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `-D` | ✅ | Y | Y | Y | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | shorthand for `--devices --specials` |
 | `--devices` | ✅ | Y | Y | Y | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--dirs` | ✅ | Y | Y | Y | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--dparam` | ✅ | Y | Y | Y | [crates/cli/tests/cli_parity.rs](../crates/cli/tests/cli_parity.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | override global daemon config parameter |
@@ -74,6 +75,8 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--fake-super` | ✅ | N | N | N | [tests/fake_super.rs](../tests/fake_super.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires `xattr` feature |
 | `--files-from` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--filter` | ✅ | Y | Y | Y | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `--filter-file` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | read rules from file |
+| `-F` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | filter merge shorthand |
 | `--force` | ✅ | Y | Y | Y | [tests/delete_policy.rs](../tests/delete_policy.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--from0` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--fsync` | ✅ | N | N | N | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
@@ -135,6 +138,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--port` | ✅ | Y | Y | Y | [tests/daemon.rs](../tests/daemon.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | overrides default port |
 | `--preallocate` | ✅ | Y | Y | Y | [tests/perf_limits.rs](../tests/perf_limits.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--progress` | ✅ | N | N | N | [tests/cli.rs#L309](../tests/cli.rs#L309) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `-P` | ✅ | N | N | N | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | shorthand for `--partial --progress` |
 | `--protocol` | ✅ | N | N | N | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--prune-empty-dirs` | ✅ | Y | Y | Y | [tests/filter_corpus.rs](../tests/filter_corpus.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--quiet` | ✅ | Y | Y | Y | [tests/golden/cli_parity/compression.sh](../tests/golden/cli_parity/compression.sh)<br>[tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh)<br>[tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -128,6 +128,7 @@ The following flags are parsed but lack verification against upstream `rsync`. A
 - `--open-noatime`: add interop tests on platforms with `O_NOATIME`. Tests: [crates/engine/tests/open_noatime.rs](../crates/engine/tests/open_noatime.rs)<br>[tests/cli_flags.rs](../tests/cli_flags.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/engine/src/lib.rs](../crates/engine/src/lib.rs).
 - `--outbuf`: add interop tests verifying stdout buffering. Tests: [tests/cli_flags.rs](../tests/cli_flags.rs). Source: [bin/oc-rsync/src/main.rs](../bin/oc-rsync/src/main.rs).
 - `--progress`: add interop tests for progress output. Tests: [tests/cli.rs](../tests/cli.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
+- `-P`: add interop tests verifying shorthand for `--partial --progress`. Tests: [tests/cli.rs](../tests/cli.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--protocol`: add interop tests verifying protocol negotiation. Tests: [tests/cli_flags.rs](../tests/cli_flags.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--relative`: add interop tests for path handling. Tests: [tests/cli.rs](../tests/cli.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--secluded-args`: add interop tests verifying argument separation. Tests: [tests/secluded_args.rs](../tests/secluded_args.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).

--- a/tests/remote_remote.rs
+++ b/tests/remote_remote.rs
@@ -3,7 +3,6 @@
 
 use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
-use hex;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::{self, Read, Write};


### PR DESCRIPTION
## Summary
- document additional CLI flags from `ARG_ORDER`
- note progress shorthand `-P` in differences and gaps docs
- drop redundant `hex` import to satisfy clippy

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: default_umask_masks_permissions, dry_run_parity_destination_untouched, progress_flag_human_readable, progress_flag_shows_output, progress_parity_p, progress_parity; run hit 60s timeout)*
- `make verify-comments` *(failed: Makefile:12 missing separator)*
- `make lint` *(failed: Makefile:12 missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d00375e88323bfc40cfca2b87537