### PR TITLE
feat(cli): add branding header placeholders

### DIFF
--- a/crates/cli/resources/rsync-help-80.txt
+++ b/crates/cli/resources/rsync-help-80.txt
@@ -1,22 +1,4 @@
-oc-rsync 0.1.0 (protocol 32)
-rsync  version 3.4.1  protocol version 32
-Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.
-Web site: https://github.com/oc-rsync/oc-rsync
-Capabilities:
-    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
-    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
-    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
-    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
-Optimizations:
-    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
-Checksum list:
-    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
-Compress list:
-    zstd lz4 zlibx zlib none
-Daemon auth list:
-    sha512 sha256 sha1 md5 md4
-
-oc-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
 are welcome to redistribute it under certain conditions.  See the GNU
 General Public Licence for details.
 
@@ -180,6 +162,6 @@ Options
 --version, -V            print the version + other info and exit
 --help, -h (*)           show this help (* -h is help only on its own)
 
-Use "oc-rsync --daemon --help" to see the daemon-mode command-line options.
-Please see the oc-rsync(1) and oc-rsyncd.conf(5) manpages for full documentation.
-For project updates and documentation, visit https://github.com/oc-rsync/oc-rsync.
+Use "rsync --daemon --help" to see the daemon-mode command-line options.
+Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
+See https://rsync.samba.org/ for updates, bug reports, and answers

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -1,7 +1,14 @@
 // crates/cli/src/branding.rs
 use std::env;
 
-pub const DEFAULT_HELP_PREFIX: &str = r#"rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+pub const DEFAULT_BRAND_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const DEFAULT_BRAND_CREDITS: &str =
+    "Automatic Rust re-implementation of rsync semantics by Ofer Chen (2025). Not affiliated with Samba.";
+
+pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
+{credits}
+
+rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
 are welcome to redistribute it under certain conditions.  See the GNU
 General Public Licence for details.
 
@@ -22,9 +29,9 @@ Options
 "#;
 
 pub const DEFAULT_HELP_SUFFIX: &str = r#"
