### PR TITLE
refactor(cli): unify block-size attribute

### DIFF
--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -531,14 +531,8 @@ pub(crate) struct ClientOpts {
         short = 'B',
         long = "block-size",
         value_name = "SIZE",
-        help_heading = "Misc"
-    )]
-    #[arg(
-        short = 'B',
-        long = "block-size",
-        value_name = "SIZE",
         help_heading = "Misc",
-        value_parser = parse_size::<usize>
+        value_parser = parse_size::<usize>,
     )]
     pub block_size: Option<usize>,
     #[arg(

--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -917,9 +917,7 @@ fn metadata_matches_source() {
     assert_eq!(mt_src, mt_dst);
     let cr_src = meta_src.created().ok();
     let cr_dst = meta_dst.created().ok();
-    if cr_src.is_some() && cr_dst.is_some() {
-         Creation times may vary slightly across filesystems; ensure both exist.
-    }
+    if cr_src.is_some() && cr_dst.is_some() {}
 }
 
 #[cfg(all(feature = "xattr"))]


### PR DESCRIPTION
## Summary
- merge duplicate `#[arg]` blocks for `block-size` into a single attribute
- drop stray line in `attrs` test to satisfy formatting

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9df492c1c8323b59f28221363df0f