### PR TITLE
Enable daemon sync attribute tests

### DIFF
--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -1,7 +1,6 @@
 // crates/cli/src/branding.rs
 use std::env;
 
-pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 pub const DEFAULT_BRAND_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_BRAND_CREDITS: &str =
     "Automatic Rust re-implementation by Ofer Chen (2025). Not affiliated with Samba.";

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -1,5 +1,4 @@
 // tests/daemon_sync_attrs.rs
-#![cfg(not(test))]
 
 #[cfg(unix)]
 use assert_cmd::{cargo::CommandCargoExt, Command};
@@ -454,6 +453,7 @@ fn daemon_xattrs_match_rsync_server() {
 #[cfg(unix)]
 #[test]
 #[serial]
+#[cfg_attr(not(target_os = "linux"), ignore = "requires Linux ACLs")]
 fn daemon_preserves_acls() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
@@ -496,6 +496,7 @@ fn daemon_preserves_acls() {
 #[cfg(unix)]
 #[test]
 #[serial]
+#[cfg_attr(not(target_os = "linux"), ignore = "requires Linux ACLs")]
 fn daemon_preserves_acls_rr_client() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
@@ -539,6 +540,7 @@ fn daemon_preserves_acls_rr_client() {
 #[cfg(unix)]
 #[test]
 #[serial]
+#[cfg_attr(not(target_os = "linux"), ignore = "requires Linux ACLs")]
 fn daemon_removes_acls() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
@@ -754,6 +756,7 @@ fn daemon_acls_match_rsync_server() {
 #[cfg(unix)]
 #[test]
 #[serial]
+#[cfg_attr(not(target_os = "linux"), ignore = "requires Linux ACLs")]
 fn daemon_acls_match_rsync_client() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
@@ -811,10 +814,16 @@ fn daemon_acls_match_rsync_client() {
 #[cfg(unix)]
 #[test]
 #[serial]
+#[cfg_attr(not(target_os = "linux"), ignore = "requires Linux uid/gid semantics")]
 fn daemon_preserves_uid_gid_perms() {
     use nix::sys::stat::{fchmodat, FchmodatFlags, Mode};
     use nix::unistd::{chown, Gid, Uid};
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    if !Uid::effective().is_root() {
+        eprintln!("skipping: requires root privileges");
+        return;
+    }
 
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");


### PR DESCRIPTION
## Summary
- enable daemon sync attribute tests on Unix by removing crate-level cfg
- gate ACL-sensitive tests behind Linux-specific cfg and skip uid/gid test when not root
- fix duplicate constant in branding module

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: many tests, network unreachable)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(incomplete; warnings)*
- `make verify-comments` *(fails: additional comments in crates/daemon/tests/no_token.rs)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9c46efa6c8323b51c3a7c6888b441