### PR TITLE
Refine branding replacements and add upstream name test

### DIFF
--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -9,6 +9,7 @@ pub const DEFAULT_BRAND_URL: &str = "https://github.com/oferchen/oc-rsync";
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";
 pub const DEFAULT_URL: &str = DEFAULT_BRAND_URL;
 pub const DEFAULT_COPYRIGHT: &str = "Copyright (C) 2024-2025 oc-rsync contributors.";
+pub const DEFAULT_UPSTREAM_NAME: &str = "rsync";
 
 pub const DEFAULT_HELP_PREFIX: &str = r#"{prog} {version}
 {credits}

--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -197,8 +197,20 @@ pub fn render_help(cmd: &Command) -> String {
     let mut help_prefix = branding::help_prefix();
     let mut help_suffix = branding::help_suffix();
     for s in [&mut help_prefix, &mut help_suffix] {
-        *s = s.replace("rsync", &upstream);
-        *s = s
+        let mut replaced = String::with_capacity(s.len());
+        let mut rest: &str = s;
+        while let Some(idx) = rest.find("rsync") {
+            replaced.push_str(&rest[..idx]);
+            let tail = &rest[idx + 5..];
+            if tail.starts_with("://") || tail.starts_with('d') {
+                replaced.push_str("rsync");
+            } else {
+                replaced.push_str(&upstream);
+            }
+            rest = tail;
+        }
+        replaced.push_str(rest);
+        *s = replaced
             .replace("{prog}", &program)
             .replace("{version}", &version)
             .replace("{credits}", &credits)

--- a/crates/cli/tests/branding.rs
+++ b/crates/cli/tests/branding.rs
@@ -1,7 +1,9 @@
 // crates/cli/tests/branding.rs
 use oc_rsync_cli::{branding, cli_command, render_help};
+use serial_test::serial;
 
 #[test]
+#[serial]
 fn help_uses_program_name() {
     std::env::set_var("OC_RSYNC_BRAND_NAME", "myrsync");
     std::env::set_var("COLUMNS", "80");
@@ -10,5 +12,17 @@ fn help_uses_program_name() {
     let first = help.lines().next().unwrap();
     assert_eq!(first, format!("myrsync {}", version));
     std::env::remove_var("OC_RSYNC_BRAND_NAME");
+    std::env::remove_var("COLUMNS");
+}
+
+#[test]
+#[serial]
+fn upstream_name_does_not_replace_rsyncd_conf() {
+    std::env::set_var("OC_RSYNC_UPSTREAM_NAME", "ursync");
+    std::env::set_var("COLUMNS", "80");
+    let help = render_help(&cli_command());
+    assert!(help.contains("rsyncd.conf"));
+    assert!(!help.contains("ursyncd.conf"));
+    std::env::remove_var("OC_RSYNC_UPSTREAM_NAME");
     std::env::remove_var("COLUMNS");
 }

--- a/crates/daemon/tests/no_token.rs
+++ b/crates/daemon/tests/no_token.rs
@@ -8,7 +8,6 @@ use transport::LocalPipeTransport;
 
 #[test]
 fn handle_connection_missing_token() {
-    // Prepare input: protocol version followed by empty token newline
     let mut input = Vec::new();
     input.extend_from_slice(&SUPPORTED_PROTOCOLS[0].to_be_bytes());
     input.extend_from_slice(b"\n");


### PR DESCRIPTION
## Summary
- replace naive `rsync` substitution with logic that preserves literals like `rsync://` and `rsyncd.conf`
- expose default upstream name constant
- test custom upstream name keeps `rsyncd.conf` intact

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace` *(fails: parity_with_rsync_* tests, parses_* tests)*


------
https://chatgpt.com/codex/tasks/task_e_68b9cf46b64c832383d6b995f18f5447