### PR TITLE
refactor: remove old tagline and url_line

### DIFF
--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -186,7 +186,7 @@ pub fn render_help(cmd: &Command) -> String {
     let credits = if branding::hide_credits() {
         String::new()
     } else {
-        branding::brand_tagline()
+        branding::brand_credits()
     };
     let url = if branding::hide_credits() {
         String::new()


### PR DESCRIPTION
## Summary
- simplify help rendering by replacing old tagline and url_line with credits and url placeholders

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: linking with `cc` failed: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b957d4a40c832390d79b3336d3c354