### PR TITLE
Remove duplicated cfg from SSH transport

### DIFF
--- a/crates/engine/benches/preallocate.rs
+++ b/crates/engine/benches/preallocate.rs
@@ -1,6 +1,8 @@
 // crates/engine/benches/preallocate.rs
+use compress::available_codecs;
 use criterion::{criterion_group, criterion_main, Criterion};
 use engine::{sync, SyncOptions};
+use filters::Matcher;
 use std::fs;
 use tempfile::tempdir;
 
@@ -17,7 +19,7 @@ fn bench_preallocate(c: &mut Criterion) {
                 preallocate: true,
                 ..SyncOptions::default()
             };
-            sync(&src, &dst, &opts).unwrap();
+            sync(&src, &dst, &Matcher::default(), &available_codecs(), &opts).unwrap();
         });
     });
 }

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -1,6 +1,4 @@
 // crates/transport/src/ssh.rs
-#![cfg(unix)]
-#![allow(clippy::duplicated_attributes)]
 
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::poll::{poll, PollFd, PollFlags, PollTimeout};


### PR DESCRIPTION
## Summary
- remove crate-level `cfg(unix)` and duplicated-attribute allow from SSH transport
- update engine preallocate bench for new sync signature

## Testing
- `cargo clippy --workspace --all-targets`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` *(fails: useless use of vec and match_result_ok)*
- `cargo nextest run --workspace --no-fail-fast` *(interrupted: 78/826 tests run)*
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9fdb57b748323a8df143ec4457977