### PR TITLE
feat: add ACL library fallback

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 // build.rs
 
-use std::{env, fs, path::Path};
+use std::{env, fs, path::Path, path::PathBuf, process::Command};
 
 use time::OffsetDateTime;
 
@@ -21,8 +21,59 @@ fn main() {
 
     if env::var_os("CARGO_FEATURE_ACL").is_some() && pkg_config::Config::new().probe("acl").is_err()
     {
-        println!("cargo:warning=libacl not found; ACL support will be disabled");
-        println!("cargo:rustc-cfg=libacl_missing");
+        let mut lib_dir: Option<PathBuf> = None;
+
+        if let Ok(output) = Command::new("ldconfig").arg("-p").output() {
+            if output.status.success() {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                for line in stdout.lines() {
+                    if line.contains("libacl.so") {
+                        if let Some(path) = line.split("=>").nth(1) {
+                            let path = path.trim();
+                            if let Some(dir) = Path::new(path).parent() {
+                                lib_dir = Some(dir.to_path_buf());
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if lib_dir.is_none() {
+            if let Ok(output) = Command::new("find")
+                .args([
+                    "/usr/lib",
+                    "/usr/lib64",
+                    "/usr/local/lib",
+                    "/usr/local/lib64",
+                    "/lib",
+                    "/lib64",
+                ])
+                .arg("-name")
+                .arg("libacl.so")
+                .arg("-print")
+                .arg("-quit")
+                .output()
+            {
+                if output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    if let Some(path) = stdout.lines().next() {
+                        if let Some(dir) = Path::new(path.trim()).parent() {
+                            lib_dir = Some(dir.to_path_buf());
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(dir) = lib_dir {
+            println!("cargo:rustc-link-lib=acl");
+            println!("cargo:rustc-link-search=native={}", dir.display());
+        } else {
+            println!("cargo:warning=libacl not found; ACL support will be disabled");
+            println!("cargo:rustc-cfg=libacl_missing");
+        }
     }
 
     let protocols = UPSTREAM_PROTOCOLS


### PR DESCRIPTION
## Summary
- search common library paths for libacl when pkg-config probe fails

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: removes_temp_dir_after_sync, backups_use_custom_suffix, list_parsing_from0_eq_newline, merge_word_split_from0, include_from_null_separated, rule_list_from0_eq_newline, random_rule_parity, clear_resets_parent_rules, archive_matches_combination_and_rsync, etc.; 21 failures total)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(interrupted after initial warnings)*
- `cargo build --features acl`


------
https://chatgpt.com/codex/tasks/task_e_68bab98f805483239c27531f5d32cf84