### PR TITLE
Disable privileged defaults

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -98,6 +98,13 @@ copied:
 - `oc-rsync "remote:/src/" "local/"` pulls the contents of `/src` from the remote
   host into `local`.
 
+### Privileged defaults
+
+Upstream `rsync` treats options that preserve symbolic links, device files,
+special files, and ownership as privileged. For parity, `oc-rsync` leaves
+`--links`, `--devices`, `--specials`, `--owner`, and `--group` disabled unless
+explicitly requested.
+
 ## Options
 
 The table below mirrors the full `rsync(1)` flag set. Defaults show the

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -63,7 +63,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--delete-excluded` | ✅ | Y | Y | Y | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--delete-missing-args` | ✅ | Y | Y | Y | [tests/delete_policy.rs](../tests/delete_policy.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `-D` | ✅ | Y | Y | Y | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | shorthand for `--devices --specials` |
-| `--devices` | ✅ | Y | Y | Y | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `--devices` | ✅ | Y | Y | Y | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | disabled by default |
 | `--dirs` | ✅ | Y | Y | Y | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--dparam` | ✅ | Y | Y | Y | [crates/cli/tests/cli_parity.rs](../crates/cli/tests/cli_parity.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | override global daemon config parameter |
 | `--dry-run` | ✅ | N | N | N | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
@@ -81,7 +81,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--from0` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--fsync` | ✅ | N | N | N | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--fuzzy` | ✅ | N | N | N | [tests/fuzzy.rs](../tests/fuzzy.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--group` | ✅ | Y | Y | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires root or CAP_CHOWN |
+| `--group` | ✅ | Y | Y | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | disabled by default; requires root or CAP_CHOWN |
 | `--groupmap` | ✅ | N | N | N | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires root or CAP_CHOWN |
 | `--hard-links` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs)<br>[crates/engine/tests/links.rs](../crates/engine/tests/links.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--help` | ✅ | N | N | N | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
@@ -102,7 +102,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--itemize-changes` | ✅ | Y | Y | Y | [tests/golden/cli_parity/itemize-changes.sh](../tests/golden/cli_parity/itemize-changes.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--keep-dirlinks` | ✅ | Y | Y | Y | [tests/local_sync_tree.rs](../tests/local_sync_tree.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--link-dest` | ✅ | Y | Y | Y | [tests/link_copy_compare_dest.rs](../tests/link_copy_compare_dest.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--links` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/engine/src/lib.rs](../crates/engine/src/lib.rs) | preserves relative/absolute targets; supports dangling links |
+| `--links` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/engine/src/lib.rs](../crates/engine/src/lib.rs) | disabled by default; preserves relative/absolute targets; supports dangling links |
 | `--list-only` | ✅ | Y | Y | Y | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--log-file` | ✅ | Y | Y | Y | [tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |  |
 | `--log-file-format` | ✅ | Y | Y | Y | [tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |  |
@@ -130,7 +130,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--open-noatime` | ✅ | Y | Y | Y | [crates/engine/tests/open_noatime.rs](../crates/engine/tests/open_noatime.rs)<br>[tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/engine/src/lib.rs](../crates/engine/src/lib.rs) | requires a platform supporting `O_NOATIME` |
 | `--out-format` | ✅ | Y | Y | Y | [tests/out_format.rs](../tests/out_format.rs)<br>[tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/logging/src/lib.rs](../crates/logging/src/lib.rs) | custom output format |
 | `--outbuf` | ✅ | N | N | N | [tests/cli_flags.rs](../tests/cli_flags.rs) | [src/bin/oc-rsync/main.rs](../src/bin/oc-rsync/main.rs) | set stdout buffering |
-| `--owner` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs)<br>[crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires root or CAP_CHOWN |
+| `--owner` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs)<br>[crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | disabled by default; requires root or CAP_CHOWN |
 | `--partial` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs)<br>[crates/engine/tests/resume.rs](../crates/engine/tests/resume.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--partial-dir` | ✅ | Y | Y | Y | [tests/resume.rs](../tests/resume.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--password-file` | ✅ | Y | Y | Y | [tests/daemon.rs](../tests/daemon.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
@@ -157,7 +157,7 @@ Classic `rsync` protocol versions 29–32 are supported.
 | `--skip-compress` | ✅ | Y | Y | Y | [tests/skip_compress.rs](../tests/skip_compress.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | comma-separated list of file suffixes to avoid compressing |
 | `--sockopts` | ✅ | N | N | N | [tests/sockopts.rs](../tests/sockopts.rs)<br>[crates/transport/tests/sockopts.rs](../crates/transport/tests/sockopts.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | supports `SO_KEEPALIVE`, `SO_SNDBUF`, `SO_RCVBUF`, `TCP_NODELAY`, `SO_REUSEADDR`, `SO_BINDTODEVICE`, and `ip:ttl`/`ip:tos`/`ip:hoplimit` |
 | `--sparse` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | creates holes for long zero runs |
-| `--specials` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs)<br>[tests/specials_parity.rs](../tests/specials_parity.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `--specials` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs)<br>[tests/specials_parity.rs](../tests/specials_parity.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | disabled by default |
 | `--stats` | ✅ | N | N | N | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--stderr` | ✅ | Y | Y | Y | [crates/cli/tests/stderr.rs](../crates/cli/tests/stderr.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs)<br>[crates/logging/src/lib.rs](../crates/logging/src/lib.rs) | control stderr output mode |
 | `--stop-after` | ✅ | N | N | N | [tests/timeout.rs](../tests/timeout.rs) | [crates/cli/src/options.rs](../crates/cli/src/options.rs)<br>[crates/engine/src/lib.rs](../crates/engine/src/lib.rs) |  |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,11 +53,11 @@ impl Default for SyncConfig {
             times: false,
             atimes: false,
             open_noatime: false,
-            links: true,
-            devices: true,
-            specials: true,
-            owner: true,
-            group: true,
+            links: false,
+            devices: false,
+            specials: false,
+            owner: false,
+            group: false,
             #[cfg(feature = "xattr")]
             xattrs: false,
             #[cfg(feature = "acl")]


### PR DESCRIPTION
## Summary
- disable privileged attributes in `SyncConfig::default`
- document default-disabled privileged flags in CLI and feature matrix

## Testing
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: removes_temp_dir_after_sync, backups_use_custom_suffix, list_parsing_from0_eq_newline, merge_word_split_from0, include_from_null_separated, rule_list_from0_eq_newline, include_exclude_precedence, rsync_filter_merge_order_and_wildcards, random_rule_parity, clear_resets_parent_rules, archive_matches_combination_and_rsync, and others)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68bad60ebff883238503b7702c1a4180