### PR TITLE
Use hex::encode in checksum seed test

### DIFF
--- a/tests/checksum_seed.rs
+++ b/tests/checksum_seed.rs
@@ -20,8 +20,8 @@ fn checksum_seed_changes_strong_checksum() {
     let cfg1 = ChecksumConfigBuilder::new().seed(1).build();
     let strong0 = cfg0.checksum(data).strong;
     let strong1 = cfg1.checksum(data).strong;
-    let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
-    let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
+    let hex0 = hex::encode(&strong0);
+    let hex1 = hex::encode(&strong1);
     assert_eq!(hex0, "ea91f391e02b5e19f432b43bd87a531d");
     assert_eq!(hex1, "92e5994e0babddace03f0ff88f767181");
     assert_ne!(hex0, hex1);
@@ -40,8 +40,8 @@ fn checksum_seed_changes_strong_checksum_md5() {
         .build();
     let strong0 = cfg0.checksum(data).strong;
     let strong1 = cfg1.checksum(data).strong;
-    let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
-    let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
+    let hex0 = hex::encode(&strong0);
+    let hex1 = hex::encode(&strong1);
     assert_eq!(hex0, "be4b47980f89d075f8f7e7a9fab84e29");
     assert_eq!(hex1, "157438ee5881306a9af554cc9b3e5974");
     assert_ne!(hex0, hex1);
@@ -60,8 +60,8 @@ fn checksum_seed_changes_strong_checksum_sha1() {
         .build();
     let strong0 = cfg0.checksum(data).strong;
     let strong1 = cfg1.checksum(data).strong;
-    let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
-    let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
+    let hex0 = hex::encode(&strong0);
+    let hex1 = hex::encode(&strong1);
     assert_eq!(hex0, "1fb6475c524899f98b088f7608bdab8f1591e078");
     assert_eq!(hex1, "076b085b6d84fa708d235291ae6ac3059b45bb37");
     assert_ne!(hex0, hex1);
@@ -80,8 +80,8 @@ fn checksum_seed_changes_strong_checksum_xxh64() {
         .build();
     let strong0 = cfg0.checksum(data).strong;
     let strong1 = cfg1.checksum(data).strong;
-    let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
-    let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
+    let hex0 = hex::encode(&strong0);
+    let hex1 = hex::encode(&strong1);
     assert_eq!(hex0, "45ab6734b21e6968");
     assert_eq!(hex1, "b01b03c5241fb7c7");
     assert_ne!(hex0, hex1);
@@ -100,8 +100,8 @@ fn checksum_seed_changes_strong_checksum_xxh3() {
         .build();
     let strong0 = cfg0.checksum(data).strong;
     let strong1 = cfg1.checksum(data).strong;
-    let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
-    let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
+    let hex0 = hex::encode(&strong0);
+    let hex1 = hex::encode(&strong1);
     assert_eq!(hex0, "d447b1ea40e6988b");
     assert_eq!(hex1, "b7aeb52a10fdaf2d");
     assert_ne!(hex0, hex1);
@@ -120,8 +120,8 @@ fn checksum_seed_changes_strong_checksum_xxh128() {
         .build();
     let strong0 = cfg0.checksum(data).strong;
     let strong1 = cfg1.checksum(data).strong;
-    let hex0: String = strong0.iter().map(|b| format!("{:02x}", b)).collect();
-    let hex1: String = strong1.iter().map(|b| format!("{:02x}", b)).collect();
+    let hex0 = hex::encode(&strong0);
+    let hex1 = hex::encode(&strong1);
     assert_eq!(hex0, "df8d09e93f874900a99b8775cc15b6c7");
     assert_eq!(hex1, "fa3a96b27c8228fc9c199070b6177663");
     assert_ne!(hex0, hex1);


### PR DESCRIPTION
## Summary
- use `hex::encode` for digest comparisons in checksum seed tests
- verify golden checksum tests already rely on `hex::encode`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: cannot find -lacl)*
- `cargo test --workspace` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba9376406c8323ac25101987e1c714