### PR TITLE
fix: silence unused parameter in open_for_read

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -385,11 +385,11 @@ pub fn fuzzy_match(dest: &Path) -> Option<PathBuf> {
     best.map(|(_, p)| p)
 }
 
-fn open_for_read(path: &Path, opts: &SyncOptions) -> std::io::Result<File> {
+fn open_for_read(path: &Path, _opts: &SyncOptions) -> std::io::Result<File> {
     #[cfg(target_os = "linux")]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        if opts.open_noatime {
+        if _opts.open_noatime {
             let mut o = OpenOptions::new();
             o.read(true).custom_flags(libc::O_NOATIME);
             if let Ok(f) = o.open(path) {


### PR DESCRIPTION
## Summary
- rename `opts` to `_opts` in `open_for_read` to avoid unused-variable warnings on non-Linux targets

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: linking with `cc` failed)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b95caac9288323a31a58c32675a022