### PR TITLE
Add preflight toolchain checks and document build deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install system dependencies (Linux only)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libacl1-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 
       - name: Format
         run: cargo fmt --all --check
@@ -111,7 +111,10 @@ jobs:
           cache: true
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libacl1-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
+
+      - name: Pre-flight check
+        run: scripts/preflight.sh
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
@@ -146,7 +149,7 @@ jobs:
           cache: true
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libacl1-dev acl attr openssh-server rsync
+        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev acl attr openssh-server rsync
 
       - name: Run interop matrix
         run: |
@@ -189,7 +192,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libacl1-dev
+          sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
           if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
             sudo apt-get install -y gcc-aarch64-linux-gnu
           fi
@@ -237,7 +240,7 @@ jobs:
           cache: true
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libacl1-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 
       - name: Install packaging tools
         run: cargo install cargo-deb cargo-generate-rpm || true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ sudo rpm -i oc-rsync-<version>.x86_64.rpm
 
 ### From source
 
+#### Prerequisites
+
+The source build requires a C toolchain and compression libraries:
+
+- `build-essential` (provides `gcc`/`ld`)
+- `libzstd-dev`
+- `zlib1g-dev`
+
+On Debian/Ubuntu systems:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential libzstd-dev zlib1g-dev
+```
+
+Run `scripts/preflight.sh` to verify these dependencies before building.
+
 ```bash
 cargo install oc-rsync
 # or build from source

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,19 @@
+# Installation
+
+## Required system packages
+
+To build oc-rsync from source you need a working C toolchain and compression libraries:
+
+- `build-essential` (provides `gcc` and `ld`)
+- `libzstd-dev`
+- `zlib1g-dev`
+
+Install them on Debian/Ubuntu with:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential libzstd-dev zlib1g-dev
+```
+
+Run `scripts/preflight.sh` to verify these dependencies before compiling.
+

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=()
+
+if ! command -v ld >/dev/null 2>&1; then
+  missing+=("ld (linker from binutils)")
+fi
+
+if ! ldconfig -p 2>/dev/null | grep -q libzstd; then
+  missing+=("libzstd (install libzstd-dev)")
+fi
+
+if ! ldconfig -p 2>/dev/null | grep -q 'libz\.so'; then
+  missing+=("zlib (install zlib1g-dev)")
+fi
+
+if ((${#missing[@]})); then
+  echo "Error: missing required build dependencies:" >&2
+  for dep in "${missing[@]}"; do
+    echo "  - $dep" >&2
+  done
+  exit 1
+fi
+
+echo "All required linkers and libraries are present."


### PR DESCRIPTION
## Summary
- document required system packages in README and a new installation guide
- install build toolchain packages in CI and add pre-flight check step
- add a preflight script to verify linker and compression libraries

## Testing
- `scripts/preflight.sh`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `acls_roundtrip` redefined)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: missing field `blocking_io` in `SshStdioTransport`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b980a10c608323a3bdd50aefd7b0d7