### PR TITLE
Disable LZ4 in CI and document experimental status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Verify comments
         run: make verify-comments
@@ -98,12 +98,9 @@ jobs:
 
 
       - name: Run tests
-        run: cargo nextest run --all-features --no-fail-fast
+        run: cargo nextest run --no-fail-fast
       - name: Test with coverage (95% lines & functions)
         run: cargo llvm-cov nextest --fail-under-lines 95 --fail-under-functions 95 --html -- --no-fail-fast
-
-      - name: Test with all features
-        run: cargo nextest run --workspace --no-fail-fast --all-features
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,5 +33,6 @@ insta = { version = "1", features = ["json"] }
 serial_test = "2"
 
 [features]
+default = []
 lz4 = ["engine/lz4", "compress/lz4"]
 

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -50,8 +50,6 @@ pub fn program_name() -> String {
         .unwrap_or_else(|_| "oc-rsync".to_string())
 }
 
-pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
-
 pub fn upstream_name() -> String {
     env::var("OC_RSYNC_UPSTREAM_NAME")
         .or_else(|_| {

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -63,7 +63,7 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | --- | --- | --- | --- |
 | zstd and zlib codecs | Implemented | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/lib.rs](../crates/compress/src/lib.rs) |
 | `--skip-compress` suffix handling | Implemented | [tests/skip_compress.rs](../tests/skip_compress.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
-| Additional codecs (e.g. lz4) | Planned post-parity ([#873](https://github.com/oferchen/oc-rsync/pull/873)) | — | — |
+| LZ4 codec (experimental) | Planned post-parity ([#873](https://github.com/oferchen/oc-rsync/pull/873)) | — | — |
 
 ## Filters
 | Feature | Status | Tests | Source |

--- a/tests/blocking_io.rs
+++ b/tests/blocking_io.rs
@@ -11,7 +11,7 @@ fn strip_banner(output: &mut Vec<u8>) {
 
 #[test]
 fn version_matches_upstream_nonblocking() {
-    let mut up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
+    let up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
 
     let mut oc_output = Command::cargo_bin("oc-rsync")
         .unwrap()
@@ -31,7 +31,7 @@ fn version_matches_upstream_nonblocking() {
 
 #[test]
 fn version_matches_upstream_blocking() {
-    let mut up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
+    let up_output = include_bytes!("golden/blocking_io/rsync_version.txt").to_vec();
 
     let mut oc_output = Command::cargo_bin("oc-rsync")
         .unwrap()

--- a/tests/interop/codec_negotiation.rs
+++ b/tests/interop/codec_negotiation.rs
@@ -16,6 +16,7 @@ fn negotiate_zstd_only() {
     assert_eq!(negotiate_codec(&local, &remote), Some(Codec::Zstd));
 }
 
+#[cfg(feature = "lz4")]
 #[test]
 fn negotiate_lz4_priority() {
     let local = [Codec::Zstd, Codec::Lz4, Codec::Zlib];


### PR DESCRIPTION
## Summary
- mark LZ4 support as experimental and note in docs
- keep LZ4 feature off by default and gate tests behind `cfg(feature="lz4")`
- avoid building LZ4 in CI workflows

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: parse_module_accepts_symlinked_dir, acls_roundtrip)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: multiple tests; run interrupted)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9b7812c8323bed3d85ca83fa291