### PR TITLE
refactor: rely on parsed dump-help-body flag

### DIFF
--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -382,7 +382,7 @@ pub fn dump_help_body(cmd: &Command) -> String {
     }
     let mut out = String::new();
     let mut in_options = false;
-    let stop_marker = "Use \"rsync --daemon --help\""; // branding replaced in render_help
+    let stop_marker = "Use \"rsync --daemon --help\"";
     for line in help.lines() {
         if line.trim() == "Options" {
             in_options = true;

--- a/src/bin/oc-rsync/main.rs
+++ b/src/bin/oc-rsync/main.rs
@@ -8,11 +8,6 @@ use std::io::ErrorKind;
 
 fn main() {
     let args: Vec<_> = std::env::args_os().collect();
-    if args.iter().any(|a| a == "--dump-help-body") {
-        let cmd = cli_command();
-        print!("{}", oc_rsync_cli::dump_help_body(&cmd));
-        return;
-    }
     if oc_rsync_cli::print_version_if_requested(args.iter().cloned()) {
         return;
     }

--- a/tests/help_output.rs
+++ b/tests/help_output.rs
@@ -8,8 +8,10 @@ fn dump_help_body_lists_unique_options() {
     let output = Command::cargo_bin("oc-rsync")
         .unwrap()
         .arg("--dump-help-body")
-        .output()
-        .unwrap();
+        .assert()
+        .success()
+        .get_output()
+        .clone();
 
     let mut seen = HashSet::new();
     for line in String::from_utf8_lossy(&output.stdout).lines() {
@@ -32,8 +34,10 @@ fn help_matches_snapshot() {
         .env("LC_ALL", "C")
         .env("LANG", "C")
         .arg("--dump-help-body")
-        .output()
-        .unwrap();
+        .assert()
+        .success()
+        .get_output()
+        .clone();
 
     let actual = output.stdout;
     let expected = fs::read("tests/golden/help/oc-rsync.help").unwrap();
@@ -48,8 +52,10 @@ fn dump_help_body_60_matches_golden() {
         .env("LC_ALL", "C")
         .env("LANG", "C")
         .arg("--dump-help-body")
-        .output()
-        .unwrap();
+        .assert()
+        .success()
+        .get_output()
+        .clone();
 
     let expected = fs::read("tests/golden/help/oc-rsync.dump-help-body.60").unwrap();
     assert_eq!(output.stdout, expected, "dump-help-body width 60 mismatch");
@@ -63,8 +69,10 @@ fn dump_help_body_100_matches_golden() {
         .env("LC_ALL", "C")
         .env("LANG", "C")
         .arg("--dump-help-body")
-        .output()
-        .unwrap();
+        .assert()
+        .success()
+        .get_output()
+        .clone();
 
     let expected = fs::read("tests/golden/help/oc-rsync.dump-help-body.100").unwrap();
     assert_eq!(output.stdout, expected, "dump-help-body width 100 mismatch");


### PR DESCRIPTION
## Summary
- remove pre-parse `--dump-help-body` handling in `oc-rsync`
- assert command success in help output tests
- drop stray comment in formatter to satisfy comment linter

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl -> resolved by installing libacl1-dev; then test `parse_tcp_nodelay_invalid` failed)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --all-features` *(fails: Broken pipe (os error 32))*


------
https://chatgpt.com/codex/tasks/task_e_68ba046c6584832397152c685fcfb66c