### PR TITLE
Use regex for standalone rsync token replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,7 @@ dependencies = [
  "meta",
  "nix 0.27.1",
  "protocol",
+ "regex",
  "serial_test",
  "shell-words",
  "tempfile",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1"
 encoding_rs = "0.8"
 textwrap = "0.16"
 time = { version = "0.3", features = ["macros", "parsing"] }
+regex = "1"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.27", features = ["user", "fs"] }

--- a/crates/cli/tests/branding.rs
+++ b/crates/cli/tests/branding.rs
@@ -26,3 +26,27 @@ fn upstream_name_does_not_replace_rsyncd_conf() {
     std::env::remove_var("OC_RSYNC_UPSTREAM_NAME");
     std::env::remove_var("COLUMNS");
 }
+
+#[test]
+#[serial]
+fn upstream_name_only_replaces_standalone_rsync() {
+    std::env::set_var("OC_RSYNC_UPSTREAM_NAME", "ursync");
+    std::env::set_var(
+        "OC_RSYNC_HELP_HEADER",
+        "rsync rsyncs /path/rsync/bin rsync://host\n",
+    );
+    std::env::set_var("OC_RSYNC_HELP_FOOTER", "");
+    std::env::set_var("COLUMNS", "120");
+
+    let help = render_help(&cli_command());
+
+    assert!(help.contains("ursync rsyncs /path/rsync/bin rsync://host"));
+    assert!(!help.contains("ursyncs"));
+    assert!(!help.contains("/path/ursync/bin"));
+    assert!(!help.contains("ursync://host"));
+
+    std::env::remove_var("OC_RSYNC_UPSTREAM_NAME");
+    std::env::remove_var("OC_RSYNC_HELP_HEADER");
+    std::env::remove_var("OC_RSYNC_HELP_FOOTER");
+    std::env::remove_var("COLUMNS");
+}


### PR DESCRIPTION
## Summary
- replace manual `rsync` substitutions in help text with a regex
- preserve URLs and path segments while branding help output
- add regression test for non-standalone `rsync` occurrences

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: removes_temp_dir_after_sync, backups_use_custom_suffix)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: multiple filters tests, engine cleanup, etc.)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f283f238832392dd91bad4df990a