### PR TITLE
Ignore progress parity -P test

### DIFF
--- a/FLAKES.md
+++ b/FLAKES.md
@@ -31,7 +31,7 @@ This file documents tests marked `#[ignore]` and why they remain excluded from a
 | `tests/filter_corpus.rs::filter_corpus_parity` | Filter corpus parity with upstream not yet validated. |
 | `tests/filter_corpus.rs::perdir_sign_parity` | Per-directory signing parity pending. |
 | `tests/cli.rs::progress_parity` | Progress output parity requires upstream comparison. |
-| `tests/cli.rs::progress_parity_p` | Same as above. |
+| `tests/cli.rs::progress_parity_p` | Progress output parity requires upstream comparison. |
 | `tests/cli.rs::default_umask_masks_permissions` | Umask handling under review. |
 | `tests/no_implied_dirs.rs::preserves_symlinked_implied_dirs` | Symlinked implied directory behavior unfinished. |
 | `tests/cli_flags.rs::blocking_io_nonblocking_by_default` | Blocking I/O flag behavior incomplete. |

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -834,6 +834,7 @@ fn progress_parity_impl(flags: &[&str], fixture: &str) -> String {
 }
 
 #[test]
+#[ignore]
 fn progress_parity_p() {
     let norm = progress_parity_impl(&["-r", "-P"], "progress_p");
     insta::assert_snapshot!("progress_parity_p", norm);


### PR DESCRIPTION
## Summary
- ignore `progress_parity_p` test
- clarify flake list entry for progress output parity

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: interrupted)*
- `make verify-comments` *(fails: interrupted)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bab9a54e1483239a9ac671473b8788