### PR TITLE
Handle unknown clap error kinds

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -68,7 +68,7 @@ pub fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
         Io => ExitCode::FileIo,
         Format => ExitCode::FileIo,
         #[allow(unreachable_patterns)]
-        _ => unreachable!("unhandled clap::ErrorKind variant"),
+        _ => ExitCode::SyntaxOrUsage,
     }
 }
 
@@ -1697,5 +1697,13 @@ mod tests {
 
         env::set_current_dir(prev).unwrap();
         handle.join().unwrap();
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    #[allow(clippy::transmute)]
+    fn exit_code_handles_unknown_error_kind() {
+        let kind: clap::error::ErrorKind = unsafe { std::mem::transmute(u8::MAX) };
+        assert_eq!(exit_code_from_error_kind(kind), ExitCode::SyntaxOrUsage);
     }
 }


### PR DESCRIPTION
## Summary
- Map unexpected `clap::ErrorKind` variants to `ExitCode::SyntaxOrUsage`
- Test that unknown `ErrorKind` values return the default exit code

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: removes_temp_dir_after_sync, backups_use_custom_suffix, include_from_null_separated, and others)*
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba044c1a688323ba615ff7a4a6d0b0