### PR TITLE
Remove duplicate usage section in help banner

### DIFF
--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -30,13 +30,6 @@ Usage: {prog} [OPTION]... SRC [SRC]... DEST
 The ':' usages connect via remote shell, while '::' & '{prog}://' usages connect
 to an {prog} daemon, and require SRC or DEST to start with a module name.
 
-Usage: {prog} [OPTION]... SRC [SRC]... DEST
-  or   {prog} [OPTION]... SRC [SRC]... [USER@]HOST:DEST
-  or   {prog} [OPTION]... SRC [SRC]... [USER@]HOST::DEST
-  or   {prog} [OPTION]... SRC [SRC]... {prog}://[USER@]HOST[:PORT]/DEST
-  or   {prog} [OPTION]... [USER@]HOST:SRC [DEST]
-  or   {prog} [OPTION]... [USER@]HOST::SRC [DEST]
-  or   {prog} [OPTION]... {prog}://[USER@]HOST[:PORT]/SRC [DEST]
 Options
 "#;
 


### PR DESCRIPTION
## Summary
- Deduplicate the CLI help banner by removing the second "Usage" block

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: duplicate function definitions in engine tests)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: duplicate function definitions in engine tests)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b99f4848808323bf484204426161e3