### PR TITLE
Use literal rsync prefix for option errors

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -93,7 +93,7 @@ pub fn handle_clap_error(cmd: &clap::Command, e: clap::Error) -> ! {
             _ => "syntax or usage error",
         };
         let code_num = u8::from(code);
-        let prog = branding::program_name();
+        let prog = "rsync";
         eprintln!("{prog}: {msg}");
         eprintln!("{prog} error: {desc} (code {code_num})");
     }

--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -364,7 +364,9 @@ fn cli_block_size_errors_match_rsync() {
     let rsync_err =
         fs::read_to_string("tests/golden/block_size/cli_block_size_errors_match_rsync.stderr")
             .unwrap();
-    let rsync_first = rsync_err.lines().next().unwrap();
+    let rsync_lines: Vec<_> = rsync_err.lines().collect();
+    let rsync_first = rsync_lines[0];
+    let rsync_second_prefix = rsync_lines[1].split(" at ").next().unwrap();
 
     let ours = Command::cargo_bin("oc-rsync")
         .unwrap()
@@ -373,6 +375,7 @@ fn cli_block_size_errors_match_rsync() {
         .unwrap();
     assert_eq!(ours.status.code(), Some(expected_code));
     let ours_err = String::from_utf8(ours.stderr).unwrap();
-    let ours_first = ours_err.lines().next().unwrap();
-    assert_eq!(rsync_first, ours_first);
+    let ours_lines: Vec<_> = ours_err.lines().collect();
+    assert_eq!(rsync_first, ours_lines[0]);
+    assert_eq!(rsync_second_prefix, ours_lines[1]);
 }


### PR DESCRIPTION
## Summary
- ensure CLI misuse errors always prefix with `rsync`
- tighten block size option regression test to check full prefix

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test block_size -- cli_block_size_errors_match_rsync`
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68b9af9ea4d48323b84a41ddbec5d04c