### PR TITLE
cli: add upstream name default

### DIFF
--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -9,6 +9,7 @@ pub const DEFAULT_BRAND_URL: &str = "https://github.com/oferchen/oc-rsync";
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";
 pub const DEFAULT_URL: &str = DEFAULT_BRAND_URL;
 pub const DEFAULT_COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
+pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 
 pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
 {credits}

--- a/crates/cli/tests/branding.rs
+++ b/crates/cli/tests/branding.rs
@@ -12,3 +12,9 @@ fn help_uses_program_name() {
     std::env::remove_var("OC_RSYNC_BRAND_NAME");
     std::env::remove_var("COLUMNS");
 }
+
+#[test]
+fn upstream_name_defaults_to_rsync() {
+    std::env::remove_var("OC_RSYNC_UPSTREAM_NAME");
+    assert_eq!(branding::upstream_name(), "rsync");
+}


### PR DESCRIPTION
## Summary
- add `DEFAULT_UPSTREAM_NAME` constant for CLI branding
- test default upstream name resolution when env var is unset

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: clippy::op-ref, clippy::while-let-on-iterator, clippy::err-expect)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: checksum parity tests, daemon config test, engine ACL test; run interrupted)*
- `make verify-comments` *(fails: additional comments in crates/daemon/tests/no_token.rs)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9cf2710408323a8ed58e4a539f5f6