### PR TITLE
feat(cli): add branding placeholders

### DIFF
--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -3,35 +3,36 @@ use std::env;
 
 pub const DEFAULT_BRAND_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_BRAND_CREDITS: &str =
-    "Automatic Rust re-implementation of rsync semantics by Ofer Chen (2025). Not affiliated with Samba.";
+    "Automatic Rust re-implementation by Ofer Chen (2025). Not affiliated with Samba.";
+pub const DEFAULT_BRAND_URL: &str = "https://github.com/oc-rsync/oc-rsync";
 
 pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
 {credits}
 
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+{prog} comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
 are welcome to redistribute it under certain conditions.  See the GNU
 General Public Licence for details.
 
-rsync is a file transfer program capable of efficient remote update
+{prog} is a file transfer program capable of efficient remote update
 via a fast differencing algorithm.
 
-Usage: rsync [OPTION]... SRC [SRC]... DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
-  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
-  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
-  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
-  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
-The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
-to an rsync daemon, and require SRC or DEST to start with a module name.
+Usage: {prog} [OPTION]... SRC [SRC]... DEST
+  or   {prog} [OPTION]... SRC [SRC]... [USER@]HOST:DEST
+  or   {prog} [OPTION]... SRC [SRC]... [USER@]HOST::DEST
+  or   {prog} [OPTION]... SRC [SRC]... {prog}://[USER@]HOST[:PORT]/DEST
+  or   {prog} [OPTION]... [USER@]HOST:SRC [DEST]
+  or   {prog} [OPTION]... [USER@]HOST::SRC [DEST]
+  or   {prog} [OPTION]... {prog}://[USER@]HOST[:PORT]/SRC [DEST]
+The ':' usages connect via remote shell, while '::' & '{prog}://' usages connect
+to an {prog} daemon, and require SRC or DEST to start with a module name.
 
 Options
 "#;
 
 pub const DEFAULT_HELP_SUFFIX: &str = r#"
