### PR TITLE
gate ACL detection on non-unix targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,61 +19,68 @@ fn main() {
     let revision = env::var("BUILD_REVISION").unwrap_or_else(|_| "unknown".to_string());
     let official = env::var("OFFICIAL_BUILD").unwrap_or_else(|_| "unofficial".to_string());
 
-    if env::var_os("CARGO_FEATURE_ACL").is_some() && pkg_config::Config::new().probe("acl").is_err()
-    {
-        let mut lib_dir: Option<PathBuf> = None;
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_ACL");
+    if cfg!(unix) {
+        if env::var_os("CARGO_FEATURE_ACL").is_some()
+            && pkg_config::Config::new().probe("acl").is_err()
+        {
+            let mut lib_dir: Option<PathBuf> = None;
 
-        if let Ok(output) = Command::new("ldconfig").arg("-p").output() {
-            if output.status.success() {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                for line in stdout.lines() {
-                    if line.contains("libacl.so") {
-                        if let Some(path) = line.split("=>").nth(1) {
-                            let path = path.trim();
-                            if let Some(dir) = Path::new(path).parent() {
-                                lib_dir = Some(dir.to_path_buf());
-                                break;
+            if let Ok(output) = Command::new("ldconfig").arg("-p").output() {
+                if output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    for line in stdout.lines() {
+                        if line.contains("libacl.so") {
+                            if let Some(path) = line.split("=>").nth(1) {
+                                let path = path.trim();
+                                if let Some(dir) = Path::new(path).parent() {
+                                    lib_dir = Some(dir.to_path_buf());
+                                    break;
+                                }
                             }
                         }
                     }
                 }
             }
-        }
 
-        if lib_dir.is_none() {
-            if let Ok(output) = Command::new("find")
-                .args([
-                    "/usr/lib",
-                    "/usr/lib64",
-                    "/usr/local/lib",
-                    "/usr/local/lib64",
-                    "/lib",
-                    "/lib64",
-                ])
-                .arg("-name")
-                .arg("libacl.so")
-                .arg("-print")
-                .arg("-quit")
-                .output()
-            {
-                if output.status.success() {
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    if let Some(path) = stdout.lines().next() {
-                        if let Some(dir) = Path::new(path.trim()).parent() {
-                            lib_dir = Some(dir.to_path_buf());
+            if lib_dir.is_none() {
+                if let Ok(output) = Command::new("find")
+                    .args([
+                        "/usr/lib",
+                        "/usr/lib64",
+                        "/usr/local/lib",
+                        "/usr/local/lib64",
+                        "/lib",
+                        "/lib64",
+                    ])
+                    .arg("-name")
+                    .arg("libacl.so")
+                    .arg("-print")
+                    .arg("-quit")
+                    .output()
+                {
+                    if output.status.success() {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        if let Some(path) = stdout.lines().next() {
+                            if let Some(dir) = Path::new(path.trim()).parent() {
+                                lib_dir = Some(dir.to_path_buf());
+                            }
                         }
                     }
                 }
             }
-        }
 
-        if let Some(dir) = lib_dir {
-            println!("cargo:rustc-link-lib=acl");
-            println!("cargo:rustc-link-search=native={}", dir.display());
-        } else {
-            println!("cargo:warning=libacl not found; ACL support will be disabled");
-            println!("cargo:rustc-cfg=libacl_missing");
+            if let Some(dir) = lib_dir {
+                println!("cargo:rustc-link-lib=acl");
+                println!("cargo:rustc-link-search=native={}", dir.display());
+            } else {
+                println!("cargo:warning=libacl not found; ACL support will be disabled");
+                println!("cargo:rustc-cfg=libacl_missing");
+            }
         }
+    } else if env::var_os("CARGO_FEATURE_ACL").is_some() {
+        println!("cargo:warning=libacl not found; ACL support will be disabled");
+        println!("cargo:rustc-cfg=libacl_missing");
     }
 
     let protocols = UPSTREAM_PROTOCOLS


### PR DESCRIPTION
## Summary
- gate ACL auto-detection behind `cfg!(unix)` and warn when ACL support is unavailable

## Testing
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` (fails: test run failed)
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68bad602b2508323b3ef9e43c516e8f0