### PR TITLE
Fix auth token comment parsing

### DIFF
--- a/crates/daemon/tests/parse_auth_token.rs
+++ b/crates/daemon/tests/parse_auth_token.rs
@@ -22,3 +22,18 @@ token2   mod3   ; another trailing comment
     );
     assert_eq!(parse_auth_token("missing", contents), None);
 }
+
+#[test]
+fn parse_auth_token_allows_comment_chars_in_quotes() {
+    let contents = r#"token1 "mod#1" 'mod;2'
+token2 "a#b" "c;d" ; trailing comment"#;
+
+    assert_eq!(
+        parse_auth_token("token1", contents),
+        Some(vec!["mod#1".to_string(), "mod;2".to_string()])
+    );
+    assert_eq!(
+        parse_auth_token("token2", contents),
+        Some(vec!["a#b".to_string(), "c;d".to_string()])
+    );
+}


### PR DESCRIPTION
## Summary
- handle `#` and `;` only when outside quotes in auth token parser
- trim surrounding quotes and add tests for quoted comment markers

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p daemon`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: removes_temp_dir_after_sync, backups_use_custom_suffix, list_parsing_from0_eq_newline, merge_word_split_from0, include_from_null_separated, rule_list_from0_eq_newline, include_exclude_precedence, rsync_filter_merge_order_and_wildcards, nested_rsync_filter_order, include_overrides_parent_exclude, include_overrides_parent_exclude_prop, nested_filters_apply_in_order, parity_with_stock_rsync, starts_daemon, exit_code_is_zero, cli_block_size_errors_match_rsync, cli_block_size_matches_rsync, ...)*
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9fdbd2aa0832387cc929902af7fee