### PR TITLE
docs: add prework test report

### DIFF
--- a/reports/prework.md
+++ b/reports/prework.md
@@ -1,0 +1,24 @@
+# Prework Test Report
+
+This document tracks the current state of failing tests in `oc-rsync` ahead of broader stabilization work. Update it whenever tests are fixed or new failures are introduced.
+
+## Failing tests
+
+- Test suite does not run under default configuration: `cargo test --workspace` fails during linking because the system `libacl` library is missing.
+- Integration and CLI tests (e.g., `archive_matches_combination_and_rsync`, `checksum_forces_transfer_cli`) fail with usage errors when required positional arguments are rejected.
+
+## Root causes
+
+- Missing system dependency `libacl` prevents binaries from linking when ACL support is enabled.
+- CLI argument parser is incomplete, causing valid invocations to be treated as missing required arguments.
+
+## Remediation
+
+- Install the required `libacl` development package on the build system so tests can link successfully.
+- Implement remaining CLI options and positional argument handling to accept standard rsync invocations.
+
+## Residual risks
+
+- Additional tests may uncover further missing dependencies or unimplemented features once the current blockers are resolved.
+
+> **Note:** Future contributors should update this file whenever they stabilize tests or introduce new failures.


### PR DESCRIPTION
## Summary
- document current failing tests and causes
- note remediation steps and future maintenance for contributors

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cargo-nextest not installed)*
- `cargo test --workspace` *(fails: missing libacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9426fd67c83238f8f60efed2a8846