### PR TITLE
refactor: centralize branding checks

### DIFF
--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -183,19 +183,18 @@ pub fn render_help(cmd: &Command) -> String {
     let width = columns();
     let program = branding::program_name();
     let version = branding::brand_version();
-    let url = branding::brand_url();
-    let _url_line = if branding::hide_credits() {
-        String::new()
-    } else {
-        format!("\nSee {} for updates, bug reports, and answers", url)
-    };
-    let mut help_prefix = branding::help_prefix();
-    let mut help_suffix = branding::help_suffix();
     let credits = if branding::hide_credits() {
         String::new()
     } else {
-        branding::DEFAULT_BRAND_CREDITS.to_string()
+        branding::brand_tagline()
     };
+    let url = if branding::hide_credits() {
+        String::new()
+    } else {
+        branding::brand_url()
+    };
+    let mut help_prefix = branding::help_prefix();
+    let mut help_suffix = branding::help_suffix();
     for s in [&mut help_prefix, &mut help_suffix] {
         *s = s
             .replace("{prog}", &program)


### PR DESCRIPTION
## Summary
- ensure branding credits and url honor `hide_credits`
- simplify help rendering by removing unused variables

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b954756ad083239796dc11e734e9f1