### PR TITLE
test: assert progress output on stdout

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -733,14 +733,16 @@ fn progress_flag_shows_output() {
     let out = assert.get_output();
     let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
     let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
-    let text = if !stdout.is_empty() { stdout } else { stderr };
-    let mut lines = text.lines();
+    assert!(stderr.is_empty(), "{}", stderr);
+    let mut lines = stdout.lines();
     assert_eq!(lines.next().unwrap(), "sending incremental file list");
     assert_eq!(lines.next().unwrap(), "a.txt");
-    let progress_line = lines.next().unwrap().trim_start_matches('\r').trim_end();
+    let progress_line_raw = lines.next().unwrap();
+    let progress_line = progress_line_raw.trim_start_matches('\r').trim_end();
     let bytes = progress_formatter(2048, false);
     let expected_prefix = format!("{:>15} {:>3}%", bytes, 100);
     assert!(progress_line.starts_with(&expected_prefix));
+    assert!(stdout.contains(progress_line_raw));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- update progress test to assert progress line is printed to stdout and stderr is empty

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast --all-features` (fails: cannot find -lacl)
- `make verify-comments`
- `make lint`
- `cargo test --test cli progress_flag_shows_output` (fails: progress line printed to stderr)


------
https://chatgpt.com/codex/tasks/task_e_68bab995f3c88323b913da06e6ae132f