### PR TITLE
Use stdout for progress display

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -797,10 +797,10 @@ impl Progress {
             bytes, percent, rate, time, self.file_idx, remaining, total_files
         );
         if done {
-            eprintln!("{line}");
+            println!("{line}");
         } else {
-            eprint!("{line}");
-            let _ = std::io::stderr().flush();
+            print!("{line}");
+            let _ = std::io::stdout().flush();
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch progress reporting from stderr to stdout

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command: nextest)*
- `make verify-comments`
- `make lint`
- `cargo test --test cli progress_parity_p` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bab97c499c832392554474d3d8fd2a