### PR TITLE
Refactor codec list and clean test imports

### DIFF
--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -9,7 +9,6 @@ pub const DEFAULT_BRAND_URL: &str = "https://github.com/oc-rsync/oc-rsync";
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";
 pub const DEFAULT_URL: &str = DEFAULT_BRAND_URL;
 pub const DEFAULT_COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
-pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 
 pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
 {credits}

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -46,22 +46,17 @@ impl Codec {
 }
 
 pub fn available_codecs() -> Vec<Codec> {
-    #[allow(unused_mut)]
-    let mut codecs = Vec::new();
-    #[cfg(feature = "zstd")]
-    {
-        codecs.push(Codec::Zstd);
-    }
-    #[cfg(feature = "lz4")]
-    {
-        codecs.push(Codec::Lz4);
-    }
-    #[cfg(feature = "zlib")]
-    {
-        codecs.push(Codec::Zlibx);
-        codecs.push(Codec::Zlib);
-    }
-    codecs
+    let codecs = [
+        #[cfg(feature = "zstd")]
+        Codec::Zstd,
+        #[cfg(feature = "lz4")]
+        Codec::Lz4,
+        #[cfg(feature = "zlib")]
+        Codec::Zlibx,
+        #[cfg(feature = "zlib")]
+        Codec::Zlib,
+    ];
+    codecs.into_iter().collect()
 }
 
 pub trait Compressor {

--- a/tests/blocking_io.rs
+++ b/tests/blocking_io.rs
@@ -11,7 +11,7 @@ fn strip_banner(output: &mut Vec<u8>) {
 
 #[test]
 fn version_matches_upstream_nonblocking() {
-    let mut up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
+    let up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
 
     let mut oc_output = Command::cargo_bin("oc-rsync")
         .unwrap()
@@ -31,7 +31,7 @@ fn version_matches_upstream_nonblocking() {
 
 #[test]
 fn version_matches_upstream_blocking() {
-    let mut up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
+    let up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
 
     let mut oc_output = Command::cargo_bin("oc-rsync")
         .unwrap()

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -15,8 +15,9 @@ use std::io::{self, Read, Write};
 use std::net::{IpAddr, TcpListener, TcpStream};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-#[allow(unused_imports)]
-use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::process::{Child, Command as StdCommand, Stdio};
 use std::sync::{mpsc, Arc};
 use std::thread::sleep;


### PR DESCRIPTION
## Summary
- avoid unnecessary mutability in `available_codecs`
- gate `Path` import in daemon tests for unix only
- drop redundant const and simplify blocking io tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: parse_module_accepts_symlinked_dir, acls_roundtrip, symlink_atimes_roundtrip, removes_temp_dir_after_sync, backups_use_custom_suffix, ...)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: list_parsing_from0_eq_newline, merge_word_split_from0, include_from_null_separated, rule_list_from0_eq_newline, and others)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9ab13f48323959a9300fb62182a