-Use "{prog} --daemon --help" to see the daemon-mode command-line options.
-Please see the {prog}(1) and {prog}d.conf(5) manpages for full documentation.
-For project updates and documentation, visit https://github.com/oc-rsync/oc-rsync.
+Use "rsync --daemon --help" to see the daemon-mode command-line options.
+Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
+See https://rsync.samba.org/ for updates, bug reports, and answers
 "#;
 
 pub fn program_name() -> String {
@@ -37,6 +44,26 @@ pub fn program_name() -> String {
         .unwrap_or_else(|_| "oc-rsync".to_string())
 }
 
+pub fn brand_version() -> String {
+    env::var("OC_RSYNC_BRAND_VERSION")
+        .or_else(|_| {
+            option_env!("OC_RSYNC_BRAND_VERSION")
+                .map(str::to_string)
+                .ok_or(env::VarError::NotPresent)
+        })
+        .unwrap_or_else(|_| DEFAULT_BRAND_VERSION.to_string())
+}
+
+pub fn brand_credits() -> String {
+    env::var("OC_RSYNC_BRAND_CREDITS")
+        .or_else(|_| {
+            option_env!("OC_RSYNC_BRAND_CREDITS")
+                .map(str::to_string)
+                .ok_or(env::VarError::NotPresent)
+        })
+        .unwrap_or_else(|_| DEFAULT_BRAND_CREDITS.to_string())
+}
+
 pub fn help_prefix() -> String {
     env::var("OC_RSYNC_BRAND_HEADER")
         .or_else(|_| {
@@ -44,7 +71,7 @@ pub fn help_prefix() -> String {
                 .map(str::to_string)
                 .ok_or(env::VarError::NotPresent)
         })
-        .unwrap_or_else(|_| DEFAULT_HELP_PREFIX.replace("rsync", &program_name()))
+        .unwrap_or_else(|_| DEFAULT_HELP_PREFIX.to_string())
 }
 
 pub fn help_suffix() -> String {
@@ -54,5 +81,5 @@ pub fn help_suffix() -> String {
                 .map(str::to_string)
                 .ok_or(env::VarError::NotPresent)
         })
-        .unwrap_or_else(|_| DEFAULT_HELP_SUFFIX.replace("{prog}", &program_name()))
+        .unwrap_or_else(|_| DEFAULT_HELP_SUFFIX.to_string())
 }

--- a/crates/cli/tests/branding.rs
+++ b/crates/cli/tests/branding.rs
@@ -1,13 +1,14 @@
 // crates/cli/tests/branding.rs
-use oc_rsync_cli::{cli_command, render_help};
+use oc_rsync_cli::{branding, cli_command, render_help};
 
 #[test]
 fn help_uses_program_name() {
     std::env::set_var("PROGRAM_NAME", "myrsync");
     std::env::set_var("COLUMNS", "80");
-    let cmd = cli_command();
-    let help = render_help(&cmd);
-    assert!(help.contains("Usage: myrsync"));
+    let version = branding::brand_version();
+    let help = render_help(&cli_command());
+    let first = help.lines().next().unwrap();
+    assert_eq!(first, format!("myrsync {}", version));
     std::env::remove_var("PROGRAM_NAME");
     std::env::remove_var("COLUMNS");
 }

--- a/crates/cli/tests/help.rs
+++ b/crates/cli/tests/help.rs
@@ -1,5 +1,5 @@
 // crates/cli/tests/help.rs
-use oc_rsync_cli::{cli_command, render_help};
+use oc_rsync_cli::{branding, cli_command, render_help};
 use serial_test::serial;
 use std::env;
 
@@ -8,8 +8,16 @@ use std::env;
 fn help_columns_80() {
     env::set_var("COLUMNS", "80");
     let out = render_help(&cli_command());
+    let mut lines = out.lines();
+    assert_eq!(
+        lines.next().unwrap(),
+        format!("{} {}", branding::program_name(), branding::brand_version())
+    );
+    assert_eq!(lines.next().unwrap(), branding::brand_credits());
+    assert!(lines.next().unwrap().is_empty());
+    let body = lines.collect::<Vec<_>>().join("\n");
     let expected = include_str!("../resources/rsync-help-80.txt").trim_end();
-    assert_eq!(out, expected);
+    assert_eq!(body, expected);
 }
 
 #[test]
@@ -17,8 +25,16 @@ fn help_columns_80() {
 fn help_columns_120() {
     env::set_var("COLUMNS", "120");
     let out = render_help(&cli_command());
+    let mut lines = out.lines();
+    assert_eq!(
+        lines.next().unwrap(),
+        format!("{} {}", branding::program_name(), branding::brand_version())
+    );
+    assert_eq!(lines.next().unwrap(), branding::brand_credits());
+    assert!(lines.next().unwrap().is_empty());
+    let body = lines.collect::<Vec<_>>().join("\n");
     let expected = include_str!("../../../tests/fixtures/rsync-help-120.txt").trim_end();
-    assert_eq!(out, expected);
+    assert_eq!(body, expected);
 }
 
 #[test]

--- a/tests/help_output.rs
+++ b/tests/help_output.rs
@@ -78,9 +78,12 @@ fn help_matches_upstream() {
         .output()
         .unwrap();
 
-    let mut ours = String::from_utf8(output.stdout).unwrap();
-    ours = ours.replace("oc-rsync", "rsync");
-    let mut expected = fs::read_to_string("crates/cli/resources/rsync-help-80.txt").unwrap();
-    expected = expected.replace("oc-rsync", "rsync");
-    assert_eq!(ours, expected, "help output diverges from upstream");
+    let ours = String::from_utf8(output.stdout).unwrap();
+    let mut lines = ours.lines();
+    lines.next();
+    lines.next();
+    lines.next();
+    let ours_body = lines.collect::<Vec<_>>().join("\n");
+    let expected = fs::read_to_string("crates/cli/resources/rsync-help-80.txt").unwrap();
+    assert_eq!(ours_body, expected, "help output diverges from upstream");
 }


### PR DESCRIPTION
## Summary
- add brand_version and brand_credits utilities and new help prefix placeholders
- interpolate branding metadata in CLI help output
- ensure help text tests verify upstream parity with oc-rsync header

## Testing
- `make lint` *(fails: Makefile:12: missing separator)*
- `make verify-comments` *(fails: Makefile:12: missing separator)*
- `cargo test` *(fails: progress_flag_human_readable, progress_flag_shows_output, progress_parity, progress_parity_p)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cfff7e188323a474d11e05cc78f4