### PR TITLE
Switch xxhash outputs to big-endian

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -95,9 +95,9 @@ pub fn strong_digest(data: &[u8], alg: StrongHash, seed: u32) -> Vec<u8> {
             hasher.update(data);
             hasher.finalize().to_vec()
         }
-        StrongHash::Xxh64 => xxh64(data, seed as u64).to_le_bytes().to_vec(),
-        StrongHash::Xxh3 => xxh3_64_with_seed(data, seed as u64).to_le_bytes().to_vec(),
-        StrongHash::Xxh128 => xxh3_128_with_seed(data, seed as u64).to_le_bytes().to_vec(),
+        StrongHash::Xxh64 => xxh64(data, seed as u64).to_be_bytes().to_vec(),
+        StrongHash::Xxh3 => xxh3_64_with_seed(data, seed as u64).to_be_bytes().to_vec(),
+        StrongHash::Xxh128 => xxh3_128_with_seed(data, seed as u64).to_be_bytes().to_vec(),
     }
 }
 
@@ -402,25 +402,16 @@ mod tests {
         );
 
         let digest_xxh64 = strong_digest(b"hello world", StrongHash::Xxh64, 0);
-        assert_eq!(hex::encode(&digest_xxh64), "68691eb23467ab45");
-        let mut be64 = digest_xxh64.clone();
-        be64.reverse();
-        assert_eq!(hex::encode(be64), "45ab6734b21e6968");
+        assert_eq!(hex::encode(&digest_xxh64), "45ab6734b21e6968");
 
         let digest_xxh3 = strong_digest(b"hello world", StrongHash::Xxh3, 0);
-        assert_eq!(hex::encode(&digest_xxh3), "8b98e640eab147d4");
-        let mut be3 = digest_xxh3.clone();
-        be3.reverse();
-        assert_eq!(hex::encode(be3), "d447b1ea40e6988b");
+        assert_eq!(hex::encode(&digest_xxh3), "d447b1ea40e6988b");
 
         let digest_xxh128 = strong_digest(b"hello world", StrongHash::Xxh128, 0);
         assert_eq!(
             hex::encode(&digest_xxh128),
-            "c7b615cc75879ba90049873fe9098ddf",
+            "df8d09e93f874900a99b8775cc15b6c7",
         );
-        let mut be128 = digest_xxh128.clone();
-        be128.reverse();
-        assert_eq!(hex::encode(be128), "df8d09e93f874900a99b8775cc15b6c7",);
     }
 
     #[test]

--- a/crates/checksums/tests/golden.rs
+++ b/crates/checksums/tests/golden.rs
@@ -71,25 +71,16 @@ fn builder_strong_digests() {
 
     let cs_xxh64 = cfg_xxh64.checksum(data);
     assert_eq!(cs_xxh64.weak, rolling_checksum(data));
-    assert_eq!(hex::encode(&cs_xxh64.strong), "68691eb23467ab45");
-    let mut be64 = cs_xxh64.strong.clone();
-    be64.reverse();
-    assert_eq!(hex::encode(be64), "45ab6734b21e6968");
+    assert_eq!(hex::encode(&cs_xxh64.strong), "45ab6734b21e6968");
 
     let cs_xxh3 = cfg_xxh3.checksum(data);
     assert_eq!(cs_xxh3.weak, rolling_checksum(data));
-    assert_eq!(hex::encode(&cs_xxh3.strong), "8b98e640eab147d4");
-    let mut be3 = cs_xxh3.strong.clone();
-    be3.reverse();
-    assert_eq!(hex::encode(be3), "d447b1ea40e6988b");
+    assert_eq!(hex::encode(&cs_xxh3.strong), "d447b1ea40e6988b");
 
     let cs_xxh128 = cfg_xxh128.checksum(data);
     assert_eq!(cs_xxh128.weak, rolling_checksum(data));
     assert_eq!(
         hex::encode(&cs_xxh128.strong),
-        "c7b615cc75879ba90049873fe9098ddf",
+        "df8d09e93f874900a99b8775cc15b6c7",
     );
-    let mut be128 = cs_xxh128.strong.clone();
-    be128.reverse();
-    assert_eq!(hex::encode(be128), "df8d09e93f874900a99b8775cc15b6c7",);
 }

--- a/crates/checksums/tests/rsync.rs
+++ b/crates/checksums/tests/rsync.rs
@@ -49,10 +49,10 @@ fn parity_with_rsync_xxh64() {
     let data = b"hello world";
     let seed = 1;
     let ours = strong_digest(data, StrongHash::Xxh64, seed);
-    assert_eq!(golden("xxh64", "le"), hex::encode(&ours));
-    let mut be = ours.clone();
-    be.reverse();
-    assert_eq!(golden("xxh64", "be"), hex::encode(be));
+    assert_eq!(golden("xxh64", "be"), hex::encode(&ours));
+    let mut le = ours.clone();
+    le.reverse();
+    assert_eq!(golden("xxh64", "le"), hex::encode(le));
 }
 
 #[test]
@@ -60,10 +60,10 @@ fn parity_with_rsync_xxh3() {
     let data = b"hello world";
     let seed = 1;
     let ours = strong_digest(data, StrongHash::Xxh3, seed);
-    assert_eq!(golden("xxh3", "le"), hex::encode(&ours));
-    let mut be = ours.clone();
-    be.reverse();
-    assert_eq!(golden("xxh3", "be"), hex::encode(be));
+    assert_eq!(golden("xxh3", "be"), hex::encode(&ours));
+    let mut le = ours.clone();
+    le.reverse();
+    assert_eq!(golden("xxh3", "le"), hex::encode(le));
 }
 
 #[test]
@@ -71,8 +71,8 @@ fn parity_with_rsync_xxh128() {
     let data = b"hello world";
     let seed = 1;
     let ours = strong_digest(data, StrongHash::Xxh128, seed);
-    assert_eq!(golden("xxh128", "le"), hex::encode(&ours));
-    let mut be = ours.clone();
-    be.reverse();
-    assert_eq!(golden("xxh128", "be"), hex::encode(be));
+    assert_eq!(golden("xxh128", "be"), hex::encode(&ours));
+    let mut le = ours.clone();
+    le.reverse();
+    assert_eq!(golden("xxh128", "le"), hex::encode(le));
 }


### PR DESCRIPTION
## Summary
- emit xxhash-based strong digests as big-endian bytes
- adjust checksum tests to expect big-endian xxhash values

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p checksums`
- `cargo test --workspace` (fails: `backups_use_custom_suffix` missing file)
- `cargo nextest run --workspace --no-fail-fast` (fails: many tests)
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba937295648323aff92928ecf51215