### PR TITLE
Validate remote specification components

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -143,7 +143,7 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         .ok_or_else(|| EngineError::Other("missing SRC or DST".into()))?;
     let srcs = opts.paths[..opts.paths.len() - 1].to_vec();
     if srcs.len() > 1 {
-        if let RemoteSpec::Local(ps) = parse_remote_spec(&dst_arg)? {
+        if let Ok(RemoteSpec::Local(ps)) = parse_remote_spec(&dst_arg) {
             if !ps.path.is_dir() {
                 return Err(EngineError::Other("destination must be a directory".into()));
             }
@@ -1428,6 +1428,21 @@ mod tests {
             }
             _ => panic!("expected remote spec"),
         }
+    }
+
+    #[test]
+    fn malformed_rsync_url_is_error() {
+        assert!(parse_remote_spec("rsync://").is_err());
+    }
+
+    #[test]
+    fn malformed_daemon_spec_is_error() {
+        assert!(parse_remote_spec("host::mod").is_err());
+    }
+
+    #[test]
+    fn malformed_ipv6_spec_is_error() {
+        assert!(parse_remote_spec("[::1]:module").is_err());
     }
 
     #[test]

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -327,6 +327,12 @@ pub(crate) fn parse_remote_spec(input: &str) -> Result<RemoteSpec> {
         let mut mp = mod_path.splitn(2, '/');
         let module = mp.next().unwrap_or("");
         let path = mp.next().unwrap_or("");
+        if host.is_empty() {
+            return Err(EngineError::Other("remote host missing".into()));
+        }
+        if module.is_empty() {
+            return Err(EngineError::Other("remote module missing".into()));
+        }
         return Ok(RemoteSpec::Remote {
             host: host.to_string(),
             path: PathSpec {
@@ -340,6 +346,12 @@ pub(crate) fn parse_remote_spec(input: &str) -> Result<RemoteSpec> {
         if let Some(end) = rest.find(']') {
             let host = &rest[..end];
             if let Some(path) = rest[end + 1..].strip_prefix(':') {
+                if host.is_empty() {
+                    return Err(EngineError::Other("remote host missing".into()));
+                }
+                if path.is_empty() || !path.starts_with('/') {
+                    return Err(EngineError::Other("remote path missing".into()));
+                }
                 return Ok(RemoteSpec::Remote {
                     host: host.to_string(),
                     path: PathSpec {
@@ -360,6 +372,15 @@ pub(crate) fn parse_remote_spec(input: &str) -> Result<RemoteSpec> {
         let mut rest = s[idx + 2..].splitn(2, '/');
         let module = rest.next().unwrap_or("");
         let path = rest.next().unwrap_or("");
+        if host.is_empty() {
+            return Err(EngineError::Other("remote host missing".into()));
+        }
+        if module.is_empty() {
+            return Err(EngineError::Other("remote module missing".into()));
+        }
+        if path.is_empty() {
+            return Err(EngineError::Other("remote path missing".into()));
+        }
         return Ok(RemoteSpec::Remote {
             host: host.to_string(),
             path: PathSpec {
@@ -386,6 +407,12 @@ pub(crate) fn parse_remote_spec(input: &str) -> Result<RemoteSpec> {
             }
         }
         let (host, path) = s.split_at(idx);
+        if host.is_empty() {
+            return Err(EngineError::Other("remote host missing".into()));
+        }
+        if path[1..].is_empty() {
+            return Err(EngineError::Other("remote path missing".into()));
+        }
         return Ok(RemoteSpec::Remote {
             host: host.to_string(),
             path: PathSpec {


### PR DESCRIPTION
## Summary
- error when rsync URLs omit host or module
- guard IPv6 and daemon paths against missing parts
- test malformed remote specs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: linking with `cc` failed: exit status 1)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bad61e1c288323a06f51eeeb4733f0