### PR TITLE
Wrap makedev calls in tests

### DIFF
--- a/reports/triage_20250904.md
+++ b/reports/triage_20250904.md
@@ -1,0 +1,6 @@
+# Triage 2025-09-04
+
+- `cargo clippy --all-targets --all-features -- -D warnings`: passed.
+- `make lint`: passed.
+- `make verify-comments`: passed.
+- `cargo nextest run --workspace --all-features --no-fail-fast`: failed to compile `crates/engine/tests/attrs.rs` (duplicate test names `xattrs_roundtrip` and `acls_roundtrip`).

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -4,9 +4,9 @@ use assert_cmd::Command;
 #[cfg(unix)]
 use filetime::{set_file_mtime, FileTime};
 #[cfg(unix)]
-use nix::unistd::{chown, mkfifo, Gid, Uid};
+use nix::unistd::{chown, Gid, Uid};
 #[cfg(unix)]
-use oc_rsync::meta::{makedev, mknod, Mode, SFlag};
+use oc_rsync::meta::{makedev, Mode, SFlag};
 #[cfg(unix)]
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
@@ -57,13 +57,16 @@ fn archive_matches_combination_and_rsync() {
     .unwrap();
     symlink("dir/file", src.join("link")).unwrap();
     meta::mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
-    meta::mknod(
-        &src.join("dev"),
-        SFlag::S_IFCHR,
-        Mode::from_bits_truncate(0o644),
-        makedev(1, 7),
-    )
-    .unwrap();
+    #[allow(clippy::useless_conversion)]
+    {
+        meta::mknod(
+            &src.join("dev"),
+            SFlag::S_IFCHR,
+            Mode::from_bits_truncate(0o644),
+            u64::from(makedev(1, 7)),
+        )
+        .unwrap();
+    }
 
     let dst_archive = tmp.path().join("dst_archive");
     let dst_combo = tmp.path().join("dst_combo");
@@ -154,13 +157,16 @@ fn archive_respects_no_options() {
     .unwrap();
     symlink("dir/file", src.join("link")).unwrap();
     meta::mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
-    meta::mknod(
-        &src.join("dev"),
-        SFlag::S_IFCHR,
-        Mode::from_bits_truncate(0o644),
-        meta::makedev(1, 7),
-    )
-    .unwrap();
+    #[allow(clippy::useless_conversion)]
+    {
+        meta::mknod(
+            &src.join("dev"),
+            SFlag::S_IFCHR,
+            Mode::from_bits_truncate(0o644),
+            u64::from(meta::makedev(1, 7)),
+        )
+        .unwrap();
+    }
 
     let src_arg = format!("{}/", src.display());
 

--- a/tests/sync_config.rs
+++ b/tests/sync_config.rs
@@ -81,13 +81,16 @@ fn defaults_skip_devices_and_specials() {
     let fifo = src_dir.join("fifo");
     mkfifo(&fifo, Mode::from_bits_truncate(0o600)).unwrap();
     let dev = src_dir.join("null");
-    mknod(
-        &dev,
-        SFlag::S_IFCHR,
-        Mode::from_bits_truncate(0o600),
-        makedev(1, 3),
-    )
-    .unwrap();
+    #[allow(clippy::useless_conversion)]
+    {
+        mknod(
+            &dev,
+            SFlag::S_IFCHR,
+            Mode::from_bits_truncate(0o600),
+            u64::from(makedev(1, 3)),
+        )
+        .unwrap();
+    }
 
     synchronize(src_dir.clone(), dst_dir.clone()).unwrap();
 


### PR DESCRIPTION
## Summary
- wrap `makedev` arguments to `mknod` with `u64::from` in tests
- note test compilation failures in triage report

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: duplicate test names in crates/engine/tests/attrs.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ab3396c83238d07e98aad1d3c76