### PR TITLE
docs: update badges and install options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # oc-rsync — Pure-Rust rsync replica (compatible with rsync 3.4.1 / protocol 32)
 
-[![CI](https://github.com/oc-rsync/oc-rsync/actions/workflows/ci.yml/badge.svg)](https://github.com/oc-rsync/oc-rsync/actions/workflows/ci.yml)
-[![Coverage](https://codecov.io/gh/oc-rsync/oc-rsync/branch/main/graph/badge.svg)](https://codecov.io/gh/oc-rsync/oc-rsync)
-[![Release](https://img.shields.io/github/v/release/oc-rsync/oc-rsync)](https://github.com/oc-rsync/oc-rsync/releases)
+[![CI](https://github.com/oferchen/oc-rsync/actions/workflows/ci.yml/badge.svg)](https://github.com/oferchen/oc-rsync/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/oferchen/oc-rsync/branch/main/graph/badge.svg)](https://codecov.io/gh/oferchen/oc-rsync)
+[![Release](https://img.shields.io/github/v/release/oferchen/oc-rsync)](https://github.com/oferchen/oc-rsync/releases)
 
 ## Project statement
 
-oc-rsync is an automatic re‑implementation of rsync’s behavior in Rust, created by Ofer Chen (2025). Not affiliated with the Samba project.
+oc-rsync is an automatic re‑implementation of rsync’s behavior in Rust, created by Ofer Chen (2025). This project is unaffiliated with the Samba team.
 
 ## Compatibility
 
@@ -16,6 +16,20 @@ oc-rsync is an automatic re‑implementation of rsync’s behavior in Rust, crea
 - Known gaps are cataloged in [docs/gaps.md](docs/gaps.md).
 
 ## Install
+
+Prebuilt binaries and packages are published on [GitHub Releases](https://github.com/oferchen/oc-rsync/releases).
+
+### Packages
+
+```bash
+# Debian/Ubuntu
+sudo dpkg -i oc-rsync_<version>_amd64.deb
+
+# Fedora/RHEL
+sudo rpm -i oc-rsync-<version>.x86_64.rpm
+```
+
+### From source
 
 ```bash
 cargo install oc-rsync


### PR DESCRIPTION
## Summary
- fix README badges to point to `oferchen/oc-rsync`
- document `.deb` and `.rpm` packages alongside binary installs
- clarify project is unaffiliated with the Samba team

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_preserves_hard_links_remote_source, probe_connects_to_daemon)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8d9ea87ec8323b31f0b4d7a016c30