### PR TITLE
Use cargo nextest for workspace tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Test with coverage (95% lines & functions)
-        run: cargo llvm-cov nextest --all-features --fail-under-lines 95 --fail-under-functions 95 --html
+        run: cargo llvm-cov nextest --all-features --fail-under-lines 95 --fail-under-functions 95 --html -- --no-fail-fast
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/daily-status.yml
+++ b/.github/workflows/daily-status.yml
@@ -19,7 +19,8 @@ jobs:
           toolchain: stable
           override: true
       - run: cargo install cargo-llvm-cov
-      - run: mkdir -p reports && cargo llvm-cov --workspace --json --summary-only --output-path reports/coverage.json
+      - run: cargo install cargo-nextest
+      - run: mkdir -p reports && cargo llvm-cov nextest --workspace --json --summary-only --output-path reports/coverage.json -- --no-fail-fast
       - run: cargo run --package xtask --bin status
 
       - name: Generate status report

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,12 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-llvm-cov
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - name: Test with coverage
-        run: cargo llvm-cov --all-features --fail-under-lines 95
+        run: cargo llvm-cov nextest --all-features --fail-under-lines 95 -- --no-fail-fast
       - name: Validate interop matrix docs
         run: scripts/check-run-matrix-docs.sh
       - name: Cross-compile check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,7 +183,7 @@ This agent architecture provides a **clean separation of responsibilities** and 
 - Lint with `cargo clippy --all-targets --all-features -- -D warnings`.
 
 ### Mandatory Checks
-- Run `cargo test` and ensure all tests pass.
+- Run `cargo nextest run --workspace --no-fail-fast` (and `--all-features`) and ensure all tests pass.
 - Execute `make verify-comments` to validate file header comments.
 - Use `make lint` to confirm formatting.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ headers:
 5. A maintainer will review your PR and may request changes.
 
 ## Testing Requirements
-- Ensure `cargo test` passes locally.
+- Ensure `cargo nextest run --workspace --no-fail-fast` (and `--all-features`) passes locally.
 - Add or update tests for any new code.
 - Prefer small, focused commits that each pass the test suite.
 
