### PR TITLE
Check flag_matrix help command status

### DIFF
--- a/tools/flag_matrix.rs
+++ b/tools/flag_matrix.rs
@@ -116,6 +116,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let oc_rsync_help = Command::new("cargo")
         .args(["run", "--quiet", "--bin", "oc-rsync", "--", "--help"])
         .output()?;
+    let status = oc_rsync_help.status;
+    if !status.success() {
+        return Err(format!(
+            "`cargo run --quiet --bin oc-rsync -- --help` failed: {}",
+            status
+        )
+        .into());
+    }
     let oc_rsync_help_str = String::from_utf8(oc_rsync_help.stdout)?;
     let (mut oc_rsync_flags, oc_rsync_aliases, _oc_rsync_alias_desc) =
         parse_help(&oc_rsync_help_str);


### PR DESCRIPTION
## Summary
- ensure flag_matrix captures and validates the status of the `--help` command

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: linking with `cc` failed: cannot find -lacl)*
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: additional comments)*
- `make lint`
- `cargo run --bin flag_matrix` *(fails: `cargo run --quiet --bin oc-rsync -- --help` failed: exit status: 101)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fdc959ec83239ffeb09dff4dda26