### PR TITLE
Reduce sparse test file size

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3582,9 +3582,9 @@ fn sparse_files_preserved() {
     std::fs::create_dir_all(&dst).unwrap();
     let sp = src.join("sparse");
     let mut f = File::create(&sp).unwrap();
-    f.seek(SeekFrom::Start(1 << 20)).unwrap();
+    f.seek(SeekFrom::Start(1 << 17)).unwrap();
     f.write_all(b"end").unwrap();
-    f.set_len(1 << 21).unwrap();
+    f.set_len(1 << 18).unwrap();
 
     let src_arg = format!("{}/", src.display());
     Command::cargo_bin("oc-rsync")
@@ -3617,7 +3617,7 @@ fn sparse_files_created() {
     std::fs::create_dir_all(&dst).unwrap();
     let zs = src.join("zeros");
     let mut f = File::create(&zs).unwrap();
-    f.write_all(&vec![0u8; 1 << 20]).unwrap();
+    f.write_all(&vec![0u8; 1 << 18]).unwrap();
 
     let src_arg = format!("{}/", src.display());
     Command::cargo_bin("oc-rsync")

--- a/tests/specials_parity.rs
+++ b/tests/specials_parity.rs
@@ -1,3 +1,4 @@
+// tests/specials_parity.rs
 use assert_cmd::prelude::*;
 use std::process::Command;
 use std::str;


### PR DESCRIPTION
## Summary
- shrink sparse file lengths in CLI tests for quicker runs
- ensure comment header on specials_parity test

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo nextest run --all-features --workspace --no-fail-fast` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ea9f8188323a0cdf250717dbac6