### PR TITLE
Lowercase skip-compress options during parsing

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1490,7 +1490,7 @@ mod tests {
 
     #[test]
     fn parses_skip_compress_list() {
-        let opts = ClientOpts::parse_from(["prog", "--skip-compress=gz,zip", "src", "dst"]);
+        let opts = ClientOpts::parse_from(["prog", "--skip-compress=GZ,Zip", "src", "dst"]);
         assert_eq!(opts.skip_compress, vec!["gz", "zip"]);
     }
 

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -12,6 +12,10 @@ use clap::{Arg, ArgAction, Args, CommandFactory, Parser, ValueEnum};
 use logging::{DebugFlag, InfoFlag, StderrMode};
 use protocol::SUPPORTED_PROTOCOLS;
 
+fn parse_lowercase(value: &str) -> Result<String, String> {
+    Ok(value.to_ascii_lowercase())
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 #[clap(rename_all = "UPPER")]
 pub enum OutBuf {
@@ -432,7 +436,8 @@ pub(crate) struct ClientOpts {
         long = "skip-compress",
         value_name = "LIST",
         help_heading = "Compression",
-        value_delimiter = ','
+        value_delimiter = ',',
+        value_parser = parse_lowercase
     )]
     pub skip_compress: Vec<String>,
 

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -100,10 +100,7 @@ pub fn should_compress(path: &Path, skip: &[String]) -> bool {
         return !DEFAULT_SKIP_COMPRESS.iter().any(|s| name.ends_with(s));
     }
 
-    !skip
-        .iter()
-        .map(|s| s.to_ascii_lowercase())
-        .any(|s| name.ends_with(&s))
+    !skip.iter().any(|s| name.ends_with(s))
 }
 
 #[cfg(feature = "zlib")]

--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -112,7 +112,7 @@ fn should_compress_respects_default_list() {
 fn should_compress_handles_mixed_case_patterns() {
     assert!(!should_compress(
         Path::new("file.TXT"),
-        &["tXt".to_string()]
+        &["txt".to_string()]
     ));
 }
 


### PR DESCRIPTION
## Summary
- Assume skip patterns are pre-lowercased in `should_compress`
- Normalize `--skip-compress` arguments to lowercase during CLI parsing
- Test case-insensitive handling of skip-compress values

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: removes_temp_dir_after_sync, backups_use_custom_suffix, filters tests, etc.)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: engine::attrs sparse tests, etc.)*
- `make verify-comments` *(fails: crates/cli/src/formatter.rs: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba04817a448323b32193e72a3fa522