### PR TITLE
feat: add no-links flag

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -128,13 +128,16 @@ fn run_single(
 ) -> Result<Stats> {
     if opts.archive {
         opts.recursive = true;
-        opts.links = !opts.no_links;
+        opts.links = true;
         opts.perms = !opts.no_perms;
         opts.times = !opts.no_times;
         opts.group = !opts.no_group;
         opts.owner = !opts.no_owner;
         opts.devices = !opts.no_devices;
         opts.specials = !opts.no_specials;
+    }
+    if opts.no_links {
+        opts.links = false;
     }
     if opts.old_dirs {
         opts.dirs = true;
@@ -557,11 +560,7 @@ fn run_single(
                 || chown_ids.is_some_and(|(_, g)| g.is_some())
                 || gid_map.is_some()
         },
-        links: if opts.no_links {
-            false
-        } else {
-            opts.links || opts.archive
-        },
+        links: opts.links,
         copy_links: opts.copy_links,
         copy_dirlinks: opts.copy_dirlinks,
         keep_dirlinks: opts.keep_dirlinks,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2609,6 +2609,13 @@ pub fn sync(
                     }
                     dir_meta.push((path.clone(), dest_path.clone()));
                 } else if file_type.is_symlink() {
+                    if !(opts.links
+                        || opts.copy_links
+                        || opts.copy_dirlinks
+                        || opts.copy_unsafe_links)
+                    {
+                        continue;
+                    }
                     let mut target = fs::read_link(&path).map_err(|e| io_context(&path, e))?;
                     if opts.munge_links {
                         if let Ok(stripped) = target.strip_prefix(MUNGE_PREFIX) {

--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -35,7 +35,6 @@ fn hash_dir(dir: &Path) -> Vec<u8> {
 
 #[cfg(unix)]
 #[test]
-#[ignore = "--no-links not yet supported"]
 fn archive_matches_combination_and_rsync() {
     if !Uid::effective().is_root() {
         println!("skipping: requires root privileges");
@@ -135,7 +134,6 @@ fn archive_matches_combination_and_rsync() {
 
 #[cfg(unix)]
 #[test]
-#[ignore = "--no-links not yet supported"]
 fn archive_respects_no_options() {
     if !Uid::effective().is_root() {
         eprintln!("skipping: requires root privileges");


### PR DESCRIPTION
## Summary
- respect --no-links when parsing archive mode
- skip symlink processing when --no-links is active
- enable archive tests for link handling

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --test archive` *(fails: linking with `cc` failed: exit status: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b96fc1cf2083239c293acb20e4b101