### PR TITLE
ci: remove node from lint workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,6 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Set up Node
-        uses: actions/setup-node@v4
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run tests
-        run: npx jest --coverage
-  
       # Official Rust toolchain; we need clippy+rustfmt for this job
       - name: Setup Rust (stable)
         uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
## Summary
- drop Node.js setup, npm install, and Jest test steps from CI lint job

## Testing
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `scripts/check-run-matrix-docs.sh`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: name `xattrs_roundtrip` defined multiple times)*
- `cargo check --workspace --target x86_64-apple-darwin` *(fails: cc unrecognized option '-arch')*
- `cargo run --quiet --bin oc-rsync -- --help | tail -n +4 > /tmp/oc-rsync-help.txt`
- `diff -u tests/golden/help/oc-rsync.help /tmp/oc-rsync-help.txt` *(fails: large differences)*
- `cargo check --workspace --target x86_64-pc-windows-msvc` *(fails: failed to find tool "lib.exe")*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68b98a247c6c8323b6f3885fc6ff1937