### PR TITLE
docs: clarify transport edge cases

### DIFF
--- a/docs/differences.md
+++ b/docs/differences.md
@@ -1,7 +1,6 @@
 # Differences
 
-- **Transport edge cases**: SSH and daemon transports are early implementations and may diverge from classic `rsync` behavior.
-  _Planned resolution_: expand interoperability tests and align protocol handling with upstream.
-
-- **Windows support**: path and permission handling on Windows is incomplete.
-  _Planned resolution_: continue cross-platform development until parity is reached.
+- **Transport edge cases**: SSH and daemon transports pass core tests but some
+  error-handling behaviors still diverge from classic `rsync`.
+  _Planned resolution_: broaden interoperability coverage—especially failure
+  scenarios—to close the remaining gaps with upstream.


### PR DESCRIPTION
## Summary
- document remaining transport discrepancies
- drop outdated Windows support difference

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: name `xattrs_roundtrip` redefined)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b98a3271c483239a366ef9b4ffcda0