### PR TITLE
docs: update feature gaps

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -35,6 +35,7 @@ when available. Do not exceed functionality of upstream at <https://rsync.samba.
 | Composite `--archive` flag expansion | ✅ | [tests/archive.rs](../tests/archive.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | Remote-only option parsing (`--remote-option`) | ✅ | [tests/interop/remote_option.rs](../tests/interop/remote_option.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | `--version` output parity | ✅ | [tests/version_output.rs](../tests/version_output.rs) | [crates/cli/src/version.rs](../crates/cli/src/version.rs) |
+| Null-delimited list parsing (`--from0`) | ✅ | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 
 Note: [tests/archive.rs](../tests/archive.rs) demonstrates the composite `--archive` flag expansion.
 
@@ -64,13 +65,14 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | --- | --- | --- | --- |
 | zstd and zlib codecs | Implemented | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/lib.rs](../crates/compress/src/lib.rs) |
 | `--skip-compress` suffix handling | Implemented | [tests/skip_compress.rs](../tests/skip_compress.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
-| LZ4 codec (experimental) | Planned post-parity ([#873](https://github.com/oferchen/oc-rsync/pull/873)) | — | — |
+| LZ4 codec | Removed pending parity ([#1183](https://github.com/oferchen/oc-rsync/pull/1183)); planned post-parity ([#873](https://github.com/oferchen/oc-rsync/pull/873)) | — | — |
 
 ## Filters
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
 | Include/Exclude parser | Implemented | [crates/filters/tests/include_exclude.rs](../crates/filters/tests/include_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | `.rsync-filter` merge semantics | Implemented | [crates/filters/tests/merge.rs](../crates/filters/tests/merge.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| Null-delimited filter lists and merges (`--from0`) | Implemented | [crates/filters/tests/include_from.rs](../crates/filters/tests/include_from.rs)<br>[crates/filters/tests/from0_merges.rs](../crates/filters/tests/from0_merges.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Rule logging and statistics | Implemented | [crates/filters/tests/rule_stats.rs](../crates/filters/tests/rule_stats.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 
 ## File Selection
@@ -89,6 +91,7 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | Permissions and ownership restoration | Implemented | [crates/meta/tests/chmod.rs](../crates/meta/tests/chmod.rs) | [crates/meta/src/unix.rs](../crates/meta/src/unix.rs) |
 | `--fake-super` xattr fallback | Implemented | [crates/meta/tests/fake_super.rs](../crates/meta/tests/fake_super.rs) | [crates/meta/src/unix.rs](../crates/meta/src/unix.rs) |
 | POSIX ACL preservation | Implemented | [crates/meta/tests/acl_roundtrip.rs](../crates/meta/tests/acl_roundtrip.rs) | [crates/meta/src/unix.rs](../crates/meta/src/unix.rs) |
+| Windows metadata preservation | Implemented | [tests/windows.rs](../tests/windows.rs) | [crates/meta/src/windows.rs](../crates/meta/src/windows.rs) |
 
 ## Transport
 | Feature | Status | Tests | Source |

--- a/man/oc-rsync.1
+++ b/man/oc-rsync.1
@@ -28,6 +28,13 @@ For a complete list of flags and their implementation status, see the
 feature matrix, which is the authoritative reference for contributors.
 The full \f[V]--help\f[R] output is captured in cli-help.txt and checked
 in CI to match the binary.
+The upstream \f[V]rsync --help\f[R] text wrapped to 80 columns is stored
+in \f[V]crates/cli/resources/rsync-help-80.txt\f[R].
+A unit test derives the expected option ordering from this file and
+compares it to the \f[V]ARG_ORDER\f[R] constant used to render our help
+text.
+If upstream adds or reorders options, update this resource and adjust
+\f[V]ARG_ORDER\f[R] so the test continues to pass.
 .SS Usage
 .IP
 .nf
@@ -1747,6 +1754,33 @@ Built-in defaults
 .PP
 No configuration file is loaded unless \f[V]--config\f[R] is supplied.
 Settings specified earlier in the list override later sources.
+.SS Branding environment variables
+.PP
+The CLI\[cq]s branding can be customized at runtime via the following
+environment variables:
+.IP \[bu] 2
+\f[V]OC_RSYNC_BRAND_NAME\f[R] \[en] override the displayed program name.
+.IP \[bu] 2
+\f[V]OC_RSYNC_BRAND_TAGLINE\f[R] \[en] one-line tagline shown in
+\f[V]--help\f[R] output.
+.IP \[bu] 2
+\f[V]OC_RSYNC_BRAND_URL\f[R] \[en] project URL printed in
+\f[V]--help\f[R] and \f[V]--version\f[R].
+.IP \[bu] 2
+\f[V]OC_RSYNC_BRAND_COPYRIGHT\f[R] \[en] copyright line used in
+\f[V]--version\f[R] output.
+.IP \[bu] 2
+\f[V]OC_RSYNC_HIDE_CREDITS\f[R] \[en] if set to a non-zero value, hides
+the tagline and URL.
+.IP \[bu] 2
+\f[V]OC_RSYNC_VERSION_PREFIX\f[R] \[en] prefix prepended to the package
+version.
+.IP \[bu] 2
+\f[V]OC_RSYNC_HELP_HEADER\f[R] \[en] replaces the default help header
+text.
+.IP \[bu] 2
+\f[V]OC_RSYNC_VERSION_HEADER\f[R] \[en] replaces the default version
+header text.
 .SS Filters
 .PP
 \f[V]oc-rsync\f[R] supports include and exclude rules using the same

--- a/man/oc-rsyncd.8
+++ b/man/oc-rsyncd.8
@@ -35,6 +35,10 @@ Daemon behaviour and module definitions are controlled by the
 configuration file \f[V]oc-rsyncd.conf(5)\f[R].
 Clients connect using \f[V]oc-rsync(1)\f[R] and specify a module name in
 the \f[V]rsync://\f[R] URL.
+.PP
+Windows hosts are supported with the same path and metadata semantics as
+Unix systems, including normalization of extended
+\f[V]\[rs]\[rs]?\[rs]\f[R] paths and propagation of ACLs and timestamps.
 .SS Options
 .PP
 These flags influence the daemon when run from the command line:

--- a/man/oc-rsyncd.conf.5
+++ b/man/oc-rsyncd.conf.5
@@ -29,27 +29,99 @@ The \f[V]-4\f[R] and \f[V]-6\f[R] flags restrict the listener to IPv4 or
 IPv6 addresses respectively.
 These can be combined with \f[V]--address\f[R] to bind a specific
 interface.
+.SS \f[V]oc-rsyncd\f[R]
+.PP
+A dedicated \f[V]oc-rsyncd\f[R] binary ships alongside the main CLI and
+enables daemon mode without remembering \f[V]--daemon\f[R].
+It is functionally equivalent to invoking \f[V]oc-rsync --daemon\f[R]
+and exposes the same flags.
+.IP
+.nf
+\f[C]
+$ oc-rsyncd --help
+Usage: oc-rsyncd [OPTIONS] --module NAME=PATH...
+
+Options:
+  --config <FILE>        Load daemon configuration
+  --module <NAME=PATH>   Export a module (repeatable)
+  --address <ADDRESS>    Bind to a specific interface
+  --port <PORT>          Listen on a custom TCP port
+  --secrets-file <FILE>  Authentication tokens
+  --no-detach            Stay in the foreground
+\f[R]
+.fi
+.PP
+Common invocations:
+.IP
+.nf
+\f[C]
+# Inline module definition
+oc-rsyncd --module \[aq]data=/srv/export\[aq]
+
+# Load modules from a config file
+oc-rsyncd --config /etc/oc-rsyncd.conf
+\f[R]
+.fi
+.PP
+The configuration syntax is documented in \f[V]oc-rsyncd.conf(5)\f[R].
+A hardened systemd unit is available under
+\f[V]packaging/systemd/oc-rsyncd.service\f[R].
+.PP
+The \f[V]oc-rsync\f[R] client can also launch the daemon directly:
+.IP
+.nf
+\f[C]
+oc-rsync --daemon --module \[aq]data=/srv/export\[aq]
+\f[R]
+.fi
+.SS Configuration file
+.PP
+\f[V]oc-rsync\f[R] understands a configuration file that mirrors
+\f[V]rsyncd.conf(5)\f[R] (https://download.samba.org/pub/rsync/rsyncd.conf.html).
+Pass \f[V]--config /path/to/rsyncd.conf\f[R] to the daemon and declare
+global options and modules inside.
+Keys are case insensitive and accept spaces, dashes, or underscores
+interchangeably:
+.IP
+.nf
+\f[C]
+port = 8730
+motd-file = /etc/oc-rsyncd.motd
+
+[data]
+    path = /srv/export
+    hosts-allow = 192.0.2.1
+\f[R]
+.fi
+.PP
+Each module requires a \f[V]path\f[R] directive which is resolved and
+canonicalised at startup.
+Unknown directives are ignored for now but using the canonical names
+from \f[V]rsyncd.conf(5)\f[R] ensures forward compatibility.
 .SS Example packaging
 .PP
 Sample files for running the daemon are provided under
 \f[V]packaging/\f[R] and are included in release artifacts:
 .IP \[bu] 2
-\f[V]packaging/examples/oc-rsyncd.conf\f[R] \[en] example configuration file
+\f[V]packaging/examples/oc-rsyncd.conf\f[R] \[en] example configuration
+file
 .IP \[bu] 2
 \f[V]packaging/systemd/oc-rsyncd.service\f[R] \[en] systemd service unit
 .SS systemd hardening
 .PP
 The bundled \f[V]oc-rsyncd.service\f[R] applies systemd sandboxing
-features to reduce attack surface. It enables
-\f[V]NoNewPrivileges=yes\f[R], mounts the host filesystem read-only with
-\f[V]ProtectSystem=strict\f[R], hides user home directories via
-\f[V]ProtectHome=true\f[R], and restarts on failure after a short delay
-with \f[V]Restart=on-failure\f[R] and \f[V]RestartSec=2s\f[R]. The unit
-grants only the \f[V]CAP_NET_BIND_SERVICE\f[R] capability via
-\f[V]CapabilityBoundingSet\f[R]/\f[V]AmbientCapabilities\f[R] and
-writes its PID and log to \f[V]/run/oc-rsyncd.pid\f[R] and
-\f[V]/var/log/oc-rsyncd.log\f[R]. These settings may be relaxed if the
-daemon requires additional privileges.
+features to reduce attack surface.
+It enables \f[V]NoNewPrivileges=yes\f[R], mounts the host filesystem
+read-only with \f[V]ProtectSystem=strict\f[R], hides user home
+directories via \f[V]ProtectHome=true\f[R], and restarts on failure
+after a short delay with \f[V]Restart=on-failure\f[R] and
+\f[V]RestartSec=2s\f[R].
+The unit grants only the \f[V]CAP_NET_BIND_SERVICE\f[R] capability via
+\f[V]CapabilityBoundingSet\f[R]/\f[V]AmbientCapabilities\f[R] and writes
+its PID and log to \f[V]/run/oc-rsyncd.pid\f[R] and
+\f[V]/var/log/oc-rsyncd.log\f[R].
+These settings may be relaxed if the daemon requires additional
+privileges.
 .SS Module setup
 .PP
 Modules map a name to a directory on disk.
@@ -108,8 +180,15 @@ will be ignored.
 .PP
 Before serving files the daemon confines itself to the module root.
 On Unix platforms it performs a \f[V]chroot\f[R] to the module path,
-changes its working directory to \f[V]/\f[R], and drops privileges to
-the nobody user and group (UID/GID 65534).
+changes its working directory to \f[V]/\f[R], and drops privileges to a
+less privileged user and group (UID/GID 65534 by default).
+The \f[V]uid\f[R] and \f[V]gid\f[R] module directives may override the
+default IDs for specific exports.
+.PP
+Unit tests exercising this chroot and privilege-dropping behavior
+require root privileges.
+When run as an unprivileged user these tests are skipped, so CI
+environments must provide sufficient permissions to execute them.
 .SS Hosts allow/deny lists
 .PP
 The daemon can restrict connections based on client address.


### PR DESCRIPTION
## Summary
- document `--from0` CLI and filter coverage
- note LZ4 codec removal and Windows metadata support
- regenerate manpages

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 707 passed, 125 failed, 33 skipped)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(build started, interrupted)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68baa7b2d7008323b036ba66215af202