### PR TITLE
Use macOS stdout symbol in oc-rsync CLI

### DIFF
--- a/bin/oc-rsync/src/main.rs
+++ b/bin/oc-rsync/src/main.rs
@@ -6,12 +6,7 @@ use std::io::ErrorKind;
 use std::ptr::{self, NonNull};
 
 extern "C" {
-    #[doc = r"Raw handle to the C `stdout` stream.
-
-# Safety
-
-This symbol originates from the C runtime and is a mutable static. Access must ensure the pointer remains
-valid and is not used concurrently in an unsafe manner."]
+    #[cfg_attr(target_os = "macos", link_name = "__stdoutp")]
     static mut stdout: *mut libc::FILE;
 }
 


### PR DESCRIPTION
## Summary
- link the C `stdout` stream to macOS's `__stdoutp` symbol

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `acls_roundtrip` redefined in engine tests)*
- `cargo test` *(fails: blocking_io tests assertion mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b95c8a6af88323b1cec1546d75ebf3