### PR TITLE
Enable default ACL/xattr support and unify tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,13 @@ required-features = ["cli"]
 name = "strip-rs-comments"
 path = "tools/strip_rs_comments.rs"
 
+# Enable extended attribute and ACL support by default so tests can run
+# without requiring feature flags. Individual crates handle runtime
+# detection of platform support.
 [features]
-default = []
-xattr = ["engine/xattr", "oc-rsync-cli/xattr", "meta/xattr"]
-acl = ["engine/acl", "oc-rsync-cli/acl", "meta/acl"]
+default = ["xattr", "acl"]
+xattr = ["engine/xattr"]
+acl = ["engine/acl"]
 # Enables CLI-only tools
 cli = []
 # Enables AVX-512 implementations requiring a nightly toolchain

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -21,6 +21,6 @@ tempfile = "3"
 predicates = "3"
 
 [features]
-default = []
-xattr = ["engine/xattr", "oc-rsync-cli/xattr"]
-acl = ["engine/acl", "oc-rsync-cli/acl"]
+default = ["xattr", "acl"]
+xattr = ["engine/xattr"]
+acl = ["engine/acl"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,7 +11,7 @@ filters = { path = "../filters" }
 transport = { path = "../transport" }
 compress = { path = "../compress" }
 shell-words = "1.1"
-meta = { path = "../meta", default-features = false }
+meta = { path = "../meta" }
 daemon = { path = "../daemon" }
 logging = { path = "../logging" }
 tracing = "0.1"
@@ -32,7 +32,3 @@ assert_cmd = "2"
 insta = { version = "1", features = ["json"] }
 serial_test = "2"
 
-[features]
-default = []
-xattr = ["engine/xattr"]
-acl = ["engine/acl"]

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -392,10 +392,8 @@ pub(crate) struct ClientOpts {
         overrides_with_all = ["devices", "specials", "devices_specials"]
     )]
     pub no_D: bool,
-    #[cfg(feature = "xattr")]
     #[arg(long, help_heading = "Attributes")]
     pub xattrs: bool,
-    #[cfg(feature = "acl")]
     #[arg(
         short = 'A',
         long,
@@ -403,7 +401,6 @@ pub(crate) struct ClientOpts {
         overrides_with = "no_acls"
     )]
     pub acls: bool,
-    #[cfg(feature = "acl")]
     #[arg(long = "no-acls", help_heading = "Attributes", overrides_with = "acls")]
     pub no_acls: bool,
     #[arg(long = "fake-super", help_heading = "Attributes")]

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -12,7 +12,7 @@ compress = { path = "../compress" }
 filelist = { path = "../filelist" }
 protocol = { path = "../protocol" }
 nix = { version = "0.27", features = ["user", "fs"] }
-meta = { path = "../meta", default-features = false }
+meta = { path = "../meta" }
 logging = { path = "../logging" }
 libc = "0.2"
 memmap2 = "0.9"
@@ -45,7 +45,7 @@ name = "preallocate"
 harness = false
 
 [features]
-default = ["zstd"]
+default = ["zstd", "xattr", "acl"]
 zstd = []
-xattr = ["meta/xattr"]
-acl = ["meta/acl"]
+xattr = []
+acl = []

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -11,22 +11,11 @@ tracing = "0.1"
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.27", features = ["fs", "user"] }
 users = "0.11"
