### PR TITLE
Embed upstream version constants

### DIFF
--- a/bin/oc-rsync/build.rs
+++ b/bin/oc-rsync/build.rs
@@ -1,24 +1,32 @@
 // bin/oc-rsync/build.rs
 use std::{env, fs, path::Path};
 
+const UPSTREAM_VERSION: &str = "3.4.1";
+const UPSTREAM_PROTOCOLS: &[u32] = &[32, 31, 30, 29];
+
 fn main() {
-    let upstream = env::var("RSYNC_UPSTREAM_VER").unwrap_or_else(|_| "unknown".to_string());
     let revision = env::var("BUILD_REVISION").unwrap_or_else(|_| "unknown".to_string());
     let official = env::var("OFFICIAL_BUILD").unwrap_or_else(|_| "unofficial".to_string());
 
-    println!("cargo:rustc-env=RSYNC_UPSTREAM_VER={upstream}");
+    let protocols = UPSTREAM_PROTOCOLS
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    println!("cargo:rustc-env=UPSTREAM_VERSION={UPSTREAM_VERSION}");
+    println!("cargo:rustc-env=UPSTREAM_PROTOCOLS={protocols}");
     println!("cargo:rustc-env=BUILD_REVISION={revision}");
     println!("cargo:rustc-env=OFFICIAL_BUILD={official}");
 
     let out_dir = env::var("OUT_DIR").expect("missing OUT_DIR");
     let info_path = Path::new(&out_dir).join("build_info.md");
     let contents = format!(
-        "rsync upstream version: {upstream}\nbuild revision: {revision}\nofficial build: {official}\n"
+        "rsync upstream version: {UPSTREAM_VERSION}\nbuild revision: {revision}\nofficial build: {official}\n",
     );
     fs::write(&info_path, contents).expect("failed to write build_info.md");
     println!("cargo:rustc-env=BUILD_INFO_PATH={}", info_path.display());
 
-    println!("cargo:rerun-if-env-changed=RSYNC_UPSTREAM_VER");
     println!("cargo:rerun-if-env-changed=BUILD_REVISION");
     println!("cargo:rerun-if-env-changed=OFFICIAL_BUILD");
 }

--- a/bin/oc-rsync/src/version.rs
+++ b/bin/oc-rsync/src/version.rs
@@ -5,6 +5,10 @@ use oc_rsync_cli::branding;
 
 pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOLS[0];
 
+const UPSTREAM_VERSION: &str = match option_env!("UPSTREAM_VERSION") {
+    Some(v) => v,
+    None => "unknown",
+};
 const COPYRIGHT: &str =
     "Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.";
 const WEBSITE: &str = "Web site: https://rsync.samba.org/";
@@ -35,10 +39,7 @@ pub fn render_version_lines() -> Vec<String> {
         env!("CARGO_PKG_VERSION"),
         RSYNC_PROTOCOL
     ));
