### PR TITLE
test: skip block size CLI tests when rsync missing

### DIFF
--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -22,6 +22,10 @@ fn parse_literal(stats: &str) -> usize {
     panic!("no literal data in stats: {stats}");
 }
 
+fn rsync_available() -> bool {
+    StdCommand::new("rsync").arg("--version").output().is_ok()
+}
+
 #[test]
 fn cdc_block_size_heuristics() {
     let cases = [
@@ -345,8 +349,11 @@ fn delta_block_size_smaller_file() {
 }
 
 #[test]
-#[ignore = "rsync binary not available"]
 fn cli_block_size_matches_rsync() {
+    if !rsync_available() {
+        eprintln!("skipping cli_block_size_matches_rsync: rsync binary not available");
+        return;
+    }
     let block_size_str = "1k";
     let block_size = 1024usize;
     let size = 1 << 20;
@@ -407,8 +414,11 @@ fn cli_block_size_matches_rsync() {
 }
 
 #[test]
-#[ignore = "rsync binary not available"]
 fn cli_block_size_errors_match_rsync() {
+    if !rsync_available() {
+        eprintln!("skipping cli_block_size_errors_match_rsync: rsync binary not available");
+        return;
+    }
     let tmp = tempdir().unwrap();
     let dst = tmp.path().join("dst");
     fs::create_dir_all(&dst).unwrap();


### PR DESCRIPTION
## Summary
- run block size CLI tests when rsync is available by replacing `#[ignore]` with runtime checks
- print a clear message when the system lacks `rsync`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test block_size -- --nocapture` *(fails: assertion `left == right` failed; no literal data in stats)*
- `make verify-comments` *(fails: additional comments in other files)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8ae127d0483238f3547e35e53a604