### PR TITLE
Use meta mknod and mkfifo in archive tests

### DIFF
--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -4,9 +4,9 @@ use assert_cmd::Command;
 #[cfg(unix)]
 use filetime::{set_file_mtime, FileTime};
 #[cfg(unix)]
-use nix::sys::stat::{mknod, Mode, SFlag};
+use nix::sys::stat::{Mode, SFlag};
 #[cfg(unix)]
-use nix::unistd::{chown, mkfifo, Gid, Uid};
+use nix::unistd::{chown, Gid, Uid};
 #[cfg(unix)]
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
@@ -56,8 +56,8 @@ fn archive_matches_combination_and_rsync() {
     )
     .unwrap();
     symlink("dir/file", src.join("link")).unwrap();
-    mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
-    mknod(
+    meta::mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
+    meta::mknod(
         &src.join("dev"),
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o644),
@@ -153,8 +153,8 @@ fn archive_respects_no_options() {
     )
     .unwrap();
     symlink("dir/file", src.join("link")).unwrap();
-    mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
-    mknod(
+    meta::mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
+    meta::mknod(
         &src.join("dev"),
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o644),


### PR DESCRIPTION
## Summary
- replace nix mknod/mkfifo calls in archive tests with oc_rsync::meta variants

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: could not compile `engine` (test "attrs"))*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: could not compile `engine` (test "attrs"))*
- `make verify-comments`
- `make lint`
- `cargo test --tests -p oc-rsync` *(fails: version_matches_upstream_blocking)*


------
https://chatgpt.com/codex/tasks/task_e_68b960f84f408323b32bf2b2868c5a82