### PR TITLE
Sanitize program name in block size error test

### DIFF
--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -917,9 +917,8 @@ fn metadata_matches_source() {
     assert_eq!(mt_src, mt_dst);
     let cr_src = meta_src.created().ok();
     let cr_dst = meta_dst.created().ok();
-    if cr_src.is_some() && cr_dst.is_some() {
-         Creation times may vary slightly across filesystems; ensure both exist.
-    }
+    assert!(cr_src.is_some());
+    assert!(cr_dst.is_some());
 }
 
 #[cfg(all(feature = "xattr"))]

--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -364,9 +364,12 @@ fn cli_block_size_errors_match_rsync() {
     let rsync_err =
         fs::read_to_string("tests/golden/block_size/cli_block_size_errors_match_rsync.stderr")
             .unwrap();
+    fn sanitize(line: &str) -> &str {
+        line.splitn(2, ' ').nth(1).unwrap_or(line)
+    }
     let rsync_lines: Vec<_> = rsync_err.lines().collect();
-    let rsync_first = rsync_lines[0];
-    let rsync_second_prefix = rsync_lines[1].split(" at ").next().unwrap();
+    let rsync_first = sanitize(rsync_lines[0]);
+    let rsync_second_prefix = sanitize(rsync_lines[1].split(" at ").next().unwrap());
 
     let ours = Command::cargo_bin("oc-rsync")
         .unwrap()
@@ -376,6 +379,9 @@ fn cli_block_size_errors_match_rsync() {
     assert_eq!(ours.status.code(), Some(expected_code));
     let ours_err = String::from_utf8(ours.stderr).unwrap();
     let ours_lines: Vec<_> = ours_err.lines().collect();
-    assert_eq!(rsync_first, ours_lines[0]);
-    assert_eq!(rsync_second_prefix, ours_lines[1]);
+    assert_eq!(rsync_first, sanitize(ours_lines[0]));
+    assert_eq!(
+        rsync_second_prefix,
+        sanitize(ours_lines[1].split(" at ").next().unwrap())
+    );
 }

--- a/tests/golden/block_size/cli_block_size_errors_match_rsync.stderr
+++ b/tests/golden/block_size/cli_block_size_errors_match_rsync.stderr
@@ -1,2 +1,2 @@
-rsync: --block-size=1x is invalid
-rsync error: syntax or usage error (code 1) at main.c(1795) [client=3.2.7]
+oc-rsync: --block-size=1x is invalid
+oc-rsync error: syntax or usage error (code 1) at main.c(1795) [client=3.2.7]


### PR DESCRIPTION
## Summary
- update golden block size stderr to use oc-rsync branding
- sanitize program name in block size parity test
- assert creation time presence in attrs test to satisfy tooling

## Testing
- `make lint`
- `make verify-comments`
- `cargo nextest run -p oc-rsync --test block_size`
- `cargo nextest run -p oc-rsync --test block_size --all-features`
- `cargo nextest run --workspace --no-fail-fast` *(fail: linking with `cc` failed: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68b9df46613c8323920c572dfc6233d9