### PR TITLE
Add prework report for failing tests and checks

### DIFF
--- a/reports/prework.md
+++ b/reports/prework.md
@@ -1,0 +1,27 @@
+# Prework Report
+
+## `cargo nextest run --workspace --no-fail-fast`
+- **Status:** Failed
+- **Details:** Linker error: `/usr/bin/ld: cannot find -lacl`
+- **Impacted tests:** `engine` crate tests (e.g., `streaming`), `oc-rsync-bin` binary tests
+- **Applied fixes:** None
+- **Remaining risks:** Missing ACL development library blocks building and testing
+
+## `cargo nextest run --workspace --all-features --no-fail-fast`
+- **Status:** Failed
+- **Details:** Linker error: `/usr/bin/ld: cannot find -lacl`
+- **Impacted components:** `protocol` crate tests
+- **Applied fixes:** None
+- **Remaining risks:** Same as above; cannot exercise all features without ACL library
+
+## `make verify-comments`
+- **Status:** Failed
+- **Details:** `tests/specials_parity.rs` reports `incorrect header`
+- **Applied fixes:** None
+- **Remaining risks:** Comment formatting check fails until headers corrected
+
+## `cargo clippy --all-targets --all-features -- -D warnings`
+- **Status:** Passed
+
+## `make lint`
+- **Status:** Passed (`cargo fmt --all --check`)


### PR DESCRIPTION
## Summary
- run workspace tests and document missing `libacl` linkage errors
- note comment header failure in `tests/specials_parity.rs`
- record results of lint and clippy checks

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments` *(fails: tests/specials_parity.rs incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9412fe11883238fe88d3d1808654f