### PR TITLE
Embed upstream version in CLI output

### DIFF
--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -10,7 +10,6 @@ pub const DEFAULT_BRAND_URL: &str = "https://github.com/oc-rsync/oc-rsync";
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";
 pub const DEFAULT_URL: &str = DEFAULT_BRAND_URL;
 pub const DEFAULT_COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
-pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 
 pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
 {credits}

--- a/tests/fixtures/oc-rsync-version.txt
+++ b/tests/fixtures/oc-rsync-version.txt
@@ -1,5 +1,5 @@
 oc-rsync 0.1.0 (protocol 32)
-compatible with rsync unknown (protocol 32)
+compatible with rsync 3.4.1 (protocol 32)
 unknown unofficial
 Copyright (C) 2024-2025 oc-rsync contributors.
 Web site: https://github.com/oc-rsync/oc-rsync


### PR DESCRIPTION
## Summary
- fix duplicate upstream constant so the CLI builds cleanly
- refresh oc-rsync version fixture showing compatibility with rsync 3.4.1

## Testing
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments` *(fails: crates/daemon/tests/no_token.rs: additional comments)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: parity_with_rsync_* etc., parse_module_accepts_symlinked_dir, acls_roundtrip)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: multiple tests; run interrupted)*
- `cargo nextest run --test bin_version`


------
https://chatgpt.com/codex/tasks/task_e_68b9c4668ce48323bb525a8ddf01f926