-    lines.push(format!(
-        "rsync {}",
-        option_env!("RSYNC_UPSTREAM_VER").unwrap_or("unknown")
-    ));
+    lines.push(format!("rsync {UPSTREAM_VERSION}"));
     lines.push(format!(
         "{} {}",
         option_env!("BUILD_REVISION").unwrap_or("unknown"),

--- a/bin/oc-rsync/tests/version.rs
+++ b/bin/oc-rsync/tests/version.rs
@@ -47,7 +47,7 @@ fn quiet_suppresses_output() {
 #[test]
 fn build_info_file_has_expected_values() {
     let info = std::fs::read_to_string(env!("BUILD_INFO_PATH")).unwrap();
-    assert!(info.contains(env!("RSYNC_UPSTREAM_VER")));
+    assert!(info.contains(env!("UPSTREAM_VERSION")));
     assert!(info.contains(env!("BUILD_REVISION")));
     assert!(info.contains(env!("OFFICIAL_BUILD")));
 }

--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -5,9 +5,17 @@ use crate::branding;
 
 pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOLS[0];
 
+const UPSTREAM_VERSION: &str = match option_env!("UPSTREAM_VERSION") {
+    Some(v) => v,
+    None => "unknown",
+};
+const UPSTREAM_PROTOCOLS: &str = match option_env!("UPSTREAM_PROTOCOLS") {
+    Some(v) => v,
+    None => "32,31,30,29",
+};
+
 const COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
 const WEBSITE: &str = "Web site: https://github.com/oc-rsync/oc-rsync";
-const COMPATIBILITY: &str = "compatible with rsync 3.4.1; proto 32";
 const CAPABILITIES: &[&str] = &[
     "    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,",
     "    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,",
@@ -27,7 +35,15 @@ pub fn render_version_lines() -> Vec<String> {
         env!("CARGO_PKG_VERSION"),
         RSYNC_PROTOCOL
     ));
-    lines.push(COMPATIBILITY.to_string());
+    let proto = UPSTREAM_PROTOCOLS
+        .split(',')
+        .next()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(RSYNC_PROTOCOL);
+    lines.push(format!(
+        "compatible with rsync {} (protocol {proto})",
+        UPSTREAM_VERSION
+    ));
     lines.push(format!(
         "{} {}",
         option_env!("BUILD_REVISION").unwrap_or("unknown"),

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -10,7 +10,17 @@ fn banner_is_static() {
             env!("CARGO_PKG_VERSION"),
             SUPPORTED_PROTOCOLS[0],
         ),
-        "compatible with rsync 3.4.1; proto 32".to_string(),
+        {
+            let proto = option_env!("UPSTREAM_PROTOCOLS")
+                .unwrap_or("32,31,30,29")
+                .split(',')
+                .next()
+                .unwrap_or("0");
+            format!(
+                "compatible with rsync {} (protocol {proto})",
+                option_env!("UPSTREAM_VERSION").unwrap_or("unknown"),
+            )
+        },
         format!(
             "{} {}",
             option_env!("BUILD_REVISION").unwrap_or("unknown"),

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -14,7 +14,7 @@ When connecting to a peer, the highest shared version from this list is selected
 
 ```
 UPSTREAM_VERSION=3.4.1
-SUPPORTED_PROTOCOLS=[32,31,30,29]
+UPSTREAM_PROTOCOLS=[32,31,30,29]
 ```
 
-The build scripts for `oc-rsync` and `oc-rsyncd` embed these values into the binaries by exporting them as compile-time environment variables (for example `cargo:rustc-env=RSYNC_UPSTREAM_VER=…`) in `build.rs`.
+The build scripts for `oc-rsync` and `oc-rsyncd` embed these values into the binaries by exporting them as compile-time environment variables (for example `cargo:rustc-env=UPSTREAM_VERSION=…` and `cargo:rustc-env=UPSTREAM_PROTOCOLS=…`) in `build.rs`.

--- a/tests/remote_remote.rs
+++ b/tests/remote_remote.rs
@@ -3,7 +3,6 @@
 
 use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
-use hex;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::io::{self, Read, Write};


### PR DESCRIPTION
## Summary
- hardcode upstream rsync version and protocol list in build script
- expose upstream compatibility via env vars and show `compatible with rsync 3.4.1 (protocol 32)` in `--version`
- document upstream version constants and adjust tests

## Testing
- `bash scripts/check-comments.sh $(git ls-files '*.rs')`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: default_umask_masks_permissions, dry_run_parity_destination_untouched, progress_flag_human_readable, progress_flag_shows_output, progress_parity, progress_parity_p)*
- `cargo test --all-features` *(fails: default_umask_masks_permissions, dry_run_parity_destination_untouched, progress_flag_human_readable, progress_flag_shows_output, progress_parity, progress_parity_p)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cff89dd48323a0b781388f781b4b