-Use "rsync --daemon --help" to see the daemon-mode command-line options.
-Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
-See https://rsync.samba.org/ for updates, bug reports, and answers
+Use "{prog} --daemon --help" to see the daemon-mode command-line options.
+Please see the {prog}(1) and {prog}d.conf(5) manpages for full documentation.
+For project updates and documentation, visit {url}.
 "#;
 
 pub fn program_name() -> String {
@@ -64,8 +65,24 @@ pub fn brand_credits() -> String {
         .unwrap_or_else(|_| DEFAULT_BRAND_CREDITS.to_string())
 }
 
+pub fn brand_url() -> String {
+    env::var("OC_RSYNC_BRAND_URL")
+        .or_else(|_| {
+            option_env!("OC_RSYNC_BRAND_URL")
+                .map(str::to_string)
+                .ok_or(env::VarError::NotPresent)
+        })
+        .unwrap_or_else(|_| DEFAULT_BRAND_URL.to_string())
+}
+
 pub fn help_prefix() -> String {
-    env::var("OC_RSYNC_BRAND_HEADER")
+    env::var("OC_RSYNC_HELP_HEADER")
+        .or_else(|_| env::var("OC_RSYNC_BRAND_HEADER"))
+        .or_else(|_| {
+            option_env!("OC_RSYNC_HELP_HEADER")
+                .map(str::to_string)
+                .ok_or(env::VarError::NotPresent)
+        })
         .or_else(|_| {
             option_env!("OC_RSYNC_BRAND_HEADER")
                 .map(str::to_string)
@@ -75,7 +92,13 @@ pub fn help_prefix() -> String {
 }
 
 pub fn help_suffix() -> String {
-    env::var("OC_RSYNC_BRAND_FOOTER")
+    env::var("OC_RSYNC_HELP_FOOTER")
+        .or_else(|_| env::var("OC_RSYNC_BRAND_FOOTER"))
+        .or_else(|_| {
+            option_env!("OC_RSYNC_HELP_FOOTER")
+                .map(str::to_string)
+                .ok_or(env::VarError::NotPresent)
+        })
         .or_else(|_| {
             option_env!("OC_RSYNC_BRAND_FOOTER")
                 .map(str::to_string)

--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -184,13 +184,15 @@ pub fn render_help(cmd: &Command) -> String {
     let program = branding::program_name();
     let version = branding::brand_version();
     let credits = branding::brand_credits();
+    let url = branding::brand_url();
     let mut help_prefix = branding::help_prefix();
     let mut help_suffix = branding::help_suffix();
     for s in [&mut help_prefix, &mut help_suffix] {
         *s = s
             .replace("{prog}", &program)
             .replace("{version}", &version)
-            .replace("{credits}", &credits);
+            .replace("{credits}", &credits)
+            .replace("{url}", &url);
     }
     if width == 80 {
         let prefix_end = match RSYNC_HELP.find(UPSTREAM_HELP_PREFIX) {

--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -15,7 +15,6 @@ const UPSTREAM_PROTOCOLS: &str = match option_env!("UPSTREAM_PROTOCOLS") {
 };
 
 const COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
-const WEBSITE: &str = "Web site: https://github.com/oc-rsync/oc-rsync";
 const CAPABILITIES: &[&str] = &[
     "    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,",
     "    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,",
@@ -50,7 +49,7 @@ pub fn render_version_lines() -> Vec<String> {
         option_env!("OFFICIAL_BUILD").unwrap_or("unofficial")
     ));
     lines.push(COPYRIGHT.to_string());
-    lines.push(WEBSITE.to_string());
+    lines.push(format!("Web site: {}", branding::brand_url()));
     lines.push("Capabilities:".to_string());
     lines.extend(CAPABILITIES.iter().map(|s| (*s).to_string()));
     lines.push("Optimizations:".to_string());

--- a/tests/fixtures/oc-rsync-help.txt
+++ b/tests/fixtures/oc-rsync-help.txt
@@ -1,19 +1,5 @@
-rsync  version 3.2.7  protocol version 31
-Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.
-Web site: https://rsync.samba.org/
-Capabilities:
-    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
-    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
-    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
-    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
-Optimizations:
-    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
-Checksum list:
-    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
-Compress list:
-    zstd lz4 zlibx zlib none
-Daemon auth list:
-    sha512 sha256 sha1 md5 md4
+oc-rsync 0.1.0
+Automatic Rust re-implementation by Ofer Chen (2025). Not affiliated with Samba.
 
 oc-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
 are welcome to redistribute it under certain conditions.  See the GNU
@@ -33,138 +19,154 @@ The ':' usages connect via remote shell, while '::' & 'oc-rsync://' usages conne
 to an oc-rsync daemon, and require SRC or DEST to start with a module name.
 
 Options
---verbose, -v            
---info=FLAGS             
---debug=FLAGS            
---quiet, -q              
---no-motd                
---checksum, -c           
---archive, -a            
---recursive, -r          
---relative, -R           
---no-implied-dirs        
---backup, -b             
---backup-dir=DIR         
---suffix=SUFFIX          
---update, -u             
---inplace                
---append                 
---append-verify          
---dirs, -d               
+--verbose, -v            increase verbosity
+--info=FLAGS             fine-grained informational verbosity
+--debug=FLAGS            fine-grained debug verbosity
+--stderr=e|a|c           change stderr output mode (default: errors)
+--quiet, -q              suppress non-error messages
+--no-motd                suppress daemon-mode MOTD
+--checksum, -c           skip based on checksum, not mod-time & size
+--archive, -a            archive mode is -rlptgoD (no -A,-X,-U,-N,-H)
+--no-OPTION              turn off an implied OPTION (e.g. --no-D)
+--recursive, -r          recurse into directories
+--relative, -R           use relative path names
+--no-implied-dirs        don't send implied dirs with --relative
+--backup, -b             make backups (see --suffix & --backup-dir)
+--backup-dir=DIR         make backups into hierarchy based in DIR
+--suffix=SUFFIX          backup suffix (default ~ w/o --backup-dir)
+--update, -u             skip files that are newer on the receiver
+--inplace                update destination files in-place
+--append                 append data onto shorter files
+--append-verify          --append w/old data in file checksum
+--dirs, -d               transfer directories without recursing
+--old-dirs, --old-d      works like --dirs when talking to old rsync
 --mkpath                 create destination's missing path components
---links, -l              
---copy-links, -L         
---copy-unsafe-links      
---safe-links             
+--links, -l              copy symlinks as symlinks
+--copy-links, -L         transform symlink into referent file/dir
+--copy-unsafe-links      only "unsafe" symlinks are transformed
+--safe-links             ignore symlinks that point outside the tree
 --munge-links            munge symlinks to make them safe & unusable
---copy-dirlinks, -k      
---keep-dirlinks, -K      
---hard-links, -H         
---perms, -p              
---executability, -E      
---chmod=CHMOD            
---owner, -o              
---group, -g              
---devices                
---copy-devices           
+--copy-dirlinks, -k      transform symlink to dir into referent dir
+--keep-dirlinks, -K      treat symlinked dir on receiver as dir
+--hard-links, -H         preserve hard links
+--perms, -p              preserve permissions
+--executability, -E      preserve executability
+--chmod=CHMOD            affect file and/or directory permissions
+--acls, -A               preserve ACLs (implies --perms)
+--xattrs, -X             preserve extended attributes
+--owner, -o              preserve owner (super-user only)
+--group, -g              preserve group
+--devices                preserve device files (super-user only)
+--copy-devices           copy device contents as a regular file
 --write-devices          write to devices as files (implies --inplace)
---specials               
--D                       
---no-D                   
---times, -t              
---atimes, -U             
---crtimes, -N            
---omit-dir-times, -O     
---omit-link-times, -J    
---fake-super             
---sparse, -S             
+--specials               preserve special files
+-D                       same as --devices --specials
+--times, -t              preserve modification times
+--atimes, -U             preserve access (use) times
+--open-noatime           avoid changing the atime on opened files
+--crtimes, -N            preserve create times (newness)
+--omit-dir-times, -O     omit directories from --times
+--omit-link-times, -J    omit symlinks from --times
+--super                  receiver attempts super-user activities
+--fake-super             store/recover privileged attrs using xattrs
+--sparse, -S             turn sequences of nulls into sparse blocks
 --preallocate            allocate dest files before writing them
---dry-run, -n            
---whole-file, -W         
---checksum-choice=STR    
---one-file-system, -x    
---block-size=SIZE, -B    
---rsh=COMMAND, -e        
---rsync-path=PATH        
---existing               
---ignore-existing        
---remove-source-files    
---delete                 
---delete-before          
---delete-during          
---delete-delay           
---delete-after           
---delete-excluded        
---ignore-missing-args    
---delete-missing-args    
---ignore-errors          
+--dry-run, -n            perform a trial run with no changes made
+--whole-file, -W         copy files whole (w/o delta-xfer algorithm)
+--checksum-choice=STR    choose the checksum algorithm (aka --cc)
+--one-file-system, -x    don't cross filesystem boundaries
+--block-size=SIZE, -B    force a fixed checksum block-size
+--rsh=COMMAND, -e        specify the remote shell to use
+--rsync-path=PROGRAM     specify the rsync to run on remote machine
+--existing               skip creating new files on receiver
+--ignore-existing        skip updating files that exist on receiver
+--remove-source-files    sender removes synchronized files (non-dir)
+--del                    an alias for --delete-during
+--delete                 delete extraneous files from dest dirs
+--delete-before          receiver deletes before xfer, not during
+--delete-during          receiver deletes during the transfer
+--delete-delay           find deletions during, delete after
+--delete-after           receiver deletes after transfer, not during
+--delete-excluded        also delete excluded files from dest dirs
+--ignore-missing-args    ignore missing source args without error
+--delete-missing-args    delete missing source args from destination
+--ignore-errors          delete even if there are I/O errors
 --force                  force deletion of dirs even if not empty
---max-delete=NUM         
---max-size=SIZE          
---min-size=SIZE          
---max-alloc=SIZE         
---partial                
---partial-dir=DIR        
---delay-updates          
---prune-empty-dirs, -m   
---numeric-ids            
---usermap=FROM:TO        
---groupmap=FROM:TO       
---chown=USER:GROUP       
---timeout=SECONDS        
---connect-timeout=SECONDS  
---ignore-times, -I       
---size-only              
---modify-window=SECONDS  
---temp-dir=DIR, -T       
---fuzzy, -y              
---compare-dest=DIR       
---copy-dest=DIR          
---link-dest=DIR          
---compress, -z           
---compress-choice=STR    
---compress-level=NUM     
---skip-compress=LIST     
+--max-delete=NUM         don't delete more than NUM files
+--max-size=SIZE          don't transfer any file larger than SIZE
+--min-size=SIZE          don't transfer any file smaller than SIZE
+--max-alloc=SIZE         change a limit relating to memory alloc
+--partial                keep partially transferred files
+--partial-dir=DIR        put a partially transferred file into DIR
+--delay-updates          put all updated files into place at end
+--prune-empty-dirs, -m   prune empty directory chains from file-list
+--numeric-ids            don't map uid/gid values by user/group name
+--usermap=STRING         custom username mapping
+--groupmap=STRING        custom groupname mapping
+--chown=USER:GROUP       simple username/groupname mapping
+--timeout=SECONDS        set I/O timeout in seconds
+--contimeout=SECONDS     set daemon connection timeout in seconds
+--ignore-times, -I       don't skip files that match size and time
+--size-only              skip files that match in size
+--modify-window=NUM, -@  set the accuracy for mod-time comparisons
+--temp-dir=DIR, -T       create temporary files in directory DIR
+--fuzzy, -y              find similar file for basis if no dest file
+--compare-dest=DIR       also compare destination files relative to DIR
+--copy-dest=DIR          ... and include copies of unchanged files
+--link-dest=DIR          hardlink to files in DIR when unchanged
+--compress, -z           compress file data during the transfer
+--compress-choice=STR    choose the compression algorithm (aka --zc)
+--compress-level=NUM     explicitly set compression level (aka --zl)
+--skip-compress=LIST     skip compressing files with suffix in LIST
 --cvs-exclude, -C        auto-ignore files in the same way CVS does
---filter=RULE, -f        
---filter-file=FILE       
--F                       
---exclude=PATTERN        
---exclude-from=FILE      
---include=PATTERN        
---include-from=FILE      
---files-from=FILE        
---from0, -0              
+--filter=RULE, -f        add a file-filtering RULE
+-F                       same as --filter='dir-merge /.rsync-filter'
+                         repeated: --filter='- .rsync-filter'
+--exclude=PATTERN        exclude files matching PATTERN
+--exclude-from=FILE      read exclude patterns from FILE
+--include=PATTERN        don't exclude files matching PATTERN
+--include-from=FILE      read include patterns from FILE
+--files-from=FILE        read list of source-file names from FILE
+--from0, -0              all *-from/filter files are delimited by 0s
+--old-args               disable the modern arg-protection idiom
 --secluded-args, -s      use the protocol to safely send the args
---trust-sender           
---copy-as=USER[:GROUP]   
---address=ADDRESS        
---port=PORT              
---sockopts=OPTIONS       
---blocking-io            
---stats                  
---8-bit-output, -8       
---human-readable         
---progress               
--P                       
+--trust-sender           trust the remote sender's file list
+--copy-as=USER[:GROUP]   specify user & optional group for the copy
+--address=ADDRESS        bind address for outgoing socket to daemon
+--port=PORT              specify double-colon alternate port number
+--sockopts=OPTIONS       specify custom TCP options
+--blocking-io            use blocking I/O for the remote shell
+--outbuf=N|L|B           set out buffering to None, Line, or Block
+--stats                  give some file-transfer stats
+--8-bit-output, -8       leave high-bit chars unescaped in output
+--human-readable, -h     output numbers in a human-readable format
+--progress               show progress during transfer
+-P                       same as --partial --progress
 --itemize-changes, -i    output a change-summary for all updates
 --remote-option=OPT, -M  send OPTION to the remote side only
---out-format=FORMAT      
---log-file=FILE          
---log-file-format=FMT    
---password-file=FILE     
---early-input=FILE       
---list-only              
---bwlimit=RATE           
---fsync                  
---write-batch=FILE       
+--out-format=FORMAT      output updates using the specified FORMAT
+--log-file=FILE          log what we're doing to the specified FILE
+--log-file-format=FMT    log updates using the specified FMT
+--password-file=FILE     read daemon-access password from FILE
+--early-input=FILE       use FILE for daemon's early exec input
+--list-only              list the files instead of copying them
+--bwlimit=RATE           limit socket I/O bandwidth
+--stop-after=MINS        Stop rsync after MINS minutes have elapsed
+--stop-at=y-m-dTh:m      Stop rsync at the specified point in time
+--fsync                  fsync every written file
+--write-batch=FILE       write a batched update to FILE
+--only-write-batch=FILE  like --write-batch but w/o updating dest
 --read-batch=FILE        read a batched update from FILE
---protocol=VER           force an older protocol version
+--protocol=NUM           force an older protocol version to be used
 --iconv=CONVERT_SPEC     request charset conversion of filenames
 --checksum-seed=NUM      set block/file checksum seed (advanced)
---ipv4, -4               
---ipv6, -6               
+--ipv4, -4               prefer IPv4
+--ipv6, -6               prefer IPv6
+--version, -V            print the version + other info and exit
+--help, -h (*)           show this help (* -h is help only on its own)
+
 
 Use "oc-rsync --daemon --help" to see the daemon-mode command-line options.
 Please see the oc-rsync(1) and oc-rsyncd.conf(5) manpages for full documentation.
 For project updates and documentation, visit https://github.com/oc-rsync/oc-rsync.
+

--- a/tests/fixtures/oc-rsync-version.txt
+++ b/tests/fixtures/oc-rsync-version.txt
@@ -1,8 +1,8 @@
 oc-rsync 0.1.0 (protocol 32)
-rsync unknown
+compatible with rsync unknown (protocol 32)
 unknown unofficial
-Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.
-Web site: https://rsync.samba.org/
+Copyright (C) 2024-2025 oc-rsync contributors.
+Web site: https://github.com/oc-rsync/oc-rsync
 Capabilities:
     64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
     socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
@@ -17,6 +17,6 @@ Compress list:
 Daemon auth list:
     sha512 sha256 sha1 md5 md4
 
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+oc-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
 are welcome to redistribute it under certain conditions.  See the GNU
 General Public Licence for details.

--- a/tests/golden/help/oc-rsync.help
+++ b/tests/golden/help/oc-rsync.help
@@ -1,19 +1,19 @@
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+oc-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
 are welcome to redistribute it under certain conditions.  See the GNU
 General Public Licence for details.
 
-rsync is a file transfer program capable of efficient remote update
+oc-rsync is a file transfer program capable of efficient remote update
 via a fast differencing algorithm.
 
-Usage: rsync [OPTION]... SRC [SRC]... DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
-  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
-  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
-  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
-  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
-The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
-to an rsync daemon, and require SRC or DEST to start with a module name.
+Usage: oc-rsync [OPTION]... SRC [SRC]... DEST
+  or   oc-rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
+  or   oc-rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
+  or   oc-rsync [OPTION]... SRC [SRC]... oc-rsync://[USER@]HOST[:PORT]/DEST
+  or   oc-rsync [OPTION]... [USER@]HOST:SRC [DEST]
+  or   oc-rsync [OPTION]... [USER@]HOST::SRC [DEST]
+  or   oc-rsync [OPTION]... oc-rsync://[USER@]HOST[:PORT]/SRC [DEST]
+The ':' usages connect via remote shell, while '::' & 'oc-rsync://' usages connect
+to an oc-rsync daemon, and require SRC or DEST to start with a module name.
 
 Options
 --verbose, -v            increase verbosity
@@ -163,7 +163,7 @@ Options
 --help, -h (*)           show this help (* -h is help only on its own)
 
 
-Use "rsync --daemon --help" to see the daemon-mode command-line options.
-Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
-See https://rsync.samba.org/ for updates, bug reports, and answers
+Use "oc-rsync --daemon --help" to see the daemon-mode command-line options.
+Please see the oc-rsync(1) and oc-rsyncd.conf(5) manpages for full documentation.
+For project updates and documentation, visit https://github.com/oc-rsync/oc-rsync.
 

--- a/tests/help_output.rs
+++ b/tests/help_output.rs
@@ -1,5 +1,6 @@
 // tests/help_output.rs
 use assert_cmd::Command;
+use oc_rsync_cli::branding;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fs;
@@ -27,6 +28,7 @@ fn help_contains_expected_flags() {
 
     let mut actual: HashMap<String, String> = HashMap::new();
     let mut in_options = false;
+    let stop_marker = format!("Use \"{} --daemon --help\"", branding::program_name());
     for line in String::from_utf8_lossy(&output.stdout).lines() {
         if line.trim() == "Options" {
             in_options = true;
@@ -35,7 +37,7 @@ fn help_contains_expected_flags() {
         if !in_options {
             continue;
         }
-        if line.starts_with("Use \"rsync --daemon --help\"") {
+        if line.starts_with(&stop_marker) {
             break;
         }
         if line.trim().is_empty() {


### PR DESCRIPTION
## Summary
- replace hard-coded `rsync` strings with `{prog}` placeholders
- allow help text and URLs to be customized via build/runtime env vars
- update help tests and snapshots to match configurable branding

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `xattrs_roundtrip` redefined)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: `xattrs_roundtrip` redefined)*
- `make verify-comments` *(fails: tests/specials_parity.rs incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b941230fac8323abcadd4e7824f60f