### PR TITLE
fix: remove duplicate DEFAULT_UPSTREAM_NAME constant

### DIFF
--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -10,7 +10,6 @@ pub const DEFAULT_BRAND_URL: &str = "https://github.com/oc-rsync/oc-rsync";
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";
 pub const DEFAULT_URL: &str = DEFAULT_BRAND_URL;
 pub const DEFAULT_COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
-pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 
 pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
 {credits}


### PR DESCRIPTION
## Summary
- dedupe CLI branding constant `DEFAULT_UPSTREAM_NAME`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p oc-rsync-cli`
- `cargo nextest run --workspace --no-fail-fast` *(fails: parity_with_rsync_md4, parity_with_rsync_md5, parity_with_rsync_sha1, parity_with_rsync_xxh128, parity_with_rsync_xxh3, parity_with_rsync_xxh64, parse_module_accepts_symlinked_dir, acls_roundtrip, symlink_atimes_roundtrip, symlink_xattrs_roundtrip, removes_temp_dir_after_sync, backups_use_custom_suffix, list_parsing_from0_eq_newline, merge_word_split_from0, include_from_null_separated, rule_list_from0_eq_newline, include_exclude_precedence, and more; interrupted with 635 tests not run)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(interrupted before tests ran)*
- `make verify-comments` *(fails: crates/daemon/tests/no_token.rs: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9c415fd38832389a195a7bba7d9fb