### PR TITLE
Add Homebrew formula

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Validate interop matrix docs
         run: scripts/check-run-matrix-docs.sh
 
+      - name: Lint Homebrew formula
+        run: brew audit --strict --new-formula ./packaging/brew/oc-rsync.rb
+
       - name: Check CLI help against transcript
         run: |
           cargo run --quiet --bin oc-rsync -- --help | tail -n +4 > /tmp/oc-rsync-help.txt

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ sudo dpkg -i oc-rsync_<version>_amd64.deb
 
 # Fedora/RHEL
 sudo rpm -i oc-rsync-<version>.x86_64.rpm
+
+# Homebrew
+brew install --build-from-source ./packaging/brew/oc-rsync.rb
 ```
 
 ### From source

--- a/packaging/brew/oc-rsync.rb
+++ b/packaging/brew/oc-rsync.rb
@@ -1,0 +1,21 @@
+class OcRsync < Formula
+  desc "Pure-Rust rsync replica"
+  homepage "https://github.com/oferchen/oc-rsync"
+  url "https://github.com/oferchen/oc-rsync/archive/refs/heads/main.tar.gz"
+  sha256 "c5f90968dd721c6c062b7441227d3f5582b40fc2e21b90243ee2d896d7f19abf"
+  license "Apache-2.0"
+  head "https://github.com/oferchen/oc-rsync.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "."), "--bin", "oc-rsync", "--bin", "oc-rsyncd"
+    man1.install "man/oc-rsync.1"
+    man8.install "man/oc-rsyncd.8"
+    man5.install "man/oc-rsyncd.conf.5"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/oc-rsync --version")
+  end
+end


### PR DESCRIPTION
## Summary
- package oc-rsync for Homebrew with binaries and manpages
- document local Homebrew build
- lint the Homebrew formula in CI

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: missing temp dir and backup suffix tests; include_from_* and list parsing tests)*
- `make verify-comments`
- `make lint`
- `brew audit --strict --new-formula ./packaging/brew/oc-rsync.rb` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa7ae43d4832388976ba1651f9cee