### PR TITLE
Add triage report and clean up imports

### DIFF
--- a/reports/triage_20250904.md
+++ b/reports/triage_20250904.md
@@ -1,0 +1,13 @@
+# Triage Report - 2025-09-04
+
+## Summary
+`cargo nextest run --workspace --all-features` fails during compilation.
+
+## Failures
+- **engine crate**: linking step for test target failed.
+  - Error: `/usr/bin/ld: cannot find -lacl: No such file or directory`
+  - Root cause: missing system library `libacl` (POSIX ACL support) required during link.
+
+## Recommendations
+- Install the development package providing `libacl` (e.g., `apt-get install libacl1-dev`).
+- Alternatively, adjust build configuration to disable ACL-dependent code when the library is unavailable.

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -4,9 +4,9 @@ use assert_cmd::Command;
 #[cfg(unix)]
 use filetime::{set_file_mtime, FileTime};
 #[cfg(unix)]
-use nix::unistd::{chown, mkfifo, Gid, Uid};
+use nix::unistd::{chown, Gid, Uid};
 #[cfg(unix)]
-use oc_rsync::meta::{makedev, mknod, Mode, SFlag};
+use oc_rsync::meta::{makedev, Mode, SFlag};
 #[cfg(unix)]
 use sha2::{Digest, Sha256};
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- document failing `cargo nextest` run and root cause
- fix unused imports in `tests/archive.rs`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b96abc884083239dcf62a093135235