### PR TITLE
docs: clarify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,17 @@ sudo apt-get install -y build-essential libzstd-dev zlib1g-dev
 Run `scripts/preflight.sh` to verify these dependencies before building.
 
 ```bash
-cargo install oc-rsync
+cargo install --path bin/oc-rsync
+# or download a prebuilt binary from GitHub Releases
 # or build from source
 cargo build -p oc-rsync-bin --bin oc-rsync
 ```
 
 See [packaging/](packaging) for daemon configs and systemd units.
+
+> **Note:** `cargo install oc-rsync` from crates.io will be available once the
+> crate is published. Update these examples before each release to reflect the
+> current publish state.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- document installation via `cargo install --path bin/oc-rsync` or GitHub release binaries
- note future crates.io publishing and reminder to update examples before releases

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `xattrs_roundtrip` redefined)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: `xattrs_roundtrip` redefined)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b99f8f4ab4832395572dc476f07cf0