+xattr = "1.5"
+posix-acl = "1.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "0.5"
-
-[dependencies.xattr]
-version = "1.5"
-optional = true
-
-[dependencies.posix-acl]
-version = "1.2"
-optional = true
-
-[features]
-default = []
-xattr = ["dep:xattr"]
-acl = ["dep:posix-acl"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -58,9 +58,9 @@ impl Options {
 use filetime::set_symlink_file_times;
 use filetime::{set_file_times, FileTime};
 use std::collections::HashMap;
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 use std::collections::HashSet;
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 use std::ffi::{OsStr, OsString};
 use std::fs;
 use std::io;
@@ -192,7 +192,7 @@ impl HardLinks {
     }
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 pub(crate) fn should_ignore_xattr_error(err: &io::Error) -> bool {
     matches!(
         err.raw_os_error(),
@@ -205,7 +205,7 @@ pub(crate) fn should_ignore_xattr_error(err: &io::Error) -> bool {
     )
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 pub fn apply_xattrs(
     path: &Path,
     xattrs: &[(OsString, Vec<u8>)],
@@ -284,5 +284,5 @@ impl UidTable {
     }
 }
 
-#[cfg(feature = "acl")]
+#[cfg(unix)]
 pub use posix_acl::{ACLEntry, PosixACL, Qualifier, ACL_EXECUTE, ACL_READ, ACL_RWX, ACL_WRITE};

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 #[cfg(unix)]
 use tempfile::tempdir;
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 use posix_acl::{PosixACL, Qualifier, ACL_READ, ACL_WRITE};
 
 #[cfg(unix)]
@@ -42,7 +42,7 @@ fn spawn_daemon(root: &std::path::Path) -> (Child, u16) {
     (child, port)
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 fn spawn_rsync_daemon_acl(root: &std::path::Path) -> (Child, u16) {
     let port = TcpListener::bind("127.0.0.1:0")
         .unwrap()
@@ -80,7 +80,7 @@ fn wait_for_daemon(port: u16) {
     panic!("daemon did not start");
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 fn try_set_xattr(path: &std::path::Path, name: &str, value: &[u8]) -> bool {
     match xattr::set(path, name, value) {
         Ok(()) => true,
@@ -89,7 +89,7 @@ fn try_set_xattr(path: &std::path::Path, name: &str, value: &[u8]) -> bool {
     }
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 fn spawn_rsync_daemon_xattr(root: &std::path::Path) -> (Child, u16) {
     let port = TcpListener::bind("127.0.0.1:0")
         .unwrap()
@@ -121,7 +121,7 @@ fn spawn_rsync_daemon_xattr(root: &std::path::Path) -> (Child, u16) {
     (child, port)
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 #[ignore]
 #[serial]
@@ -171,7 +171,7 @@ fn daemon_preserves_xattrs() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_preserves_symlink_xattrs_rr_client() {
@@ -206,7 +206,7 @@ fn daemon_preserves_symlink_xattrs_rr_client() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_preserves_xattrs_rr_client() {
@@ -260,7 +260,7 @@ fn daemon_preserves_xattrs_rr_client() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 #[ignore]
 #[serial]
@@ -315,7 +315,7 @@ fn daemon_preserves_xattrs_rr_daemon() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 #[ignore]
 #[serial]
@@ -361,7 +361,7 @@ fn daemon_excludes_filtered_xattrs() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 #[ignore]
 #[serial]
@@ -408,7 +408,7 @@ fn daemon_excludes_filtered_xattrs_rr_client() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_xattrs_match_rsync_server() {
@@ -451,7 +451,7 @@ fn daemon_xattrs_match_rsync_server() {
     assert_eq!(val_oc, val_rs);
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_preserves_acls() {
@@ -493,7 +493,7 @@ fn daemon_preserves_acls() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_preserves_acls_rr_client() {
@@ -536,7 +536,7 @@ fn daemon_preserves_acls_rr_client() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_removes_acls() {
@@ -577,7 +577,7 @@ fn daemon_removes_acls() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_ignores_acls_without_flag() {
@@ -610,7 +610,7 @@ fn daemon_ignores_acls_without_flag() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_inherits_default_acls() {
@@ -654,7 +654,7 @@ fn daemon_inherits_default_acls() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_inherits_default_acls_rr_client() {
@@ -699,7 +699,7 @@ fn daemon_inherits_default_acls_rr_client() {
     let _ = child.wait();
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_acls_match_rsync_server() {
@@ -751,7 +751,7 @@ fn daemon_acls_match_rsync_server() {
     assert_eq!(dacl_oc.entries(), dacl_rs.entries());
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 #[serial]
 fn daemon_acls_match_rsync_client() {

--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -109,7 +109,7 @@ fn sync_keep_dirlinks_preserves_symlinked_dir() {
     assert!(dst.join("sub/file").exists());
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 fn sync_preserves_xattrs() {
     let tmp = tempdir().unwrap();
@@ -134,7 +134,7 @@ fn sync_preserves_xattrs() {
     assert_eq!(&val[..], b"val");
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 fn sync_preserves_symlink_xattrs() {
     let tmp = tempdir().unwrap();
@@ -159,7 +159,7 @@ fn sync_preserves_symlink_xattrs() {
     assert_eq!(&val[..], b"val");
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 fn sync_preserves_acls() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -198,7 +198,7 @@ fn sync_preserves_acls() {
     assert_eq!(dacl_src.entries(), dacl_dst.entries());
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 fn sync_xattrs_match_rsync() {
     let tmp = tempdir().unwrap();
@@ -233,7 +233,7 @@ fn sync_xattrs_match_rsync() {
     assert_eq!(val_oc, val_rs);
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 fn sync_acls_match_rsync() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -276,7 +276,7 @@ fn sync_acls_match_rsync() {
     assert_eq!(dacl_oc.entries(), dacl_rs.entries());
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 fn sync_removes_acls() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -312,7 +312,7 @@ fn sync_removes_acls() {
     assert!(dacl_dst.entries().is_empty());
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 fn sync_removes_acls_match_rsync() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -361,7 +361,7 @@ fn sync_removes_acls_match_rsync() {
     assert_eq!(dacl_oc.entries(), dacl_rs.entries());
 }
 
-#[cfg(all(unix, feature = "acl"))]
+#[cfg(unix)]
 #[test]
 fn sync_ignores_acls_without_flag() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -1034,7 +1034,7 @@ fn sync_follows_symlinks() {
     assert_eq!(fs::read(dst.join("link")).unwrap(), b"hi");
 }
 
-#[cfg(all(unix, feature = "xattr"))]
+#[cfg(unix)]
 #[test]
 fn sync_copy_links_preserves_xattrs() {
     let tmp = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- Enable ACL and xattr features by default across the workspace
- Remove conditional compilation for ACL/xattr in meta and CLI crates
- Run xattr and ACL regression tests on Unix by default

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: daemon_preserves_hard_links_remote_source)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9345095b48323ae4ee8d10858e463