### PR TITLE
Use fallible device conversion in tests

### DIFF
--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -10,6 +10,8 @@ use oc_rsync::meta::{makedev, Mode, SFlag};
 #[cfg(unix)]
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
+use std::convert::TryInto;
+#[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::{symlink, FileTypeExt, MetadataExt, PermissionsExt};
@@ -57,15 +59,13 @@ fn archive_matches_combination_and_rsync() {
     symlink("dir/file", src.join("link")).unwrap();
     meta::mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
     #[allow(clippy::useless_conversion)]
-    {
-        meta::mknod(
-            &src.join("dev"),
-            SFlag::S_IFCHR,
-            Mode::from_bits_truncate(0o644),
-            u64::from(makedev(1, 7)),
-        )
-        .unwrap();
-    }
+    meta::mknod(
+        &src.join("dev"),
+        SFlag::S_IFCHR,
+        Mode::from_bits_truncate(0o644),
+        makedev(1, 7).try_into().unwrap(),
+    )
+    .unwrap();
 
     let dst_archive = tmp.path().join("dst_archive");
     let dst_combo = tmp.path().join("dst_combo");

--- a/tests/sync_config.rs
+++ b/tests/sync_config.rs
@@ -80,6 +80,7 @@ fn defaults_do_not_preserve_permissions_or_ownership() {
 fn defaults_skip_devices_and_specials() {
     use nix::unistd::{mkfifo, Uid};
     use oc_rsync::meta::{makedev, mknod, Mode, SFlag};
+    use std::convert::TryInto;
 
     let (_dir, src_dir, dst_dir) = setup_dirs();
 
@@ -92,15 +93,13 @@ fn defaults_skip_devices_and_specials() {
     mkfifo(&fifo, Mode::from_bits_truncate(0o600)).unwrap();
     let dev = src_dir.join("null");
     #[allow(clippy::useless_conversion)]
-    {
-        mknod(
-            &dev,
-            SFlag::S_IFCHR,
-            Mode::from_bits_truncate(0o600),
-            u64::from(makedev(1, 3)),
-        )
-        .unwrap();
-    }
+    mknod(
+        &dev,
+        SFlag::S_IFCHR,
+        Mode::from_bits_truncate(0o600),
+        makedev(1, 3).try_into().unwrap(),
+    )
+    .unwrap();
 
     synchronize(src_dir.clone(), dst_dir.clone()).unwrap();
 


### PR DESCRIPTION
## Summary
- use fallible device number conversion with `TryInto`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: tcp_read_timeout)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(failed: interrupted)*
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: additional comments)*
- `make lint`
- `cargo test --test sync_config` *(fails: defaults_do_not_preserve_permissions_or_ownership, defaults_skip_devices_and_specials)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fbe123188323973d5d710d94183b