### PR TITLE
systemd: use single ExecStart

### DIFF
--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -14,8 +14,11 @@ RuntimeDirectory=oc-rsyncd
 LogsDirectory=oc-rsyncd
 StateDirectory=oc-rsyncd
 ConfigurationDirectory=oc-rsyncd
-ExecStart=/usr/local/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf
 ExecStart=/usr/local/bin/oc-rsyncd --no-detach --config=/etc/oc-rsyncd.conf
+# To run the daemon via the main oc-rsync CLI instead of the dedicated oc-rsyncd
+# binary, create a drop-in with the following lines:
+# ExecStart=
+# ExecStart=/usr/local/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf
 Restart=on-failure
 RestartSec=2s
 NoNewPrivileges=yes

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -47,7 +47,6 @@ fn service_unit_matches_spec() {
         "ProtectHome=true",
         "Restart=on-failure",
         "RestartSec=2s",
-        "ExecStart=/usr/local/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf",
         "CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_CHOWN CAP_DAC_OVERRIDE",
         "AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_CHOWN CAP_DAC_OVERRIDE",
         "RestrictNamespaces=yes",
@@ -56,6 +55,10 @@ fn service_unit_matches_spec() {
         "StateDirectory=oc-rsyncd",
         "ConfigurationDirectory=oc-rsyncd",
         "ExecStart=/usr/local/bin/oc-rsyncd --no-detach --config=/etc/oc-rsyncd.conf",
+        "# To run the daemon via the main oc-rsync CLI instead of the dedicated oc-rsyncd",
+        "# binary, create a drop-in with the following lines:",
+        "# ExecStart=",
+        "# ExecStart=/usr/local/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf",
         "Documentation=man:oc-rsyncd(8) man:oc-rsyncd.conf(5) man:oc-rsync(1)",
     ] {
         assert!(


### PR DESCRIPTION
## Summary
- streamline oc-rsyncd systemd unit to a single ExecStart and note how to run via oc-rsync
- update packaging test for new ExecStart and comments

## Testing
- `systemd-analyze verify packaging/systemd/oc-rsyncd.service`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `acls_roundtrip` redefined)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: `acls_roundtrip` redefined)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b94273f0388323a0c48530954b9561