### PR TITLE
Use meta module for mknod tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "assert_cmd",
  "clap",
  "engine",
+ "libc",
  "logging",
  "oc-rsync-cli",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ filetime = "0.2"
 clap = { version = "4" }
 oc-rsync-cli = { path = "crates/cli" }
 libc = "0.2"
+meta = { path = "crates/meta" }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.27", features = ["user", "fs"] }
@@ -52,7 +53,6 @@ serial_test = "2"
 transport = { path = "crates/transport" }
 shell-words = "1.1"
 wait-timeout = "0.2"
-meta = { path = "crates/meta" }
 daemon = { path = "crates/daemon" }
 sha2 = "0.10"
 encoding_rs = "0.8"

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -15,6 +15,9 @@ pub use nix::sys::stat::{major, makedev, minor};
 #[cfg(target_os = "macos")]
 pub use libc::{major, makedev, minor};
 
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub use nix::sys::stat::{Mode, SFlag};
+
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 mod stub;
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ use logging::{subscriber, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
 use std::path::{Path, PathBuf};
 use tracing::subscriber::with_default;
 
+pub use meta;
+
 #[derive(Clone)]
 pub struct SyncConfig {
     pub log_format: LogFormat,

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -4,9 +4,9 @@ use assert_cmd::Command;
 #[cfg(unix)]
 use filetime::{set_file_mtime, FileTime};
 #[cfg(unix)]
-use nix::sys::stat::{mknod, Mode, SFlag};
-#[cfg(unix)]
 use nix::unistd::{chown, mkfifo, Gid, Uid};
+#[cfg(unix)]
+use oc_rsync::meta::{makedev, mknod, Mode, SFlag};
 #[cfg(unix)]
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
@@ -38,7 +38,7 @@ fn hash_dir(dir: &Path) -> Vec<u8> {
 #[ignore = "--no-links not yet supported"]
 fn archive_matches_combination_and_rsync() {
     if !Uid::effective().is_root() {
-        eprintln!("skipping: requires root privileges");
+        println!("skipping: requires root privileges");
         return;
     }
 
@@ -61,7 +61,7 @@ fn archive_matches_combination_and_rsync() {
         &src.join("dev"),
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o644),
-        meta::makedev(1, 7),
+        makedev(1, 7),
     )
     .unwrap();
 

--- a/tests/sync_config.rs
+++ b/tests/sync_config.rs
@@ -68,10 +68,15 @@ fn defaults_do_not_preserve_permissions_or_ownership() {
 #[cfg(unix)]
 #[test]
 fn defaults_skip_devices_and_specials() {
-    use nix::sys::stat::{makedev, mknod, Mode, SFlag};
-    use nix::unistd::mkfifo;
+    use nix::unistd::{mkfifo, Uid};
+    use oc_rsync::meta::{makedev, mknod, Mode, SFlag};
 
     let (_dir, src_dir, dst_dir) = setup_dirs();
+
+    if !Uid::effective().is_root() {
+        println!("skipping: requires root privileges");
+        return;
+    }
 
     let fifo = src_dir.join("fifo");
     mkfifo(&fifo, Mode::from_bits_truncate(0o600)).unwrap();


### PR DESCRIPTION
## Summary
- use `oc_rsync::meta` for test mknod helpers
- skip device node tests when not root
- reexport `meta` and its `Mode`/`SFlag` types

## Testing
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `acls_roundtrip` redefined)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: `acls_roundtrip` redefined)*
- `cargo test --test sync_config` *(fails: defaults_preserve checks)*
- `cargo test --no-run --target x86_64-apple-darwin --test sync_config` *(fails: cc: unrecognized option '-mmacosx-version-min=10.7')*

------
https://chatgpt.com/codex/tasks/task_e_68b960f715508323b3989458b5f1a5e5