### PR TITLE
Explicitly map Clap error kinds

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -49,22 +49,25 @@ pub mod version;
 pub fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
     use clap::error::ErrorKind::*;
     match kind {
-        UnknownArgument
-        | InvalidSubcommand
-        | NoEquals
-        | ValueValidation
-        | TooManyValues
-        | TooFewValues
-        | WrongNumberOfValues
-        | ArgumentConflict
-        | MissingRequiredArgument
-        | MissingSubcommand
-        | InvalidUtf8
-        | DisplayHelpOnMissingArgumentOrSubcommand => ExitCode::SyntaxOrUsage,
         InvalidValue => ExitCode::Unsupported,
-        DisplayHelp | DisplayVersion => ExitCode::Ok,
-        Io | Format => ExitCode::FileIo,
-        _ => ExitCode::SyntaxOrUsage,
+        UnknownArgument => ExitCode::SyntaxOrUsage,
+        InvalidSubcommand => ExitCode::SyntaxOrUsage,
+        NoEquals => ExitCode::SyntaxOrUsage,
+        ValueValidation => ExitCode::SyntaxOrUsage,
+        TooManyValues => ExitCode::SyntaxOrUsage,
+        TooFewValues => ExitCode::SyntaxOrUsage,
+        WrongNumberOfValues => ExitCode::SyntaxOrUsage,
+        ArgumentConflict => ExitCode::SyntaxOrUsage,
+        MissingRequiredArgument => ExitCode::SyntaxOrUsage,
+        MissingSubcommand => ExitCode::SyntaxOrUsage,
+        InvalidUtf8 => ExitCode::SyntaxOrUsage,
+        DisplayHelp => ExitCode::Ok,
+        DisplayHelpOnMissingArgumentOrSubcommand => ExitCode::SyntaxOrUsage,
+        DisplayVersion => ExitCode::Ok,
+        Io => ExitCode::FileIo,
+        Format => ExitCode::FileIo,
+        #[allow(unreachable_patterns)]
+        _ => unreachable!("unhandled clap::ErrorKind variant"),
     }
 }
 

--- a/src/bin/oc-rsync/main.rs
+++ b/src/bin/oc-rsync/main.rs
@@ -52,58 +52,31 @@ mod tests {
 
     #[test]
     fn maps_error_kinds_to_exit_codes() {
-        assert_eq!(
-            exit_code_from_error_kind(UnknownArgument),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(InvalidSubcommand),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(exit_code_from_error_kind(NoEquals), ExitCode::SyntaxOrUsage);
-        assert_eq!(
-            exit_code_from_error_kind(ValueValidation),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(TooManyValues),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(TooFewValues),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(WrongNumberOfValues),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(ArgumentConflict),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(MissingRequiredArgument),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(MissingSubcommand),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(InvalidUtf8),
-            ExitCode::SyntaxOrUsage
-        );
-        assert_eq!(
-            exit_code_from_error_kind(DisplayHelpOnMissingArgumentOrSubcommand),
-            ExitCode::SyntaxOrUsage,
-        );
-        assert_eq!(
-            exit_code_from_error_kind(InvalidValue),
-            ExitCode::Unsupported
-        );
-        assert_eq!(exit_code_from_error_kind(DisplayHelp), ExitCode::Ok);
-        assert_eq!(exit_code_from_error_kind(DisplayVersion), ExitCode::Ok);
-        assert_eq!(exit_code_from_error_kind(Io), ExitCode::FileIo);
-        assert_eq!(exit_code_from_error_kind(Format), ExitCode::FileIo);
+        let cases = [
+            (InvalidValue, ExitCode::Unsupported),
+            (UnknownArgument, ExitCode::SyntaxOrUsage),
+            (InvalidSubcommand, ExitCode::SyntaxOrUsage),
+            (NoEquals, ExitCode::SyntaxOrUsage),
+            (ValueValidation, ExitCode::SyntaxOrUsage),
+            (TooManyValues, ExitCode::SyntaxOrUsage),
+            (TooFewValues, ExitCode::SyntaxOrUsage),
+            (WrongNumberOfValues, ExitCode::SyntaxOrUsage),
+            (ArgumentConflict, ExitCode::SyntaxOrUsage),
+            (MissingRequiredArgument, ExitCode::SyntaxOrUsage),
+            (MissingSubcommand, ExitCode::SyntaxOrUsage),
+            (InvalidUtf8, ExitCode::SyntaxOrUsage),
+            (
+                DisplayHelpOnMissingArgumentOrSubcommand,
+                ExitCode::SyntaxOrUsage,
+            ),
+            (DisplayHelp, ExitCode::Ok),
+            (DisplayVersion, ExitCode::Ok),
+            (Io, ExitCode::FileIo),
+            (Format, ExitCode::FileIo),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(exit_code_from_error_kind(kind), expected);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- map every `clap::error::ErrorKind` variant to an `ExitCode`
- expand tests to verify mappings for all error kinds

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: removes_temp_dir_after_sync, backups_use_custom_suffix, filters::* tests)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: unexpected cfg warnings, further test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f2b71e348323b21c0220ea63988d