### PR TITLE
Sanitize version banner via build metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "engine",
+ "libc",
  "logging",
  "oc-rsync-cli",
  "predicates",

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -14,6 +14,7 @@ engine = { path = "../../crates/engine" }
 logging = { path = "../../crates/logging" }
 protocol = { path = "../../crates/protocol" }
 clap = { version = "4" }
+libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/bin/oc-rsync/build.rs
+++ b/bin/oc-rsync/build.rs
@@ -8,6 +8,14 @@ fn main() {
     let revision = env::var("BUILD_REVISION").unwrap_or_else(|_| "unknown".to_string());
     let official = env::var("OFFICIAL_BUILD").unwrap_or_else(|_| "unofficial".to_string());
 
+    let name = env::var("OC_RSYNC_NAME").unwrap_or_else(|_| "oc-rsync".to_string());
+    let version =
+        env::var("OC_RSYNC_VERSION").unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
+    let copyright = env::var("OC_RSYNC_COPYRIGHT")
+        .unwrap_or_else(|_| "Copyright (C) 2024-2025 oc-rsync contributors.".to_string());
+    let url = env::var("OC_RSYNC_URL")
+        .unwrap_or_else(|_| "Web site: https://github.com/oc-rsync/oc-rsync".to_string());
+
     let protocols = UPSTREAM_PROTOCOLS
         .iter()
         .map(|p| p.to_string())
@@ -18,6 +26,10 @@ fn main() {
     println!("cargo:rustc-env=UPSTREAM_PROTOCOLS={protocols}");
     println!("cargo:rustc-env=BUILD_REVISION={revision}");
     println!("cargo:rustc-env=OFFICIAL_BUILD={official}");
+    println!("cargo:rustc-env=OC_RSYNC_NAME={name}");
+    println!("cargo:rustc-env=OC_RSYNC_VERSION={version}");
+    println!("cargo:rustc-env=OC_RSYNC_COPYRIGHT={copyright}");
+    println!("cargo:rustc-env=OC_RSYNC_URL={url}");
 
     let out_dir = env::var("OUT_DIR").expect("missing OUT_DIR");
     let info_path = Path::new(&out_dir).join("build_info.md");
@@ -29,4 +41,8 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=BUILD_REVISION");
     println!("cargo:rerun-if-env-changed=OFFICIAL_BUILD");
+    println!("cargo:rerun-if-env-changed=OC_RSYNC_NAME");
+    println!("cargo:rerun-if-env-changed=OC_RSYNC_VERSION");
+    println!("cargo:rerun-if-env-changed=OC_RSYNC_COPYRIGHT");
+    println!("cargo:rerun-if-env-changed=OC_RSYNC_URL");
 }

--- a/bin/oc-rsync/src/version.rs
+++ b/bin/oc-rsync/src/version.rs
@@ -1,17 +1,15 @@
 // bin/oc-rsync/src/version.rs
 use protocol::SUPPORTED_PROTOCOLS;
 
-use oc_rsync_cli::branding;
-
 pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOLS[0];
 
-const UPSTREAM_VERSION: &str = match option_env!("UPSTREAM_VERSION") {
-    Some(v) => v,
-    None => "unknown",
-};
-const COPYRIGHT: &str =
-    "Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.";
-const WEBSITE: &str = "Web site: https://rsync.samba.org/";
+const UPSTREAM_VERSION: &str = option_env!("UPSTREAM_VERSION").unwrap_or("unknown");
+const UPSTREAM_PROTOCOLS: &str = option_env!("UPSTREAM_PROTOCOLS").unwrap_or("32,31,30,29");
+
+const NAME: &str = env!("OC_RSYNC_NAME");
+const VERSION: &str = env!("OC_RSYNC_VERSION");
+const COPYRIGHT: &str = env!("OC_RSYNC_COPYRIGHT");
+const WEBSITE: &str = env!("OC_RSYNC_URL");
 const CAPABILITIES: &[&str] = &[
     "    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,",
     "    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,",
@@ -33,13 +31,15 @@ const DAEMON_AUTH: &[&str] = &[
 
 pub fn render_version_lines() -> Vec<String> {
     let mut lines = Vec::new();
+    lines.push(format!("{NAME} {VERSION} (protocol {RSYNC_PROTOCOL})"));
+    let proto = UPSTREAM_PROTOCOLS
+        .split(',')
+        .next()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(RSYNC_PROTOCOL);
     lines.push(format!(
-        "{} {} (protocol {})",
-        branding::program_name(),
-        env!("CARGO_PKG_VERSION"),
-        RSYNC_PROTOCOL
+        "compatible with rsync {UPSTREAM_VERSION} (protocol {proto})"
     ));
-    lines.push(format!("rsync {UPSTREAM_VERSION}"));
     lines.push(format!(
         "{} {}",
         option_env!("BUILD_REVISION").unwrap_or("unknown"),
@@ -58,10 +58,9 @@ pub fn render_version_lines() -> Vec<String> {
     lines.push("Daemon auth list:".to_string());
     lines.extend(DAEMON_AUTH.iter().map(|s| (*s).to_string()));
     lines.push(String::new());
-    lines.push(
-        "rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you"
-            .to_string(),
-    );
+    lines.push(format!(
+        "{NAME} comes with ABSOLUTELY NO WARRANTY.  This is free software, and you"
+    ));
     lines.push(
         "are welcome to redistribute it under certain conditions.  See the GNU"
             .to_string(),

--- a/bin/oc-rsync/tests/fixtures/version.txt
+++ b/bin/oc-rsync/tests/fixtures/version.txt
@@ -1,0 +1,22 @@
+oc-rsync 0.1.0 (protocol 32)
+compatible with rsync unknown (protocol 32)
+unknown unofficial
+Copyright (C) 2024-2025 oc-rsync contributors.
+Web site: https://github.com/oc-rsync/oc-rsync
+Capabilities:
+    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
+    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
+    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
+    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
+Optimizations:
+    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
+Checksum list:
+    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
+Compress list:
+    zstd lz4 zlibx zlib none
+Daemon auth list:
+    sha512 sha256 sha1 md5 md4
+
+oc-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.

--- a/bin/oc-rsync/tests/version.rs
+++ b/bin/oc-rsync/tests/version.rs
@@ -18,6 +18,13 @@ fn matches_rendered_version() {
 }
 
 #[test]
+fn matches_fixture() {
+    let out = version_output();
+    let expected = include_str!("fixtures/version.txt");
+    assert_eq!(out, expected);
+}
+
+#[test]
 fn output_is_immutable() {
     let first = version_output();
     let second = version_output();


### PR DESCRIPTION
## Summary
- expose oc-rsync name, version, copyright and URL as build env variables
- generate version banner from these values, dropping upstream authors and links
- add a fixture-based test confirming the sanitized banner

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_preserves_hard_links_remote_source, probe_connects_to_daemon)*
- `cargo test -p oc-rsync-bin --test version`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8d9ad5f3483239ba1104e04db65ab