### PR TITLE
Add version output golden test

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+// build.rs
 const UPSTREAM_VERSION: &str = "3.4.1";
 const UPSTREAM_PROTOCOLS: &[u32] = &[32, 31, 30, 29];
 

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -9,6 +9,7 @@ pub const DEFAULT_BRAND_URL: &str = "https://github.com/oc-rsync/oc-rsync";
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";
 pub const DEFAULT_URL: &str = DEFAULT_BRAND_URL;
 pub const DEFAULT_COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
+pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 
 pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
 {credits}

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -34,6 +34,7 @@ when available. Do not exceed functionality of upstream at <https://rsync.samba.
 | Comprehensive flag parsing and help text parity | ✅ | [tests/cli.rs](../tests/cli.rs)<br>[tests/help_output.rs](../tests/help_output.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | Composite `--archive` flag expansion | ✅ | [tests/archive.rs](../tests/archive.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | Remote-only option parsing (`--remote-option`) | ✅ | [tests/interop/remote_option.rs](../tests/interop/remote_option.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
+| `--version` output parity | ✅ | [tests/version_output.rs](../tests/version_output.rs) | [crates/cli/src/version.rs](../crates/cli/src/version.rs) |
 
 Note: [tests/archive.rs](../tests/archive.rs) demonstrates the composite `--archive` flag expansion.
 

--- a/tests/golden/version/oc-rsync.version
+++ b/tests/golden/version/oc-rsync.version
@@ -1,0 +1,17 @@
+Capabilities:
+    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
+    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
+    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, ACLs,
+    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
+Optimizations:
+    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
+Checksum list:
+    xxh128 xxh3 xxh64 (xxhash) md5 md4 sha1 none
+Compress list:
+    zstd zlibx zlib none
+Daemon auth list:
+    sha512 sha256 sha1 md5 md4
+
+oc-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.

--- a/tests/version_output.rs
+++ b/tests/version_output.rs
@@ -1,6 +1,7 @@
 // tests/version_output.rs
 use assert_cmd::cargo::cargo_bin;
 use assert_cmd::Command;
+use std::fs;
 
 #[test]
 fn version_matches_banner() {
@@ -27,4 +28,22 @@ fn daemon_version_matches_banner() {
         .unwrap();
     let got = String::from_utf8_lossy(&output.stdout);
     assert_eq!(got, expected);
+}
+
+#[test]
+fn version_matches_golden() {
+    let output = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .env("LC_ALL", "C")
+        .arg("--version")
+        .output()
+        .unwrap();
+
+    let mut parts = output.stdout.splitn(6, |b| *b == b'\n');
+    for _ in 0..5 {
+        parts.next();
+    }
+    let actual = parts.next().unwrap_or_default();
+    let expected = fs::read("tests/golden/version/oc-rsync.version").unwrap();
+    assert_eq!(actual, expected, "version output does not match golden");
 }


### PR DESCRIPTION
## Summary
- record banner-stripped `oc-rsync --version` output as a golden file
- assert runtime `--version` output matches the golden snapshot
- document version output parity in gaps list and add build script header

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: daemon::parse_module_accepts_symlinked_dir, engine::attrs::acls_roundtrip)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(interrupted: multiple tests pending, same failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bcf3ea348323b07afad35373354b