### PR TITLE
Add Codecov config and document coverage thresholds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95%
+    patch:
+      default:
+        target: 95%

--- a/docs/coverage_exclusions.md
+++ b/docs/coverage_exclusions.md
@@ -1,8 +1,8 @@
 # Coverage Exclusions
 
 This document lists code that is intentionally excluded from the project's
-coverage requirements. The coverage workflow enforces a 95% threshold for both
-line and function coverage.
+coverage requirements. Coverage gates enforce a 95% threshold for both project
+and patch metrics, as well as line and function coverage.
 
 The following areas are excluded when interpreting coverage reports:
 


### PR DESCRIPTION
## Summary
- add `codecov.yml` with project and patch coverage targets set to 95%
- document coverage gates in `coverage_exclusions.md`

## Testing
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: DEFAULT_UPSTREAM_NAME redefined)*
- `make verify-comments` *(fails: crates/daemon/tests/no_token.rs additional comments)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: DEFAULT_UPSTREAM_NAME redefined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c432938c83238090095e58359435