### PR TITLE
Document libacl requirement and warn when missing

### DIFF
--- a/.github/workflows/daily-status.yml
+++ b/.github/workflows/daily-status.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           toolchain: stable
           override: true
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
       - run: cargo install cargo-llvm-cov
       - run: cargo install cargo-nextest
       - run: mkdir -p reports && cargo llvm-cov nextest --workspace --json --summary-only --output-path reports/coverage.json -- --no-fail-fast

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,6 +995,7 @@ dependencies = [
  "meta",
  "nix 0.27.1",
  "oc-rsync-cli",
+ "pkg-config",
  "posix-acl",
  "predicates",
  "protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ posix-acl = "1.2"
 
 [build-dependencies]
 time = { version = "0.3", default-features = false, features = ["std"] }
+pkg-config = "0.3"
 
 [[bin]]
 name = "oc-rsync"

--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ sudo rpm -i oc-rsync-<version>.x86_64.rpm
 
 #### Prerequisites
 
-The source build requires a C toolchain and compression libraries:
+The source build requires a C toolchain, compression libraries, and ACL headers:
 
 - `build-essential` (provides `gcc`/`ld`)
 - `libzstd-dev`
 - `zlib1g-dev`
+- `libacl1-dev`
 
 On Debian/Ubuntu systems:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y build-essential libzstd-dev zlib1g-dev
+sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 ```
 
 Run `scripts/preflight.sh` to verify these dependencies before building. Then

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 // build.rs
 
 use std::{env, fs, path::Path};
+
 use time::OffsetDateTime;
 
 const UPSTREAM_VERSION: &str = "3.4.1";
@@ -17,6 +18,12 @@ const BRANDING_VARS: &[&str] = &[
 fn main() {
     let revision = env::var("BUILD_REVISION").unwrap_or_else(|_| "unknown".to_string());
     let official = env::var("OFFICIAL_BUILD").unwrap_or_else(|_| "unofficial".to_string());
+
+    if env::var_os("CARGO_FEATURE_ACL").is_some() && pkg_config::Config::new().probe("acl").is_err()
+    {
+        println!("cargo:warning=libacl not found; ACL support will be disabled");
+        println!("cargo:rustc-cfg=libacl_missing");
+    }
 
     let protocols = UPSTREAM_PROTOCOLS
         .iter()

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,17 +2,18 @@
 
 ## Required system packages
 
-To build oc-rsync from source you need a working C toolchain and compression libraries:
+To build oc-rsync from source you need a working C toolchain, compression libraries, and ACL headers:
 
 - `build-essential` (provides `gcc` and `ld`)
 - `libzstd-dev`
 - `zlib1g-dev`
+- `libacl1-dev`
 
 Install them on Debian/Ubuntu with:
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y build-essential libzstd-dev zlib1g-dev
+sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 ```
 
 Run `scripts/preflight.sh` to verify these dependencies before compiling.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -15,6 +15,10 @@ if ! ldconfig -p 2>/dev/null | grep -q 'libz\.so'; then
   missing+=("zlib (install zlib1g-dev)")
 fi
 
+if ! ldconfig -p 2>/dev/null | grep -q libacl; then
+  missing+=("libacl (install libacl1-dev)")
+fi
+
 if ((${#missing[@]})); then
   echo "Error: missing required build dependencies:" >&2
   for dep in "${missing[@]}"; do


### PR DESCRIPTION
## Summary
- document libacl as a required build dependency in README and install guide
- warn in build.rs when libacl headers are missing and add preflight check
- ensure daily-status CI workflow installs libacl development package

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(failed: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_68baa8464a50832390b83e8e42f82f7b