### PR TITLE
Remove obsolete protocol logs

### DIFF
--- a/tests/interop/README.md
+++ b/tests/interop/README.md
@@ -1,7 +1,9 @@
 This directory stores recorded wire transcripts, file-list goldens and
 filesystem trees for interoperability tests.
 
-- `wire/` contains captured protocol transcripts.
+- `wire/` contains captured protocol transcripts. Legacy transcripts may
+  remain for historical coverage; tests using them automatically skip when
+  a protocol version isn't supported.
 - `filelists/` stores `rsync --list-only` outputs.
 - `golden/` holds destination tree tarballs for interoperability tests. Each
   tarball is stored at

--- a/tests/interop/wire/proto-27.log
+++ b/tests/interop/wire/proto-27.log
@@ -1,1 +1,0 @@
-placeholder wire proto 27

--- a/tests/interop/wire/proto-28.log
+++ b/tests/interop/wire/proto-28.log
@@ -1,1 +1,0 @@
-placeholder wire proto 28


### PR DESCRIPTION
## Summary
- drop legacy proto-27 and proto-28 wire transcripts
- document purpose of wire transcripts and skipping behaviour

## Testing
- `cargo fmt --all` *(fails: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator)*
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed: exit status: 1)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: linking with `cc` failed: exit status: 1)*
- `make verify-comments`
- `make lint` *(fails: expected one of `!`, `.`, `::`, `;`, `?`, `{`, `}`, or an operator)*

------
https://chatgpt.com/codex/tasks/task_e_68b9df6911f48323bf6a6e89d78bcad8