### PR TITLE
Use /usr/bin in systemd service paths

### DIFF
--- a/packaging/systemd/README.md
+++ b/packaging/systemd/README.md
@@ -4,6 +4,10 @@ The `oc-rsyncd.service` unit is configured with a minimal capability set. Only
 `CAP_NET_BIND_SERVICE` is retained so the daemon can listen on the privileged
 rsync port 873 while running as the unprivileged `ocrsync` user.
 
+The service file assumes the binaries are installed in `/usr/bin` (`/usr/bin/oc-rsyncd`
+and `/usr/bin/oc-rsync`). If your distribution installs them elsewhere, override
+`ExecStart` via a systemd drop-in.
+
 ```
 $ systemd-analyze security --offline=yes oc-rsyncd.service
 → Overall exposure level for oc-rsyncd.service: 1.3 OK 🙂

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -14,11 +14,11 @@ RuntimeDirectory=oc-rsyncd
 LogsDirectory=oc-rsyncd
 StateDirectory=oc-rsyncd
 ConfigurationDirectory=oc-rsyncd
-ExecStart=/usr/local/bin/oc-rsyncd --no-detach --config=/etc/oc-rsyncd.conf
+ExecStart=/usr/bin/oc-rsyncd --no-detach --config=/etc/oc-rsyncd.conf
 # To run the daemon via the main oc-rsync CLI instead of the dedicated oc-rsyncd
 # binary, create a drop-in with the following lines:
 # ExecStart=
-# ExecStart=/usr/local/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf
+# ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf
 Restart=on-failure
 RestartSec=2s
 NoNewPrivileges=yes

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -54,11 +54,11 @@ fn service_unit_matches_spec() {
         "LogsDirectory=oc-rsyncd",
         "StateDirectory=oc-rsyncd",
         "ConfigurationDirectory=oc-rsyncd",
-        "ExecStart=/usr/local/bin/oc-rsyncd --no-detach --config=/etc/oc-rsyncd.conf",
+        "ExecStart=/usr/bin/oc-rsyncd --no-detach --config=/etc/oc-rsyncd.conf",
         "# To run the daemon via the main oc-rsync CLI instead of the dedicated oc-rsyncd",
         "# binary, create a drop-in with the following lines:",
         "# ExecStart=",
-        "# ExecStart=/usr/local/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf",
+        "# ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf",
         "Documentation=man:oc-rsyncd(8) man:oc-rsyncd.conf(5) man:oc-rsync(1)",
     ] {
         assert!(


### PR DESCRIPTION
## Summary
- point systemd oc-rsyncd.service to `/usr/bin/oc-rsyncd`
- document `/usr/bin` as the default install location for systemd unit
- adjust packaging test to expect the new binary paths

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: 124 tests failed)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bad629bf348323b2199a8c24bec948