### PR TITLE
Embed upstream metadata in oc-rsyncd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ version = "0.1.0"
 description = "Pure-Rust reimplementation of rsync (protocol v32)"
 license = "Apache-2.0 OR MIT"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 protocol = { path = "crates/protocol" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+const UPSTREAM_VERSION: &str = "3.4.1";
+const UPSTREAM_PROTOCOLS: &[u32] = &[32, 31, 30, 29];
+
+fn main() {
+    let protocols = UPSTREAM_PROTOCOLS
+        .iter()
+        .map(|p| p.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+
+    println!("cargo:rustc-env=UPSTREAM_VERSION={UPSTREAM_VERSION}");
+    println!("cargo:rustc-env=UPSTREAM_PROTOCOLS={protocols}");
+
+    println!("cargo:rerun-if-env-changed=UPSTREAM_VERSION");
+    println!("cargo:rerun-if-env-changed=UPSTREAM_PROTOCOLS");
+}

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -9,7 +9,6 @@ pub const DEFAULT_BRAND_URL: &str = "https://github.com/oc-rsync/oc-rsync";
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";
 pub const DEFAULT_URL: &str = DEFAULT_BRAND_URL;
 pub const DEFAULT_COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
-pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 
 pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
 {credits}

--- a/tests/blocking_io.rs
+++ b/tests/blocking_io.rs
@@ -11,7 +11,7 @@ fn strip_banner(output: &mut Vec<u8>) {
 
 #[test]
 fn version_matches_upstream_nonblocking() {
-    let mut up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
+    let up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
 
     let mut oc_output = Command::cargo_bin("oc-rsync")
         .unwrap()
@@ -31,7 +31,7 @@ fn version_matches_upstream_nonblocking() {
 
 #[test]
 fn version_matches_upstream_blocking() {
-    let mut up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
+    let up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
 
     let mut oc_output = Command::cargo_bin("oc-rsync")
         .unwrap()

--- a/tests/version_output.rs
+++ b/tests/version_output.rs
@@ -1,4 +1,5 @@
 // tests/version_output.rs
+use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
 
 #[test]
@@ -8,6 +9,19 @@ fn version_matches_banner() {
         .unwrap()
         .env("LC_ALL", "C")
         .env("COLUMNS", "80")
+        .arg("--version")
+        .output()
+        .unwrap();
+    let got = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn daemon_version_matches_banner() {
+    let expected = oc_rsync_cli::version::version_banner();
+    let output = Command::cargo_bin("oc-rsyncd")
+        .unwrap()
+        .env("OC_RSYNC_BIN", cargo_bin("oc-rsync"))
         .arg("--version")
         .output()
         .unwrap();


### PR DESCRIPTION
## Summary
- add build script exporting upstream version/protocols for oc-rsyncd
- expose build script in Cargo metadata and fix CLI branding duplication
- test that `oc-rsyncd --version` matches canonical version banner

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments` *(no output)*
- `cargo nextest run --workspace --no-fail-fast` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8013278832392ee6ea1e1de1301