### PR TITLE
Handle missing auth tokens in daemon and add parser tests

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -646,7 +646,7 @@ pub fn load_config(path: Option<&Path>) -> io::Result<DaemonConfig> {
 
 pub fn parse_auth_token(token: &str, contents: &str) -> Option<Vec<String>> {
     for raw in contents.lines() {
-        let line = raw.split(['#', ';']).next().unwrap().trim();
+        let line = raw.split(['#', ';']).next().unwrap_or("").trim();
         if line.is_empty() {
             continue;
         }

--- a/crates/daemon/tests/parse_auth_token.rs
+++ b/crates/daemon/tests/parse_auth_token.rs
@@ -1,0 +1,24 @@
+// crates/daemon/tests/parse_auth_token.rs
+use daemon::parse_auth_token;
+
+#[test]
+fn parse_auth_token_handles_whitespace_and_comments() {
+    let contents = "\
+# hash comment
+   ; semicolon comment
+
+  token1   mod1   mod2   # trailing comment
+token2   mod3   ; another trailing comment
+   # post comment
+";
+
+    assert_eq!(
+        parse_auth_token("token1", contents),
+        Some(vec!["mod1".to_string(), "mod2".to_string()])
+    );
+    assert_eq!(
+        parse_auth_token("token2", contents),
+        Some(vec!["mod3".to_string()])
+    );
+    assert_eq!(parse_auth_token("missing", contents), None);
+}


### PR DESCRIPTION
## Summary
- avoid panic when splitting auth lines by using `unwrap_or("")`
- test auth token parsing with whitespace and comment-only lines

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: `xattrs_roundtrip` redefined in engine tests)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b99f5c0e308323912345d73febc070