### PR TITLE
use golden for specials parity and drop rsync dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,12 @@ jobs:
           cache: true
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev acl attr openssh-server rsync
+        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev acl attr openssh-server
 
       - name: Run interop matrix
         run: |
           sudo mkdir -p /run/sshd
-          CLIENT_VERSIONS=system SERVER_VERSIONS=system TRANSPORTS="ssh rsync" COMMON_FLAGS="--archive" tests/interop/run_matrix.sh
+          CLIENT_VERSIONS=oc-rsync SERVER_VERSIONS=oc-rsync TRANSPORTS="ssh rsync" COMMON_FLAGS="--archive" tests/interop/run_matrix.sh
 
   build-matrix:
     needs: [lint, test-linux]

--- a/tests/golden/help/rsync_specials_line.txt
+++ b/tests/golden/help/rsync_specials_line.txt
@@ -1,0 +1,1 @@
+--specials               preserve special files

--- a/tests/specials_parity.rs
+++ b/tests/specials_parity.rs
@@ -1,12 +1,15 @@
 // tests/specials_parity.rs
 use assert_cmd::prelude::*;
+use std::fs;
 use std::process::Command;
 use std::str;
 
 #[test]
 fn specials_help_line_matches_rsync() {
-    let rsync_output = Command::new("rsync").arg("--help").output().unwrap();
-    assert!(rsync_output.status.success());
+    let expected = fs::read_to_string("tests/golden/help/rsync_specials_line.txt")
+        .unwrap()
+        .trim()
+        .to_owned();
     let oc_output = Command::cargo_bin("oc-rsync")
         .unwrap()
         .arg("--help")
@@ -14,27 +17,17 @@ fn specials_help_line_matches_rsync() {
         .unwrap();
     assert!(oc_output.status.success());
 
-    let rsync_line = str::from_utf8(&rsync_output.stdout)
-        .unwrap()
-        .lines()
-        .find(|l| l.contains("--specials"))
-        .unwrap()
-        .trim();
     let oc_line = str::from_utf8(&oc_output.stdout)
         .unwrap()
         .lines()
         .find(|l| l.contains("--specials"))
         .unwrap()
         .trim();
-    assert_eq!(oc_line, rsync_line);
+    assert_eq!(oc_line, expected);
 }
 
 #[test]
 fn specials_flag_parses() {
-    Command::new("rsync")
-        .args(["--specials", "--version"])
-        .assert()
-        .success();
     Command::cargo_bin("oc-rsync")
         .unwrap()
         .args(["--specials", "--version"])


### PR DESCRIPTION
## Summary
- replace rsync parity test with golden snapshot
- remove system rsync from CI and use oc-rsync only
- add golden line for specials help output

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` (fails: xattrs_roundtrip redefined)
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b98b27723c8323b4992665cdb080bb