### PR TITLE
Fix dump-help-body flag duplication

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use clap::parser::ValueSource;
-use clap::{Arg, ArgAction, ArgMatches, FromArgMatches};
+use clap::{ArgMatches, FromArgMatches};
 
 pub mod branding;
 pub mod daemon;
@@ -45,14 +45,7 @@ use users::get_user_by_uid;
 
 pub mod version;
 
-pub fn cli_command() -> clap::Command {
-    options::cli_command().arg(
-        Arg::new("dump-help-body")
-            .long("dump-help-body")
-            .action(ArgAction::SetTrue)
-            .hide(true),
-    )
-}
+pub use options::cli_command;
 
 pub fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
     use clap::error::ErrorKind::*;

--- a/src/bin/oc-rsync/main.rs
+++ b/src/bin/oc-rsync/main.rs
@@ -10,14 +10,7 @@ fn main() {
     let args: Vec<_> = std::env::args_os().collect();
     if args.iter().any(|a| a == "--dump-help-body") {
         let cmd = cli_command();
-        let help = oc_rsync_cli::render_help(&cmd);
-        let mut parts = help.splitn(4, '\n');
-        parts.next();
-        parts.next();
-        parts.next();
-        if let Some(body) = parts.next() {
-            println!("{body}");
-        }
+        print!("{}", oc_rsync_cli::dump_help_body(&cmd));
         return;
     }
     if oc_rsync_cli::print_version_if_requested(args.iter().cloned()) {

--- a/tests/golden/help/oc-rsync.dump-help-body.100
+++ b/tests/golden/help/oc-rsync.dump-help-body.100
@@ -1,153 +1,141 @@
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
-are welcome to redistribute it under certain conditions.  See the GNU
-General Public Licence for details.
-
-rsync is a file transfer program capable of efficient remote update
-via a fast differencing algorithm.
-
-Usage: rsync [OPTION]... SRC [SRC]... DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
-  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
-  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
-  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
-  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
-The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
-to an rsync daemon, and require SRC or DEST to start with a module name.
-
-Options
---verbose, -v            
---info=FLAGS             
---debug=FLAGS            
---quiet, -q              
---no-motd                
---checksum, -c           
---archive, -a            
---recursive, -r          
---relative, -R           
---no-implied-dirs        
---backup, -b             
---backup-dir=DIR         
---suffix=SUFFIX          
---update, -u             
---inplace                
---append                 
---append-verify          
---dirs, -d               
---mkpath                 create destination's missing path components
---links, -l              
---copy-links, -L         
---copy-unsafe-links      
---safe-links             
---munge-links            munge symlinks to make them safe & unusable
---copy-dirlinks, -k      
---keep-dirlinks, -K      
---hard-links, -H         
---perms, -p              
---executability, -E      
---chmod=CHMOD            
---owner, -o              
---group, -g              
---devices                
---copy-devices           
---write-devices          write to devices as files (implies --inplace)
---specials               preserve special files
--D                       same as --devices --specials
---no-D                   
---times, -t              
---atimes, -U             
---crtimes, -N            
---omit-dir-times, -O     
---omit-link-times, -J    
---fake-super             
---sparse, -S             
---preallocate            allocate dest files before writing them
---dry-run, -n            
---whole-file, -W         
---checksum-choice=STR    
---one-file-system, -x    
---block-size=SIZE, -B    
---rsh=COMMAND, -e        
---rsync-path=PATH        
---existing               
---ignore-existing        
---remove-source-files    
---delete                 
---delete-before          
---delete-during          
---delete-delay           
---delete-after           
---delete-excluded        
---ignore-missing-args    
---delete-missing-args    
---ignore-errors          
---force                  force deletion of dirs even if not empty
---max-delete=NUM         
---max-size=SIZE          
---min-size=SIZE          
---max-alloc=SIZE         
---partial                
---partial-dir=DIR        
---delay-updates          
---prune-empty-dirs, -m   
---numeric-ids            
---usermap=FROM:TO        
---groupmap=FROM:TO       
---chown=USER:GROUP       
---timeout=SECONDS        
---connect-timeout=SECONDS  
---ignore-times, -I       
---size-only              
---modify-window=SECONDS  
---temp-dir=DIR, -T       
---fuzzy, -y              
---compare-dest=DIR       
---copy-dest=DIR          
---link-dest=DIR          
---compress, -z           
---compress-choice=STR    
---compress-level=NUM     
---skip-compress=LIST     
---cvs-exclude, -C        auto-ignore files in the same way CVS does
---filter=RULE, -f        
---filter-file=FILE       
--F                       
---exclude=PATTERN        
---exclude-from=FILE      
---include=PATTERN        
---include-from=FILE      
---files-from=FILE        
---from0, -0              
---secluded-args, -s      use the protocol to safely send the args
---trust-sender           
---copy-as=USER[:GROUP]   
---address=ADDRESS        
---port=PORT              
---sockopts=OPTIONS       
---blocking-io            
---stats                  
---8-bit-output, -8       
---human-readable         
---progress               
--P                       
---itemize-changes, -i    output a change-summary for all updates
---remote-option=OPT, -M  send OPTION to the remote side only
---out-format=FORMAT      
---log-file=FILE          
---log-file-format=FMT    
---password-file=FILE     
---early-input=FILE       
---list-only              
---bwlimit=RATE           
---fsync                  
---write-batch=FILE       
---read-batch=FILE        read a batched update from FILE
---protocol=VER           force an older protocol version
---iconv=CONVERT_SPEC     request charset conversion of filenames
---checksum-seed=NUM      set block/file checksum seed (advanced)
---ipv4, -4               
---ipv6, -6               
-
-Use "rsync --daemon --help" to see the daemon-mode command-line options.
-Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
-For project updates and documentation, visit https://github.com/oferchen/oc-rsync.
+--verbose	increaseverbosity
+--info=FLAGS	fine-grainedinformationalverbosity
+--debug=FLAGS	fine-graineddebugverbosity
+--stderr=e|a|c	changestderroutputmode(default:errors)
+--quiet	suppressnon-errormessages
+--no-motd	suppressdaemon-modeMOTD
+--checksum	skipbasedonchecksum,notmod-time&size
+--archive	archivemodeis-rlptgoD(no-A,-X,-U,-N,-H)
+--no-OPTION	turnoffanimpliedOPTION(e.g.--no-D)
+--recursive	recurseintodirectories
+--relative	userelativepathnames
+--no-implied-dirs	don'tsendimplieddirswith--relative
+--backup	makebackups(see--suffix&--backup-dir)
+--backup-dir=DIR	makebackupsintohierarchybasedinDIR
+--suffix=SUFFIX	backupsuffix(default~w/o--backup-dir)
+--update	skipfilesthatareneweronthereceiver
+--inplace	updatedestinationfilesin-place
+--append	appenddataontoshorterfiles
+--append-verify	--appendw/olddatainfilechecksum
+--dirs	transferdirectorieswithoutrecursing
+--old-dirs	workslike--dirswhentalkingtooldrsync
+--mkpath	createdestination'smissingpathcomponents
+--links	copysymlinksassymlinks
+--copy-links	transformsymlinkintoreferentfile/dir
+--copy-unsafe-links	only"unsafe"symlinksaretransformed
+--safe-links	ignoresymlinksthatpointoutsidethetree
+--munge-links	mungesymlinkstomakethemsafe&unusable
+--copy-dirlinks	transformsymlinktodirintoreferentdir
+--keep-dirlinks	treatsymlinkeddironreceiverasdir
+--hard-links	preservehardlinks
+--perms	preservepermissions
+--executability	preserveexecutability
+--chmod=CHMOD	affectfileand/ordirectorypermissions
+--acls	preserveACLs(implies--perms)
+--xattrs	preserveextendedattributes
+--owner	preserveowner(super-useronly)
+--group	preservegroup
+--devices	preservedevicefiles(super-useronly)
+--copy-devices	copydevicecontentsasaregularfile
+--write-devices	writetodevicesasfiles(implies--inplace)
+--specials	preservespecialfiles
+--times	preservemodificationtimes
+--atimes	preserveaccess(use)times
+--open-noatime	avoidchangingtheatimeonopenedfiles
+--crtimes	preservecreatetimes(newness)
+--omit-dir-times	omitdirectoriesfrom--times
+--omit-link-times	omitsymlinksfrom--times
+--super	receiverattemptssuper-useractivities
+--fake-super	store/recoverprivilegedattrsusingxattrs
+--sparse	turnsequencesofnullsintosparseblocks
+--preallocate	allocatedestfilesbeforewritingthem
+--dry-run	performatrialrunwithnochangesmade
+--whole-file	copyfileswhole(w/odelta-xferalgorithm)
+--checksum-choice=STR	choosethechecksumalgorithm(aka--cc)
+--one-file-system	don'tcrossfilesystemboundaries
+--block-size=SIZE	forceafixedchecksumblock-size
+--rsh=COMMAND	specifytheremoteshelltouse
+--rsync-path=PROGRAM	specifythersynctorunonremotemachine
+--existing	skipcreatingnewfilesonreceiver
+--ignore-existing	skipupdatingfilesthatexistonreceiver
+--remove-source-files	senderremovessynchronizedfiles(non-dir)
+--del	analiasfor--delete-during
+--delete	deleteextraneousfilesfromdestdirs
+--delete-before	receiverdeletesbeforexfer,notduring
+--delete-during	receiverdeletesduringthetransfer
+--delete-delay	finddeletionsduring,deleteafter
+--delete-after	receiverdeletesaftertransfer,notduring
+--delete-excluded	alsodeleteexcludedfilesfromdestdirs
+--ignore-missing-args	ignoremissingsourceargswithouterror
+--delete-missing-args	deletemissingsourceargsfromdestination
+--ignore-errors	deleteevenifthereareI/Oerrors
+--force	forcedeletionofdirsevenifnotempty
+--max-delete=NUM	don'tdeletemorethanNUMfiles
+--max-size=SIZE	don'ttransferanyfilelargerthanSIZE
+--min-size=SIZE	don'ttransferanyfilesmallerthanSIZE
+--max-alloc=SIZE	changealimitrelatingtomemoryalloc
+--partial	keeppartiallytransferredfiles
+--partial-dir=DIR	putapartiallytransferredfileintoDIR
+--delay-updates	putallupdatedfilesintoplaceatend
+--prune-empty-dirs	pruneemptydirectorychainsfromfile-list
+--numeric-ids	don'tmapuid/gidvaluesbyuser/groupname
+--usermap=STRING	customusernamemapping
+--groupmap=STRING	customgroupnamemapping
+--chown=USER:GROUP	simpleusername/groupnamemapping
+--timeout=SECONDS	setI/Otimeoutinseconds
+--contimeout=SECONDS	setdaemonconnectiontimeoutinseconds
+--ignore-times	don'tskipfilesthatmatchsizeandtime
+--size-only	skipfilesthatmatchinsize
+--modify-window=NUM	settheaccuracyformod-timecomparisons
+--temp-dir=DIR	createtemporaryfilesindirectoryDIR
+--fuzzy	findsimilarfileforbasisifnodestfile
+--compare-dest=DIR	alsocomparedestinationfilesrelativetoDIR
+--copy-dest=DIR	...andincludecopiesofunchangedfiles
+--link-dest=DIR	hardlinktofilesinDIRwhenunchanged
+--compress	compressfiledataduringthetransfer
+--compress-choice=STR	choosethecompressionalgorithm(aka--zc)
+--compress-level=NUM	explicitlysetcompressionlevel(aka--zl)
+--skip-compress=LIST	skipcompressingfileswithsuffixinLIST
+--cvs-exclude	auto-ignorefilesinthesamewayCVSdoes
+--filter=RULE	addafile-filteringRULE
+--exclude=PATTERN	excludefilesmatchingPATTERN
+--exclude-from=FILE	readexcludepatternsfromFILE
+--include=PATTERN	don'texcludefilesmatchingPATTERN
+--include-from=FILE	readincludepatternsfromFILE
+--files-from=FILE	readlistofsource-filenamesfromFILE
+--from0	all*-from/filterfilesaredelimitedby0s
+--old-args	disablethemodernarg-protectionidiom
+--secluded-args	usetheprotocoltosafelysendtheargs
+--trust-sender	trusttheremotesender'sfilelist
+--copy-as=USER[:GROUP]	specifyuser&optionalgroupforthecopy
+--address=ADDRESS	bindaddressforoutgoingsockettodaemon
+--port=PORT	specifydouble-colonalternateportnumber
+--sockopts=OPTIONS	specifycustomTCPoptions
+--blocking-io	useblockingI/Ofortheremoteshell
+--outbuf=N|L|B	setoutbufferingtoNone,Line,orBlock
+--stats	givesomefile-transferstats
+--8-bit-output	leavehigh-bitcharsunescapedinoutput
+--human-readable	outputnumbersinahuman-readableformat
+--progress	showprogressduringtransfer
+--itemize-changes	outputachange-summaryforallupdates
+--remote-option=OPT	sendOPTIONtotheremotesideonly
+--out-format=FORMAT	outputupdatesusingthespecifiedFORMAT
+--log-file=FILE	logwhatwe'redoingtothespecifiedFILE
+--log-file-format=FMT	logupdatesusingthespecifiedFMT
+--password-file=FILE	readdaemon-accesspasswordfromFILE
+--early-input=FILE	useFILEfordaemon'searlyexecinput
+--list-only	listthefilesinsteadofcopyingthem
+--bwlimit=RATE	limitsocketI/Obandwidth
+--stop-after=MINS	StoprsyncafterMINSminuteshaveelapsed
+--stop-at=y-m-dTh:m	Stoprsyncatthespecifiedpointintime
+--fsync	fsynceverywrittenfile
+--write-batch=FILE	writeabatchedupdatetoFILE
+--only-write-batch=FILE	like--write-batchbutw/oupdatingdest
+--read-batch=FILE	readabatchedupdatefromFILE
+--protocol=NUM	forceanolderprotocolversiontobeused
+--iconv=CONVERT_SPEC	requestcharsetconversionoffilenames
+--checksum-seed=NUM	setblock/filechecksumseed(advanced)
+--ipv4	preferIPv4
+--ipv6	preferIPv6
+--version	printtheversion+otherinfoandexit
+--help	showthishelp(*-hishelponlyonitsown)

--- a/tests/golden/help/oc-rsync.dump-help-body.60
+++ b/tests/golden/help/oc-rsync.dump-help-body.60
@@ -1,163 +1,141 @@
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
-are welcome to redistribute it under certain conditions.  See the GNU
-General Public Licence for details.
-
-rsync is a file transfer program capable of efficient remote update
-via a fast differencing algorithm.
-
-Usage: rsync [OPTION]... SRC [SRC]... DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
-  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
-  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
-  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
-  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
-The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
-to an rsync daemon, and require SRC or DEST to start with a module name.
-
-Options
---verbose, -v            
---info=FLAGS             
---debug=FLAGS            
---quiet, -q              
---no-motd                
---checksum, -c           
---archive, -a            
---recursive, -r          
---relative, -R           
---no-implied-dirs        
---backup, -b             
---backup-dir=DIR         
---suffix=SUFFIX          
---update, -u             
---inplace                
---append                 
---append-verify          
---dirs, -d               
---mkpath                 create destination's missing path
-                         components
---links, -l              
---copy-links, -L         
---copy-unsafe-links      
---safe-links             
---munge-links            munge symlinks to make them safe
-                         & unusable
---copy-dirlinks, -k      
---keep-dirlinks, -K      
---hard-links, -H         
---perms, -p              
---executability, -E      
---chmod=CHMOD            
---owner, -o              
---group, -g              
---devices                
---copy-devices           
---write-devices          write to devices as files (implies
-                         --inplace)
---specials               preserve special files
--D                       same as --devices --specials
---no-D                   
---times, -t              
---atimes, -U             
---crtimes, -N            
---omit-dir-times, -O     
---omit-link-times, -J    
---fake-super             
---sparse, -S             
---preallocate            allocate dest files before writing
-                         them
---dry-run, -n            
---whole-file, -W         
---checksum-choice=STR    
---one-file-system, -x    
---block-size=SIZE, -B    
---rsh=COMMAND, -e        
---rsync-path=PATH        
---existing               
---ignore-existing        
---remove-source-files    
---delete                 
---delete-before          
---delete-during          
---delete-delay           
---delete-after           
---delete-excluded        
---ignore-missing-args    
---delete-missing-args    
---ignore-errors          
---force                  force deletion of dirs even if
-                         not empty
---max-delete=NUM         
---max-size=SIZE          
---min-size=SIZE          
---max-alloc=SIZE         
---partial                
---partial-dir=DIR        
---delay-updates          
---prune-empty-dirs, -m   
---numeric-ids            
---usermap=FROM:TO        
---groupmap=FROM:TO       
---chown=USER:GROUP       
---timeout=SECONDS        
---connect-timeout=SECONDS  
---ignore-times, -I       
---size-only              
---modify-window=SECONDS  
---temp-dir=DIR, -T       
---fuzzy, -y              
---compare-dest=DIR       
---copy-dest=DIR          
---link-dest=DIR          
---compress, -z           
---compress-choice=STR    
---compress-level=NUM     
---skip-compress=LIST     
---cvs-exclude, -C        auto-ignore files in the same way
-                         CVS does
---filter=RULE, -f        
---filter-file=FILE       
--F                       
---exclude=PATTERN        
---exclude-from=FILE      
---include=PATTERN        
---include-from=FILE      
---files-from=FILE        
---from0, -0              
---secluded-args, -s      use the protocol to safely send
-                         the args
---trust-sender           
---copy-as=USER[:GROUP]   
---address=ADDRESS        
---port=PORT              
---sockopts=OPTIONS       
---blocking-io            
---stats                  
---8-bit-output, -8       
---human-readable         
---progress               
--P                       
---itemize-changes, -i    output a change-summary for all
-                         updates
---remote-option=OPT, -M  send OPTION to the remote side only
---out-format=FORMAT      
---log-file=FILE          
---log-file-format=FMT    
---password-file=FILE     
---early-input=FILE       
---list-only              
---bwlimit=RATE           
---fsync                  
---write-batch=FILE       
---read-batch=FILE        read a batched update from FILE
---protocol=VER           force an older protocol version
---iconv=CONVERT_SPEC     request charset conversion of
-                         filenames
---checksum-seed=NUM      set block/file checksum seed
-                         (advanced)
---ipv4, -4               
---ipv6, -6               
-
-Use "rsync --daemon --help" to see the daemon-mode command-line options.
-Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
-For project updates and documentation, visit https://github.com/oferchen/oc-rsync.
+--verbose	increaseverbosity
+--info=FLAGS	fine-grainedinformationalverbosity
+--debug=FLAGS	fine-graineddebugverbosity
+--stderr=e|a|c	changestderroutputmode(default:errors)
+--quiet	suppressnon-errormessages
+--no-motd	suppressdaemon-modeMOTD
+--checksum	skipbasedonchecksum,notmod-time&size
+--archive	archivemodeis-rlptgoD(no-A,-X,-U,-N,-H)
+--no-OPTION	turnoffanimpliedOPTION(e.g.--no-D)
+--recursive	recurseintodirectories
+--relative	userelativepathnames
+--no-implied-dirs	don'tsendimplieddirswith--relative
+--backup	makebackups(see--suffix&--backup-dir)
+--backup-dir=DIR	makebackupsintohierarchybasedinDIR
+--suffix=SUFFIX	backupsuffix(default~w/o--backup-dir)
+--update	skipfilesthatareneweronthereceiver
+--inplace	updatedestinationfilesin-place
+--append	appenddataontoshorterfiles
+--append-verify	--appendw/olddatainfilechecksum
+--dirs	transferdirectorieswithoutrecursing
+--old-dirs	workslike--dirswhentalkingtooldrsync
+--mkpath	createdestination'smissingpathcomponents
+--links	copysymlinksassymlinks
+--copy-links	transformsymlinkintoreferentfile/dir
+--copy-unsafe-links	only"unsafe"symlinksaretransformed
+--safe-links	ignoresymlinksthatpointoutsidethetree
+--munge-links	mungesymlinkstomakethemsafe&unusable
+--copy-dirlinks	transformsymlinktodirintoreferentdir
+--keep-dirlinks	treatsymlinkeddironreceiverasdir
+--hard-links	preservehardlinks
+--perms	preservepermissions
+--executability	preserveexecutability
+--chmod=CHMOD	affectfileand/ordirectorypermissions
+--acls	preserveACLs(implies--perms)
+--xattrs	preserveextendedattributes
+--owner	preserveowner(super-useronly)
+--group	preservegroup
+--devices	preservedevicefiles(super-useronly)
+--copy-devices	copydevicecontentsasaregularfile
+--write-devices	writetodevicesasfiles(implies--inplace)
+--specials	preservespecialfiles
+--times	preservemodificationtimes
+--atimes	preserveaccess(use)times
+--open-noatime	avoidchangingtheatimeonopenedfiles
+--crtimes	preservecreatetimes(newness)
+--omit-dir-times	omitdirectoriesfrom--times
+--omit-link-times	omitsymlinksfrom--times
+--super	receiverattemptssuper-useractivities
+--fake-super	store/recoverprivilegedattrsusingxattrs
+--sparse	turnsequencesofnullsintosparseblocks
+--preallocate	allocatedestfilesbeforewritingthem
+--dry-run	performatrialrunwithnochangesmade
+--whole-file	copyfileswhole(w/odelta-xferalgorithm)
+--checksum-choice=STR	choosethechecksumalgorithm(aka--cc)
+--one-file-system	don'tcrossfilesystemboundaries
+--block-size=SIZE	forceafixedchecksumblock-size
+--rsh=COMMAND	specifytheremoteshelltouse
+--rsync-path=PROGRAM	specifythersynctorunonremotemachine
+--existing	skipcreatingnewfilesonreceiver
+--ignore-existing	skipupdatingfilesthatexistonreceiver
+--remove-source-files	senderremovessynchronizedfiles(non-dir)
+--del	analiasfor--delete-during
+--delete	deleteextraneousfilesfromdestdirs
+--delete-before	receiverdeletesbeforexfer,notduring
+--delete-during	receiverdeletesduringthetransfer
+--delete-delay	finddeletionsduring,deleteafter
+--delete-after	receiverdeletesaftertransfer,notduring
+--delete-excluded	alsodeleteexcludedfilesfromdestdirs
+--ignore-missing-args	ignoremissingsourceargswithouterror
+--delete-missing-args	deletemissingsourceargsfromdestination
+--ignore-errors	deleteevenifthereareI/Oerrors
+--force	forcedeletionofdirsevenifnotempty
+--max-delete=NUM	don'tdeletemorethanNUMfiles
+--max-size=SIZE	don'ttransferanyfilelargerthanSIZE
+--min-size=SIZE	don'ttransferanyfilesmallerthanSIZE
+--max-alloc=SIZE	changealimitrelatingtomemoryalloc
+--partial	keeppartiallytransferredfiles
+--partial-dir=DIR	putapartiallytransferredfileintoDIR
+--delay-updates	putallupdatedfilesintoplaceatend
+--prune-empty-dirs	pruneemptydirectorychainsfromfile-list
+--numeric-ids	don'tmapuid/gidvaluesbyuser/groupname
+--usermap=STRING	customusernamemapping
+--groupmap=STRING	customgroupnamemapping
+--chown=USER:GROUP	simpleusername/groupnamemapping
+--timeout=SECONDS	setI/Otimeoutinseconds
+--contimeout=SECONDS	setdaemonconnectiontimeoutinseconds
+--ignore-times	don'tskipfilesthatmatchsizeandtime
+--size-only	skipfilesthatmatchinsize
+--modify-window=NUM	settheaccuracyformod-timecomparisons
+--temp-dir=DIR	createtemporaryfilesindirectoryDIR
+--fuzzy	findsimilarfileforbasisifnodestfile
+--compare-dest=DIR	alsocomparedestinationfilesrelativetoDIR
+--copy-dest=DIR	...andincludecopiesofunchangedfiles
+--link-dest=DIR	hardlinktofilesinDIRwhenunchanged
+--compress	compressfiledataduringthetransfer
+--compress-choice=STR	choosethecompressionalgorithm(aka--zc)
+--compress-level=NUM	explicitlysetcompressionlevel(aka--zl)
+--skip-compress=LIST	skipcompressingfileswithsuffixinLIST
+--cvs-exclude	auto-ignorefilesinthesamewayCVSdoes
+--filter=RULE	addafile-filteringRULE
+--exclude=PATTERN	excludefilesmatchingPATTERN
+--exclude-from=FILE	readexcludepatternsfromFILE
+--include=PATTERN	don'texcludefilesmatchingPATTERN
+--include-from=FILE	readincludepatternsfromFILE
+--files-from=FILE	readlistofsource-filenamesfromFILE
+--from0	all*-from/filterfilesaredelimitedby0s
+--old-args	disablethemodernarg-protectionidiom
+--secluded-args	usetheprotocoltosafelysendtheargs
+--trust-sender	trusttheremotesender'sfilelist
+--copy-as=USER[:GROUP]	specifyuser&optionalgroupforthecopy
+--address=ADDRESS	bindaddressforoutgoingsockettodaemon
+--port=PORT	specifydouble-colonalternateportnumber
+--sockopts=OPTIONS	specifycustomTCPoptions
+--blocking-io	useblockingI/Ofortheremoteshell
+--outbuf=N|L|B	setoutbufferingtoNone,Line,orBlock
+--stats	givesomefile-transferstats
+--8-bit-output	leavehigh-bitcharsunescapedinoutput
+--human-readable	outputnumbersinahuman-readableformat
+--progress	showprogressduringtransfer
+--itemize-changes	outputachange-summaryforallupdates
+--remote-option=OPT	sendOPTIONtotheremotesideonly
+--out-format=FORMAT	outputupdatesusingthespecifiedFORMAT
+--log-file=FILE	logwhatwe'redoingtothespecifiedFILE
+--log-file-format=FMT	logupdatesusingthespecifiedFMT
+--password-file=FILE	readdaemon-accesspasswordfromFILE
+--early-input=FILE	useFILEfordaemon'searlyexecinput
+--list-only	listthefilesinsteadofcopyingthem
+--bwlimit=RATE	limitsocketI/Obandwidth
+--stop-after=MINS	StoprsyncafterMINSminuteshaveelapsed
+--stop-at=y-m-dTh:m	Stoprsyncatthespecifiedpointintime
+--fsync	fsynceverywrittenfile
+--write-batch=FILE	writeabatchedupdatetoFILE
+--only-write-batch=FILE	like--write-batchbutw/oupdatingdest
+--read-batch=FILE	readabatchedupdatefromFILE
+--protocol=NUM	forceanolderprotocolversiontobeused
+--iconv=CONVERT_SPEC	requestcharsetconversionoffilenames
+--checksum-seed=NUM	setblock/filechecksumseed(advanced)
+--ipv4	preferIPv4
+--ipv6	preferIPv6
+--version	printtheversion+otherinfoandexit
+--help	showthishelp(*-hishelponlyonitsown)

--- a/tests/golden/help/oc-rsync.help
+++ b/tests/golden/help/oc-rsync.help
@@ -1,169 +1,141 @@
-rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
-are welcome to redistribute it under certain conditions.  See the GNU
-General Public Licence for details.
-
-rsync is a file transfer program capable of efficient remote update
-via a fast differencing algorithm.
-
-Usage: rsync [OPTION]... SRC [SRC]... DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
-  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
-  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
-  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
-  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
-  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
-The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
-to an rsync daemon, and require SRC or DEST to start with a module name.
-
-Options
---verbose, -v            increase verbosity
---info=FLAGS             fine-grained informational verbosity
---debug=FLAGS            fine-grained debug verbosity
---stderr=e|a|c           change stderr output mode (default: errors)
---quiet, -q              suppress non-error messages
---no-motd                suppress daemon-mode MOTD
---checksum, -c           skip based on checksum, not mod-time & size
---archive, -a            archive mode is -rlptgoD (no -A,-X,-U,-N,-H)
---no-OPTION              turn off an implied OPTION (e.g. --no-D)
---recursive, -r          recurse into directories
---relative, -R           use relative path names
---no-implied-dirs        don't send implied dirs with --relative
---backup, -b             make backups (see --suffix & --backup-dir)
---backup-dir=DIR         make backups into hierarchy based in DIR
---suffix=SUFFIX          backup suffix (default ~ w/o --backup-dir)
---update, -u             skip files that are newer on the receiver
---inplace                update destination files in-place
---append                 append data onto shorter files
---append-verify          --append w/old data in file checksum
---dirs, -d               transfer directories without recursing
---old-dirs, --old-d      works like --dirs when talking to old rsync
---mkpath                 create destination's missing path components
---links, -l              copy symlinks as symlinks
---copy-links, -L         transform symlink into referent file/dir
---copy-unsafe-links      only "unsafe" symlinks are transformed
---safe-links             ignore symlinks that point outside the tree
---munge-links            munge symlinks to make them safe & unusable
---copy-dirlinks, -k      transform symlink to dir into referent dir
---keep-dirlinks, -K      treat symlinked dir on receiver as dir
---hard-links, -H         preserve hard links
---perms, -p              preserve permissions
---executability, -E      preserve executability
---chmod=CHMOD            affect file and/or directory permissions
---acls, -A               preserve ACLs (implies --perms)
---xattrs, -X             preserve extended attributes
---owner, -o              preserve owner (super-user only)
---group, -g              preserve group
---devices                preserve device files (super-user only)
---copy-devices           copy device contents as a regular file
---write-devices          write to devices as files (implies --inplace)
---specials               preserve special files
--D                       same as --devices --specials
---times, -t              preserve modification times
---atimes, -U             preserve access (use) times
---open-noatime           avoid changing the atime on opened files
---crtimes, -N            preserve create times (newness)
---omit-dir-times, -O     omit directories from --times
---omit-link-times, -J    omit symlinks from --times
---super                  receiver attempts super-user activities
---fake-super             store/recover privileged attrs using xattrs
---sparse, -S             turn sequences of nulls into sparse blocks
---preallocate            allocate dest files before writing them
---dry-run, -n            perform a trial run with no changes made
---whole-file, -W         copy files whole (w/o delta-xfer algorithm)
---checksum-choice=STR    choose the checksum algorithm (aka --cc)
---one-file-system, -x    don't cross filesystem boundaries
---block-size=SIZE, -B    force a fixed checksum block-size
---rsh=COMMAND, -e        specify the remote shell to use
---rsync-path=PROGRAM     specify the rsync to run on remote machine
---existing               skip creating new files on receiver
---ignore-existing        skip updating files that exist on receiver
---remove-source-files    sender removes synchronized files (non-dir)
---del                    an alias for --delete-during
---delete                 delete extraneous files from dest dirs
---delete-before          receiver deletes before xfer, not during
---delete-during          receiver deletes during the transfer
---delete-delay           find deletions during, delete after
---delete-after           receiver deletes after transfer, not during
---delete-excluded        also delete excluded files from dest dirs
---ignore-missing-args    ignore missing source args without error
---delete-missing-args    delete missing source args from destination
---ignore-errors          delete even if there are I/O errors
---force                  force deletion of dirs even if not empty
---max-delete=NUM         don't delete more than NUM files
---max-size=SIZE          don't transfer any file larger than SIZE
---min-size=SIZE          don't transfer any file smaller than SIZE
---max-alloc=SIZE         change a limit relating to memory alloc
---partial                keep partially transferred files
---partial-dir=DIR        put a partially transferred file into DIR
---delay-updates          put all updated files into place at end
---prune-empty-dirs, -m   prune empty directory chains from file-list
---numeric-ids            don't map uid/gid values by user/group name
---usermap=STRING         custom username mapping
---groupmap=STRING        custom groupname mapping
---chown=USER:GROUP       simple username/groupname mapping
---timeout=SECONDS        set I/O timeout in seconds
---contimeout=SECONDS     set daemon connection timeout in seconds
---ignore-times, -I       don't skip files that match size and time
---size-only              skip files that match in size
---modify-window=NUM, -@  set the accuracy for mod-time comparisons
---temp-dir=DIR, -T       create temporary files in directory DIR
---fuzzy, -y              find similar file for basis if no dest file
---compare-dest=DIR       also compare destination files relative to DIR
---copy-dest=DIR          ... and include copies of unchanged files
---link-dest=DIR          hardlink to files in DIR when unchanged
---compress, -z           compress file data during the transfer
---compress-choice=STR    choose the compression algorithm (aka --zc)
---compress-level=NUM     explicitly set compression level (aka --zl)
---skip-compress=LIST     skip compressing files with suffix in LIST
---cvs-exclude, -C        auto-ignore files in the same way CVS does
---filter=RULE, -f        add a file-filtering RULE
--F                       same as --filter='dir-merge /.rsync-filter'
-                         repeated: --filter='- .rsync-filter'
---exclude=PATTERN        exclude files matching PATTERN
---exclude-from=FILE      read exclude patterns from FILE
---include=PATTERN        don't exclude files matching PATTERN
---include-from=FILE      read include patterns from FILE
---files-from=FILE        read list of source-file names from FILE
---from0, -0              all *-from/filter files are delimited by 0s
---old-args               disable the modern arg-protection idiom
---secluded-args, -s      use the protocol to safely send the args
---trust-sender           trust the remote sender's file list
---copy-as=USER[:GROUP]   specify user & optional group for the copy
---address=ADDRESS        bind address for outgoing socket to daemon
---port=PORT              specify double-colon alternate port number
---sockopts=OPTIONS       specify custom TCP options
---blocking-io            use blocking I/O for the remote shell
---outbuf=N|L|B           set out buffering to None, Line, or Block
---stats                  give some file-transfer stats
---8-bit-output, -8       leave high-bit chars unescaped in output
---human-readable, -h     output numbers in a human-readable format
---progress               show progress during transfer
--P                       same as --partial --progress
---itemize-changes, -i    output a change-summary for all updates
---remote-option=OPT, -M  send OPTION to the remote side only
---out-format=FORMAT      output updates using the specified FORMAT
---log-file=FILE          log what we're doing to the specified FILE
---log-file-format=FMT    log updates using the specified FMT
---password-file=FILE     read daemon-access password from FILE
---early-input=FILE       use FILE for daemon's early exec input
---list-only              list the files instead of copying them
---bwlimit=RATE           limit socket I/O bandwidth
---stop-after=MINS        Stop rsync after MINS minutes have elapsed
---stop-at=y-m-dTh:m      Stop rsync at the specified point in time
---fsync                  fsync every written file
---write-batch=FILE       write a batched update to FILE
---only-write-batch=FILE  like --write-batch but w/o updating dest
---read-batch=FILE        read a batched update from FILE
---protocol=NUM           force an older protocol version to be used
---iconv=CONVERT_SPEC     request charset conversion of filenames
---checksum-seed=NUM      set block/file checksum seed (advanced)
---ipv4, -4               prefer IPv4
---ipv6, -6               prefer IPv6
---version, -V            print the version + other info and exit
---help, -h (*)           show this help (* -h is help only on its own)
-
-
-Use "rsync --daemon --help" to see the daemon-mode command-line options.
-Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
-For project updates and documentation, visit https://github.com/oferchen/oc-rsync.
-
+--verbose	increaseverbosity
+--info=FLAGS	fine-grainedinformationalverbosity
+--debug=FLAGS	fine-graineddebugverbosity
+--stderr=e|a|c	changestderroutputmode(default:errors)
+--quiet	suppressnon-errormessages
+--no-motd	suppressdaemon-modeMOTD
+--checksum	skipbasedonchecksum,notmod-time&size
+--archive	archivemodeis-rlptgoD(no-A,-X,-U,-N,-H)
+--no-OPTION	turnoffanimpliedOPTION(e.g.--no-D)
+--recursive	recurseintodirectories
+--relative	userelativepathnames
+--no-implied-dirs	don'tsendimplieddirswith--relative
+--backup	makebackups(see--suffix&--backup-dir)
+--backup-dir=DIR	makebackupsintohierarchybasedinDIR
+--suffix=SUFFIX	backupsuffix(default~w/o--backup-dir)
+--update	skipfilesthatareneweronthereceiver
+--inplace	updatedestinationfilesin-place
+--append	appenddataontoshorterfiles
+--append-verify	--appendw/olddatainfilechecksum
+--dirs	transferdirectorieswithoutrecursing
+--old-dirs	workslike--dirswhentalkingtooldrsync
+--mkpath	createdestination'smissingpathcomponents
+--links	copysymlinksassymlinks
+--copy-links	transformsymlinkintoreferentfile/dir
+--copy-unsafe-links	only"unsafe"symlinksaretransformed
+--safe-links	ignoresymlinksthatpointoutsidethetree
+--munge-links	mungesymlinkstomakethemsafe&unusable
+--copy-dirlinks	transformsymlinktodirintoreferentdir
+--keep-dirlinks	treatsymlinkeddironreceiverasdir
+--hard-links	preservehardlinks
+--perms	preservepermissions
+--executability	preserveexecutability
+--chmod=CHMOD	affectfileand/ordirectorypermissions
+--acls	preserveACLs(implies--perms)
+--xattrs	preserveextendedattributes
+--owner	preserveowner(super-useronly)
+--group	preservegroup
+--devices	preservedevicefiles(super-useronly)
+--copy-devices	copydevicecontentsasaregularfile
+--write-devices	writetodevicesasfiles(implies--inplace)
+--specials	preservespecialfiles
+--times	preservemodificationtimes
+--atimes	preserveaccess(use)times
+--open-noatime	avoidchangingtheatimeonopenedfiles
+--crtimes	preservecreatetimes(newness)
+--omit-dir-times	omitdirectoriesfrom--times
+--omit-link-times	omitsymlinksfrom--times
+--super	receiverattemptssuper-useractivities
+--fake-super	store/recoverprivilegedattrsusingxattrs
+--sparse	turnsequencesofnullsintosparseblocks
+--preallocate	allocatedestfilesbeforewritingthem
+--dry-run	performatrialrunwithnochangesmade
+--whole-file	copyfileswhole(w/odelta-xferalgorithm)
+--checksum-choice=STR	choosethechecksumalgorithm(aka--cc)
+--one-file-system	don'tcrossfilesystemboundaries
+--block-size=SIZE	forceafixedchecksumblock-size
+--rsh=COMMAND	specifytheremoteshelltouse
+--rsync-path=PROGRAM	specifythersynctorunonremotemachine
+--existing	skipcreatingnewfilesonreceiver
+--ignore-existing	skipupdatingfilesthatexistonreceiver
+--remove-source-files	senderremovessynchronizedfiles(non-dir)
+--del	analiasfor--delete-during
+--delete	deleteextraneousfilesfromdestdirs
+--delete-before	receiverdeletesbeforexfer,notduring
+--delete-during	receiverdeletesduringthetransfer
+--delete-delay	finddeletionsduring,deleteafter
+--delete-after	receiverdeletesaftertransfer,notduring
+--delete-excluded	alsodeleteexcludedfilesfromdestdirs
+--ignore-missing-args	ignoremissingsourceargswithouterror
+--delete-missing-args	deletemissingsourceargsfromdestination
+--ignore-errors	deleteevenifthereareI/Oerrors
+--force	forcedeletionofdirsevenifnotempty
+--max-delete=NUM	don'tdeletemorethanNUMfiles
+--max-size=SIZE	don'ttransferanyfilelargerthanSIZE
+--min-size=SIZE	don'ttransferanyfilesmallerthanSIZE
+--max-alloc=SIZE	changealimitrelatingtomemoryalloc
+--partial	keeppartiallytransferredfiles
+--partial-dir=DIR	putapartiallytransferredfileintoDIR
+--delay-updates	putallupdatedfilesintoplaceatend
+--prune-empty-dirs	pruneemptydirectorychainsfromfile-list
+--numeric-ids	don'tmapuid/gidvaluesbyuser/groupname
+--usermap=STRING	customusernamemapping
+--groupmap=STRING	customgroupnamemapping
+--chown=USER:GROUP	simpleusername/groupnamemapping
+--timeout=SECONDS	setI/Otimeoutinseconds
+--contimeout=SECONDS	setdaemonconnectiontimeoutinseconds
+--ignore-times	don'tskipfilesthatmatchsizeandtime
+--size-only	skipfilesthatmatchinsize
+--modify-window=NUM	settheaccuracyformod-timecomparisons
+--temp-dir=DIR	createtemporaryfilesindirectoryDIR
+--fuzzy	findsimilarfileforbasisifnodestfile
+--compare-dest=DIR	alsocomparedestinationfilesrelativetoDIR
+--copy-dest=DIR	...andincludecopiesofunchangedfiles
+--link-dest=DIR	hardlinktofilesinDIRwhenunchanged
+--compress	compressfiledataduringthetransfer
+--compress-choice=STR	choosethecompressionalgorithm(aka--zc)
+--compress-level=NUM	explicitlysetcompressionlevel(aka--zl)
+--skip-compress=LIST	skipcompressingfileswithsuffixinLIST
+--cvs-exclude	auto-ignorefilesinthesamewayCVSdoes
+--filter=RULE	addafile-filteringRULE
+--exclude=PATTERN	excludefilesmatchingPATTERN
+--exclude-from=FILE	readexcludepatternsfromFILE
+--include=PATTERN	don'texcludefilesmatchingPATTERN
+--include-from=FILE	readincludepatternsfromFILE
+--files-from=FILE	readlistofsource-filenamesfromFILE
+--from0	all*-from/filterfilesaredelimitedby0s
+--old-args	disablethemodernarg-protectionidiom
+--secluded-args	usetheprotocoltosafelysendtheargs
+--trust-sender	trusttheremotesender'sfilelist
+--copy-as=USER[:GROUP]	specifyuser&optionalgroupforthecopy
+--address=ADDRESS	bindaddressforoutgoingsockettodaemon
+--port=PORT	specifydouble-colonalternateportnumber
+--sockopts=OPTIONS	specifycustomTCPoptions
+--blocking-io	useblockingI/Ofortheremoteshell
+--outbuf=N|L|B	setoutbufferingtoNone,Line,orBlock
+--stats	givesomefile-transferstats
+--8-bit-output	leavehigh-bitcharsunescapedinoutput
+--human-readable	outputnumbersinahuman-readableformat
+--progress	showprogressduringtransfer
+--itemize-changes	outputachange-summaryforallupdates
+--remote-option=OPT	sendOPTIONtotheremotesideonly
+--out-format=FORMAT	outputupdatesusingthespecifiedFORMAT
+--log-file=FILE	logwhatwe'redoingtothespecifiedFILE
+--log-file-format=FMT	logupdatesusingthespecifiedFMT
+--password-file=FILE	readdaemon-accesspasswordfromFILE
+--early-input=FILE	useFILEfordaemon'searlyexecinput
+--list-only	listthefilesinsteadofcopyingthem
+--bwlimit=RATE	limitsocketI/Obandwidth
+--stop-after=MINS	StoprsyncafterMINSminuteshaveelapsed
+--stop-at=y-m-dTh:m	Stoprsyncatthespecifiedpointintime
+--fsync	fsynceverywrittenfile
+--write-batch=FILE	writeabatchedupdatetoFILE
+--only-write-batch=FILE	like--write-batchbutw/oupdatingdest
+--read-batch=FILE	readabatchedupdatefromFILE
+--protocol=NUM	forceanolderprotocolversiontobeused
+--iconv=CONVERT_SPEC	requestcharsetconversionoffilenames
+--checksum-seed=NUM	setblock/filechecksumseed(advanced)
+--ipv4	preferIPv4
+--ipv6	preferIPv6
+--version	printtheversion+otherinfoandexit
+--help	showthishelp(*-hishelponlyonitsown)


### PR DESCRIPTION
## Summary
- expose `cli_command` directly from options to avoid duplicate dump-help-body flag
- use `dump_help_body` helper for early help printing
- refresh golden help outputs

## Testing
- `cargo test --test bin_branding --test help_output`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: tcp_read_timeout and many others)*
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: additional comments)*

------
https://chatgpt.com/codex/tasks/task_e_68b9fbd46a78832388b4d44b7d7c0a76