### PR TITLE
test: drop system rsync option

### DIFF
--- a/tests/interop/run_matrix.sh
+++ b/tests/interop/run_matrix.sh
@@ -190,10 +190,11 @@ for v in "${CLIENT_VERSIONS[@]}" "${SERVER_VERSIONS[@]}"; do
       echo "Building oc-rsync" >&2
       cargo build --quiet --bin oc-rsync --features="acl xattr"
     fi
-  elif [[ "$v" == "system" ]]; then
-    command -v rsync >/dev/null || { echo "system rsync not found" >&2; exit 1; }
   elif [[ "$v" == "upstream" ]]; then
     [[ -n "${UPSTREAM_RSYNC:-}" && -x "$UPSTREAM_RSYNC" ]] || { echo "UPSTREAM_RSYNC not set or executable" >&2; exit 1; }
+  elif [[ "$v" == "system" ]]; then
+    echo "system rsync is not supported; specify a version or set UPSTREAM_RSYNC" >&2
+    exit 1
   else
     fetch_rsync "$v" >/dev/null
   fi
@@ -204,8 +205,6 @@ for c in "${CLIENT_VERSIONS[@]}"; do
     client_bin="$ROOT/target/debug/oc-rsync"
   elif [[ "$c" == "upstream" ]]; then
     client_bin="$UPSTREAM_RSYNC"
-  elif [[ "$c" == "system" ]]; then
-    client_bin="$(command -v rsync)"
   else
     client_bin="$ROOT/rsync-$c/rsync"
   fi
@@ -214,8 +213,6 @@ for c in "${CLIENT_VERSIONS[@]}"; do
       server_bin="$ROOT/target/debug/oc-rsync"
     elif [[ "$s" == "upstream" ]]; then
       server_bin="$UPSTREAM_RSYNC"
-    elif [[ "$s" == "system" ]]; then
-      server_bin="$(command -v rsync)"
     else
       server_bin="$ROOT/rsync-$s/rsync"
     fi


### PR DESCRIPTION
## Summary
- fail fast when `system` rsync is requested and require explicit versions or `UPSTREAM_RSYNC`
- rely only on bundled goldens or fetched binaries in interop matrix

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: duplicate `DEFAULT_UPSTREAM_NAME`)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: command not found)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9b7efb9ac8323aa799d39872c722d