@@ -54,7 +54,8 @@ environment:
 LC_ALL=C LANG=C COLUMNS=80 TZ=UTC make test
 ```
 
-The `make test` target exports these variables automatically.
+The `make test` target exports these variables automatically and runs
+`cargo nextest run --workspace --no-fail-fast`.
 
 ## Fetching upstream rsync
 Some interop tests require the official rsync sources. Use the helper

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ doc:
 	cargo doc --no-deps --all-features
 
 test:
-	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo test
-	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo test --all-features
+	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast
+	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --all-features
 
 coverage:
-	cargo llvm-cov --workspace --doctests \
-		--fail-under-lines 95 --fail-under-functions 95
+	cargo llvm-cov nextest --workspace --doctests \
+		--fail-under-lines 95 --fail-under-functions 95 -- --no-fail-fast
 
 interop:
 	@bash tests/interop/run_matrix.sh

--- a/bin/oc-rsync/Cargo.toml
+++ b/bin/oc-rsync/Cargo.toml
@@ -14,6 +14,7 @@ engine = { path = "../../crates/engine" }
 logging = { path = "../../crates/logging" }
 protocol = { path = "../../crates/protocol" }
 clap = { version = "4" }
+libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/crates/cli/tests/multiple_sources.rs
+++ b/crates/cli/tests/multiple_sources.rs
@@ -1,4 +1,5 @@
 // crates/cli/tests/multiple_sources.rs
+use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;
@@ -61,8 +62,8 @@ fn multiple_source_parity() {
             &format!("{}/", src2.display()),
         ])
         .arg(&dst_up)
-        .status()
-        .unwrap();
+        .assert()
+        .success();
 
     Command::cargo_bin("oc-rsync")
         .unwrap()
@@ -72,8 +73,8 @@ fn multiple_source_parity() {
             &format!("{}/", src2.display()),
             dst_ours.to_str().unwrap(),
         ])
-        .status()
-        .unwrap();
+        .assert()
+        .success();
 
     let up = collect(&dst_up);
     let ours = collect(&dst_ours);

--- a/crates/filters/tests/include_from.rs
+++ b/crates/filters/tests/include_from.rs
@@ -7,7 +7,7 @@ use std::collections::HashSet;
 fn include_from_null_separated() {
     let data = b"foo\0bar\0";
     let mut v = HashSet::new();
-    let rules = parse_rule_list_from_bytes(data, true, '+', &mut v, 0).unwrap();
+    let rules = parse_rule_list_from_bytes(data, true, '+', &mut v, 0, None).unwrap();
     let matcher = Matcher::new(rules);
     assert!(matcher.is_included("foo").unwrap());
     assert!(matcher.is_included("bar").unwrap());
@@ -18,7 +18,7 @@ fn include_from_null_separated() {
 fn exclude_from_null_separated() {
     let data = b"foo\0bar\0";
     let mut v = HashSet::new();
-    let rules = parse_rule_list_from_bytes(data, true, '-', &mut v, 0).unwrap();
+    let rules = parse_rule_list_from_bytes(data, true, '-', &mut v, 0, None).unwrap();
     let matcher = Matcher::new(rules);
     assert!(!matcher.is_included("foo").unwrap());
     assert!(!matcher.is_included("bar").unwrap());
@@ -37,10 +37,10 @@ proptest! {
             bytes.push(0);
         }
         let mut v0 = HashSet::new();
-        let rules0 = parse_rule_list_from_bytes(&bytes, true, '+', &mut v0, 0).unwrap();
+        let rules0 = parse_rule_list_from_bytes(&bytes, true, '+', &mut v0, 0, None).unwrap();
         let mut v1 = HashSet::new();
         let joined = entries.iter().map(|s| s.as_str()).collect::<Vec<_>>().join("\n");
-        let rules1 = parse_rule_list_from_bytes(joined.as_bytes(), false, '+', &mut v1, 0).unwrap();
+        let rules1 = parse_rule_list_from_bytes(joined.as_bytes(), false, '+', &mut v1, 0, None).unwrap();
         let m0 = Matcher::new(rules0);
         let m1 = Matcher::new(rules1);
         for e in entries {

--- a/tests/compression_negotiation.sh
+++ b/tests/compression_negotiation.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # Run compression codec negotiation tests from the compress crate
-cargo test -p compress --test codecs -- negotiation_helper_picks_common_codec
+cargo nextest run --no-fail-fast -p compress --test codecs -- --exact negotiation_helper_picks_common_codec
 
 # Engine should prefer zstd when both peers support it
-cargo test -p engine --test compress -- codec_selection_prefers_zstd
+cargo nextest run --no-fail-fast -p engine --test compress -- --exact codec_selection_prefers_zstd
 
 # Protocol handshake exchanges codec lists using Message::Codecs
-cargo test -p protocol --test server -- server_negotiates_version
+cargo nextest run --no-fail-fast -p protocol --test server -- --exact server_negotiates_version
 
 # Stock rsync falls back to zlib when it doesn't support codec lists
-cargo test -p oc-rsync --test rsync_zlib -- rsync_client_falls_back_to_zlib
+cargo nextest run --no-fail-fast -p oc-rsync --test rsync_zlib -- --exact rsync_client_falls_back_to_zlib

--- a/tests/daemon_auth.sh
+++ b/tests/daemon_auth.sh
@@ -2,10 +2,10 @@
 set -euo pipefail
 
 # Execute daemon authentication tests individually for clarity
-cargo test --test daemon -- --exact daemon_rejects_invalid_token
-cargo test --test daemon -- --exact daemon_rejects_unauthorized_module
-cargo test --test daemon -- --exact daemon_accepts_authorized_client
-cargo test --test daemon -- --exact client_authenticates_with_password_file
-cargo test --test daemon -- --exact client_respects_no_motd
-cargo test --test daemon -- --exact daemon_logs_connections
-cargo test --test daemon -- --exact daemon_honors_bwlimit
+cargo nextest run --no-fail-fast --test daemon -- --exact daemon_rejects_invalid_token
+cargo nextest run --no-fail-fast --test daemon -- --exact daemon_rejects_unauthorized_module
+cargo nextest run --no-fail-fast --test daemon -- --exact daemon_accepts_authorized_client
+cargo nextest run --no-fail-fast --test daemon -- --exact client_authenticates_with_password_file
+cargo nextest run --no-fail-fast --test daemon -- --exact client_respects_no_motd
+cargo nextest run --no-fail-fast --test daemon -- --exact daemon_logs_connections
+cargo nextest run --no-fail-fast --test daemon -- --exact daemon_honors_bwlimit

--- a/tests/daemon_features.sh
+++ b/tests/daemon_features.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cargo test --test daemon -- --exact host_allow_supports_cidr
-cargo test --test daemon -- --exact daemon_refuses_configured_option
-cargo test --test daemon -- --exact daemon_refuses_numeric_ids_option
-cargo test --test daemon -- --exact daemon_refuses_no_numeric_ids_option
-cargo test --test daemon -- --exact chroot_drops_privileges
-cargo test --test daemon -- --exact chroot_requires_root
-cargo test --test daemon -- --exact chroot_and_drop_privileges_rejects_missing_dir
-cargo test --test daemon -- --exact drop_privileges_requires_root
+cargo nextest run --no-fail-fast --test daemon -- --exact host_allow_supports_cidr
+cargo nextest run --no-fail-fast --test daemon -- --exact daemon_refuses_configured_option
+cargo nextest run --no-fail-fast --test daemon -- --exact daemon_refuses_numeric_ids_option
+cargo nextest run --no-fail-fast --test daemon -- --exact daemon_refuses_no_numeric_ids_option
+cargo nextest run --no-fail-fast --test daemon -- --exact chroot_drops_privileges
+cargo nextest run --no-fail-fast --test daemon -- --exact chroot_requires_root
+cargo nextest run --no-fail-fast --test daemon -- --exact chroot_and_drop_privileges_rejects_missing_dir
+cargo nextest run --no-fail-fast --test daemon -- --exact drop_privileges_requires_root


### PR DESCRIPTION
## Summary
- run tests with `cargo nextest run --workspace --no-fail-fast`
- install `cargo-nextest` in CI workflows and daily status job
- document the new test command for contributors and agents

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: missing field `blocking_io` in `SshStdioTransport`)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: linker error: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68b9345488788323ae8d3a51027ab1c2