### PR TITLE
chore(cli): combine block-size arg attributes

### DIFF
--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -531,14 +531,8 @@ pub(crate) struct ClientOpts {
         short = 'B',
         long = "block-size",
         value_name = "SIZE",
-        help_heading = "Misc"
-    )]
-    #[arg(
-        short = 'B',
-        long = "block-size",
-        value_name = "SIZE",
         help_heading = "Misc",
-        value_parser = parse_size::<usize>
+        value_parser = parse_size::<usize>,
     )]
     pub block_size: Option<usize>,
     #[arg(


### PR DESCRIPTION
## Summary
- consolidate duplicated block-size argument metadata into a single `clap` attribute

## Testing
- `cargo fmt --all` *(fails: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `times`)*
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: linking with `cc` failed: cannot find -lacl)*
- `make verify-comments`
- `make lint` *(fails: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator, found `times`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9df729c948323a93134f16483b478