### PR TITLE
Use safe stdout retrieval across platforms

### DIFF
--- a/bin/oc-rsync/tests/stdio.rs
+++ b/bin/oc-rsync/tests/stdio.rs
@@ -4,7 +4,7 @@ mod stdio;
 
 use oc_rsync_cli::options::OutBuf;
 use std::ptr;
-use stdio::{set_stdout_buffering, set_stream_buffer};
+use stdio::{set_stdout_buffering, set_stream_buffer, stdout_stream};
 
 #[test]
 fn mode_changes_ok() {
@@ -26,4 +26,25 @@ fn invalid_setvbuf_returns_error() {
 #[test]
 fn null_stream_returns_error() {
     assert!(set_stream_buffer(ptr::null_mut(), libc::_IONBF).is_err());
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn unix_stdout_stream_is_valid() {
+    let stream = stdout_stream().unwrap();
+    assert!(!stream.as_ptr().is_null());
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn macos_stdout_stream_is_valid() {
+    let stream = stdout_stream().unwrap();
+    assert!(!stream.as_ptr().is_null());
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_stdout_stream_is_valid() {
+    let stream = stdout_stream().unwrap();
+    assert!(!stream.as_ptr().is_null());
 }

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+// build.rs
 const UPSTREAM_VERSION: &str = "3.4.1";
 const UPSTREAM_PROTOCOLS: &[u32] = &[32, 31, 30, 29];
 

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -5,6 +5,7 @@ pub const DEFAULT_BRAND_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_BRAND_CREDITS: &str =
     "Automatic Rust re-implementation by Ofer Chen (2025). Not affiliated with Samba.";
 pub const DEFAULT_BRAND_URL: &str = "https://github.com/oc-rsync/oc-rsync";
+pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";
 pub const DEFAULT_URL: &str = DEFAULT_BRAND_URL;


### PR DESCRIPTION
## Summary
- obtain stdout stream via platform APIs instead of extern pointer
- handle invalid stream pointers and expose cross-platform stdout tests
- add missing default upstream name constant and fix build script header

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` returned exit status 1)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: linking with `cc` returned exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bcc504c88323b25e822ce591e0fe