### PR TITLE
daemon: allow unauthenticated module listing

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -939,8 +939,8 @@ fn stats_parity() {
         out.lines()
             .find_map(|l| {
                 let l = l.trim_start();
-                if l.starts_with(prefix) {
-                    l[prefix.len()..]
+                if let Some(stripped) = l.strip_prefix(prefix) {
+                    stripped
                         .trim()
                         .strip_suffix(" seconds")
                         .and_then(|v| v.parse::<f64>().ok())


### PR DESCRIPTION
## Summary
- allow module listing when no auth token and authentication is disabled
- replace manual prefix stripping in CLI tests with `strip_prefix`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: cannot find -lacl)*
- `cargo test --test daemon -- daemon_hides_unlisted_modules` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68badadcc9488323aa518992cac4242e