### PR TITLE
Use fork per connection in daemon

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -9,6 +9,10 @@ use std::sync::{atomic::AtomicUsize, atomic::Ordering, Arc};
 use std::time::Duration;
 
 #[cfg(unix)]
+use nix::errno::Errno;
+#[cfg(unix)]
+use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+#[cfg(unix)]
 use nix::unistd::{fork, setsid, ForkResult};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -1236,6 +1240,18 @@ pub fn run_daemon(
     });
     let active = Arc::new(AtomicUsize::new(0));
     loop {
+        #[cfg(unix)]
+        loop {
+            match waitpid(None, Some(WaitPidFlag::WNOHANG)) {
+                Ok(WaitStatus::StillAlive) | Err(Errno::ECHILD) => break,
+                Ok(_) => {
+                    if max_connections.is_some() {
+                        active.fetch_sub(1, Ordering::SeqCst);
+                    }
+                }
+                Err(_) => break,
+            }
+        }
         let (stream, addr) = TcpTransport::accept(&listener, &hosts_allow, &hosts_deny)?;
         if let Some(max) = max_connections {
             if active.load(Ordering::SeqCst) >= max {
@@ -1253,6 +1269,68 @@ pub fn run_daemon(
         let handler = handler.clone();
         let refuse = refuse_options.clone();
         let active_conn = active.clone();
+        #[cfg(unix)]
+        match unsafe { fork() } {
+            Ok(ForkResult::Parent { .. }) => {
+                drop(stream);
+            }
+            Ok(ForkResult::Child) => {
+                let transport = TcpTransport::from_stream(stream);
+                let res = (|| -> io::Result<()> {
+                    let t = TimeoutTransport::new(transport, timeout)?;
+                    if let Some(limit) = bwlimit {
+                        let mut t = RateLimitedTransport::new(t, limit);
+                        handle_connection(
+                            &mut t,
+                            &modules,
+                            secrets.as_deref(),
+                            password.as_deref(),
+                            log_file.as_deref(),
+                            log_format.as_deref(),
+                            motd.as_deref(),
+                            list,
+                            &refuse,
+                            &peer,
+                            uid,
+                            gid,
+                            &handler,
+                        )
+                    } else {
+                        let mut t = t;
+                        handle_connection(
+                            &mut t,
+                            &modules,
+                            secrets.as_deref(),
+                            password.as_deref(),
+                            log_file.as_deref(),
+                            log_format.as_deref(),
+                            motd.as_deref(),
+                            list,
+                            &refuse,
+                            &peer,
+                            uid,
+                            gid,
+                            &handler,
+                        )
+                    }
+                })();
+                if let Err(e) = res {
+                    if !quiet {
+                        eprintln!("connection error: {}", e);
+                    }
+                }
+                std::process::exit(0);
+            }
+            Err(e) => {
+                if max_connections.is_some() {
+                    active_conn.fetch_sub(1, Ordering::SeqCst);
+                }
+                if !quiet {
+                    eprintln!("fork failed: {}", e);
+                }
+            }
+        }
+        #[cfg(not(unix))]
         std::thread::spawn(move || {
             let transport = TcpTransport::from_stream(stream);
             let res = (|| -> io::Result<()> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -938,15 +938,11 @@ fn stats_parity() {
     let parse_time = |out: &str, prefix: &str| -> f64 {
         out.lines()
             .find_map(|l| {
-                let l = l.trim_start();
-                if l.starts_with(prefix) {
-                    l[prefix.len()..]
-                        .trim()
+                l.trim_start().strip_prefix(prefix).and_then(|rest| {
+                    rest.trim()
                         .strip_suffix(" seconds")
                         .and_then(|v| v.parse::<f64>().ok())
-                } else {
-                    None
-                }
+                })
             })
             .unwrap_or(0.0)
     };

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -2221,3 +2221,36 @@ fn daemon_stays_foreground_with_no_detach() {
     let _ = child.kill();
     let _ = child.wait();
 }
+
+#[test]
+#[serial]
+fn daemon_accepts_sequential_chrooted_connections() {
+    if require_network().is_err() {
+        eprintln!("skipping daemon test: network access required");
+        return;
+    }
+    let (mut child, port, _dir) = match spawn_daemon() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("skipping daemon test: {e}");
+            return;
+        }
+    };
+    wait_for_daemon(port);
+    for _ in 0..3 {
+        let mut t = TcpTransport::connect("127.0.0.1", port, None, None).unwrap();
+        t.set_read_timeout(Some(Duration::from_secs(5))).unwrap();
+        t.send(&LATEST_VERSION.to_be_bytes()).unwrap();
+        let mut buf = [0u8; 4];
+        t.receive(&mut buf).unwrap();
+        t.authenticate(None, false).unwrap();
+        let mut ok = [0u8; 64];
+        t.receive(&mut ok).unwrap();
+        t.send(b"data\n").unwrap();
+        t.send(b"\n").unwrap();
+        let n = t.receive(&mut buf).unwrap_or(0);
+        assert_eq!(n, 0);
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}


### PR DESCRIPTION
## Summary
- spawn a fork per connection instead of threads and keep parent accepting new clients
- clean up child processes and enforce max connection limits
- test sequential connections survive chrooted sessions

## Testing
- `cargo fmt --all`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: linking with `cc` failed)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68badaf13d4c8323b3c43a7de72c609e