### PR TITLE
Remove obsolete old-d flag check

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -108,9 +108,6 @@ pub fn handle_clap_error(cmd: &clap::Command, e: clap::Error) -> ! {
 pub fn run(matches: &clap::ArgMatches) -> Result<()> {
     let mut opts =
         ClientOpts::from_arg_matches(matches).map_err(|e| EngineError::Other(e.to_string()))?;
-    if matches.contains_id("old-d") {
-        opts.old_dirs = true;
-    }
     if opts.no_D {
         opts.no_devices = true;
         opts.no_specials = true;


### PR DESCRIPTION
## Summary
- simplify `run` by relying on `ClientOpts.old_dirs` instead of checking `old-d`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `/usr/bin/ld: cannot find -lacl`)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: `/usr/bin/ld: cannot find -lacl`)*
- `cargo test --test bin_daemon` *(fails: `/usr/bin/ld: cannot find -lacl`)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8609c4288323bf7f8281965a47c3