### PR TITLE
test: add dry-run interop test

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -132,13 +132,13 @@ _Future contributors: update this section when adding or fixing message behavior
 | Comprehensive flag parsing via `clap` | ✅ | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | `--log-file-format` | ✅ | [tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | `--munge-links` option | ✅ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
+| `--dry-run` prevents destination changes | ✅ | [tests/interop/dry_run.rs](../tests/interop/dry_run.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 ### Outstanding Options
 
 The following flags are parsed but lack verification against upstream `rsync`. Add interop tests to confirm parity.
 
 - `--config`: add interop tests verifying parity. Tests: [tests/daemon_config.rs](../tests/daemon_config.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--copy-as`: requires root or CAP_CHOWN; add privileged interop tests. Tests: [tests/copy_as.rs](../tests/copy_as.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
-- `--dry-run`: add interop tests ensuring no file changes. Tests: [tests/cli.rs](../tests/cli.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--early-input`: add interop tests verifying early argument handling. Tests: [tests/cli_flags.rs](../tests/cli_flags.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--fake-super`: requires `xattr` feature; add interop tests. Tests: [tests/fake_super.rs](../tests/fake_super.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).
 - `--fsync`: add interop tests verifying fsync semantics. Tests: [tests/cli_flags.rs](../tests/cli_flags.rs). Source: [crates/cli/src/lib.rs](../crates/cli/src/lib.rs).

--- a/tests/interop/dry_run.rs
+++ b/tests/interop/dry_run.rs
@@ -1,0 +1,41 @@
+// tests/interop/dry_run.rs
+
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn dry_run_preserves_destination() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+
+    fs::write(src.join("new.txt"), b"new").unwrap();
+    fs::write(dst.join("old.txt"), b"old").unwrap();
+
+    let mut before: Vec<_> = fs::read_dir(&dst)
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .collect();
+    before.sort();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--recursive", "--dry-run", &src_arg, dst.to_str().unwrap()])
+        .assert()
+        .success();
+
+    let mut after: Vec<_> = fs::read_dir(&dst)
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .collect();
+    after.sort();
+
+    assert_eq!(before, after);
+    assert!(!dst.join("new.txt").exists());
+    assert_eq!(fs::read_to_string(dst.join("old.txt")).unwrap(), "old");
+}
+


### PR DESCRIPTION
## Summary
- add interop test ensuring `--dry-run` leaves destination untouched
- mark `--dry-run` option verified in documentation

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: engine::cleanup removes_temp_dir_after_sync, engine::backup backups_use_custom_suffix, filters::from0_merges list_parsing_from0_eq_newline, filters::from0_merges merge_word_split_from0, filters::include_from include_from_null_separated, filters::include_from rule_list_from0_eq_newline, filters::list_files include_exclude_precedence)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2eb66348323917b4bacf5168d6e