### PR TITLE
feat: add packaging metadata

### DIFF
--- a/.rpm/oc-rsyncd.conf
+++ b/.rpm/oc-rsyncd.conf
@@ -1,0 +1,1 @@
+../packaging/examples/oc-rsyncd.conf

--- a/.rpm/oc-rsyncd.service
+++ b/.rpm/oc-rsyncd.service
@@ -1,0 +1,1 @@
+../packaging/systemd/oc-rsyncd.service

--- a/.rpm/oc-rsyncd.systemd.conf
+++ b/.rpm/oc-rsyncd.systemd.conf
@@ -1,0 +1,1 @@
+../packaging/systemd/oc-rsyncd.conf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ resolver = "2"
 [package]
 name = "oc-rsync"
 version = "0.1.0"
+description = "Pure-Rust reimplementation of rsync (protocol v32)"
+license = "Apache-2.0 OR MIT"
 edition = "2021"
 
 [dependencies]
@@ -94,15 +96,32 @@ cli = []
 nightly = ["checksums/nightly", "compress/nightly"]
 
 [package.metadata.deb]
-systemd-units = ["packaging/systemd/oc-rsyncd.service"]
+maintainer = "oc-rsync maintainers <maintainers@rsync.rs>"
+depends = "$auto, systemd"
 assets = [
+    ["packaging/systemd/oc-rsyncd.service", "/lib/systemd/system/oc-rsyncd.service", "644"],
     ["packaging/examples/oc-rsyncd.conf", "/usr/share/doc/oc-rsync/examples/oc-rsyncd.conf", "644"],
     ["packaging/systemd/oc-rsyncd.conf", "/usr/share/doc/oc-rsync/examples/oc-rsyncd.systemd.conf", "644"],
 ]
 
 [package.metadata.rpm]
-systemd-units = ["packaging/systemd/oc-rsyncd.service"]
-assets = [
-    ["packaging/examples/oc-rsyncd.conf", "/usr/share/doc/oc-rsync/examples/oc-rsyncd.conf", "644"],
-    ["packaging/systemd/oc-rsyncd.conf", "/usr/share/doc/oc-rsync/examples/oc-rsyncd.systemd.conf", "644"],
-]
+maintainer = "oc-rsync maintainers <maintainers@rsync.rs>"
+requires = ["systemd"]
+
+[package.metadata.rpm.targets.oc-rsync]
+path = "/usr/bin/oc-rsync"
+
+[package.metadata.rpm.targets.oc-rsyncd]
+path = "/usr/bin/oc-rsyncd"
+
+[package.metadata.rpm.files."oc-rsyncd.conf"]
+path = "/usr/share/doc/oc-rsync/examples/oc-rsyncd.conf"
+mode = "644"
+
+[package.metadata.rpm.files."oc-rsyncd.systemd.conf"]
+path = "/usr/share/doc/oc-rsync/examples/oc-rsyncd.systemd.conf"
+mode = "644"
+
+[package.metadata.rpm.files."oc-rsyncd.service"]
+path = "/usr/lib/systemd/system/oc-rsyncd.service"
+mode = "644"


### PR DESCRIPTION
## Summary
- add maintainer info and explicit asset paths for deb and rpm builds
- document package and license details
- include example config and systemd service in package metadata

## Testing
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_preserves_hard_links_remote_source, probe_connects_to_daemon)*
- `cargo deb --no-build`
- `cargo rpm build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8dda8e8b88323820b039b2fff56ae