### PR TITLE
docs: drop hard-link gap

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,8 +41,7 @@ kept up to date from their results.
 
 * SSH and daemon transports are functional but still early implementations and
   may diverge from classic `rsync` behavior.
-* Filters, sparse files, and compression work across transports. Hard links are
-  not yet supported.
+* Filters, sparse files, compression, and hard links work across transports.
 * Extended attributes and ACLs are available only when built with the `xattr`
   and `acl` feature gates and are exercised by round-trip tests.
 * Filesystem differences (case sensitivity, permissions) across platforms may

--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,8 +1,5 @@
 # Differences
 
-- **Hard links**: classic `rsync` preserves hard links, while `oc-rsync` currently skips them.
-  _Planned resolution_: implement hard-link tracking in the file list and engine.
-
 - **Transport edge cases**: SSH and daemon transports are early implementations and may diverge from classic `rsync` behavior.
   _Planned resolution_: expand interoperability tests and align protocol handling with upstream.
 


### PR DESCRIPTION
## Summary
- remove obsolete hard-link entry from differences
- update compatibility notes to reflect hard-link support

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9426a97d483239de9d3e5389a9d3f