### PR TITLE
daemon: use provided module path

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -208,11 +208,10 @@ pub fn parse_module(s: &str) -> std::result::Result<Module, String> {
     } else {
         env::current_dir().map_err(|e| e.to_string())?.join(raw)
     };
-    let canonical = fs::canonicalize(abs).map_err(|e| e.to_string())?;
 
     let mut module = Module {
         name: name.to_string(),
-        path: canonical,
+        path: abs,
         ..Module::default()
     };
 


### PR DESCRIPTION
## Summary
- avoid canonicalizing module paths so daemon uses caller-supplied roots

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command)*
- `cargo test --test daemon daemon_preserves_hard_links_remote_source` *(fails: link_stat "/workspace/oc-rsync/" failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9806163408323aa6ad2139de8d451