### PR TITLE
transport: silence unused BindToDevice iface

### DIFF
--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -201,6 +201,7 @@ impl TcpTransport {
                         target_os = "linux",
                     )))]
                     {
+                        let _ = iface;
                         return Err(io::Error::new(
                             io::ErrorKind::Unsupported,
                             "SO_BINDTODEVICE is only supported on Linux-like systems",


### PR DESCRIPTION
## Summary
- avoid unused variable warning for `SockOpt::BindToDevice` on unsupported platforms

## Testing
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` *(fails: taken reference of right operand in crates/walk/tests/walk.rs and other clippy warnings)*
- `cargo clippy --workspace`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `acls_roundtrip` redefined in crates/engine/tests/attrs.rs)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: could not find -lacl during linking)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b95ca62bcc8323a5288df04de8ca07