### PR TITLE
Read module name unconditionally in daemon connection

### DIFF
--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -962,7 +962,7 @@ pub fn handle_connection<T: Transport>(
     let latest = SUPPORTED_PROTOCOLS[0];
     transport.send(&latest.to_be_bytes())?;
     negotiate_version(latest, peer_ver).map_err(|e| io::Error::other(e.to_string()))?;
-    let (mut token, global_allowed, no_motd) = authenticate(transport, secrets, password)?;
+    let (token, global_allowed, no_motd) = authenticate(transport, secrets, password)?;
     if !no_motd {
         if let Some(mpath) = motd {
             if let Ok(content) = fs::read_to_string(mpath) {
@@ -974,15 +974,9 @@ pub fn handle_connection<T: Transport>(
         }
     }
     transport.send(b"@RSYNCD: OK\n")?;
-    let name = if global_allowed.is_empty() && secrets.is_none() {
-        token
-            .take()
-            .ok_or_else(|| io::Error::new(io::ErrorKind::PermissionDenied, "auth token missing"))?
-    } else {
-        let mut name_buf = [0u8; 256];
-        let n = transport.receive(&mut name_buf)?;
-        String::from_utf8_lossy(&name_buf[..n]).trim().to_string()
-    };
+    let mut name_buf = [0u8; 256];
+    let n = transport.receive(&mut name_buf)?;
+    let name = String::from_utf8_lossy(&name_buf[..n]).trim().to_string();
     if name.is_empty() {
         if list {
             for m in modules.values().filter(|m| m.list) {

--- a/crates/daemon/tests/no_token.rs
+++ b/crates/daemon/tests/no_token.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 use transport::LocalPipeTransport;
 
 #[test]
-fn handle_connection_missing_token() {
+fn handle_connection_empty_module_name() {
     let mut input = Vec::new();
     input.extend_from_slice(&SUPPORTED_PROTOCOLS[0].to_be_bytes());
-    input.extend_from_slice(b"\n");
+    input.extend_from_slice(b"\n\n");
     let reader = Cursor::new(input);
     let writer = Cursor::new(Vec::new());
     let mut transport = LocalPipeTransport::new(reader, writer);
@@ -18,7 +18,7 @@ fn handle_connection_missing_token() {
     let modules: HashMap<String, Module> = HashMap::new();
     let handler: Arc<Handler> = Arc::new(|_t| Ok(()));
 
-    let result = handle_connection(
+    handle_connection(
         &mut transport,
         &modules,
         None,
@@ -32,9 +32,10 @@ fn handle_connection_missing_token() {
         0,
         0,
         &handler,
-    );
+    )
+    .expect("empty module name should succeed");
 
-    let err = result.expect_err("missing token should error");
-    assert_eq!(err.kind(), std::io::ErrorKind::PermissionDenied);
-    assert_eq!(err.to_string(), "auth token missing");
+    let (_, writer) = transport.into_inner();
+    let out = writer.into_inner();
+    assert_eq!(&out[4..], b"@RSYNCD: OK\n\n");
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -939,14 +939,9 @@ fn stats_parity() {
         out.lines()
             .find_map(|l| {
                 let l = l.trim_start();
-                if l.starts_with(prefix) {
-                    l[prefix.len()..]
-                        .trim()
-                        .strip_suffix(" seconds")
-                        .and_then(|v| v.parse::<f64>().ok())
-                } else {
-                    None
-                }
+                l.strip_prefix(prefix)
+                    .and_then(|rest| rest.trim().strip_suffix(" seconds"))
+                    .and_then(|v| v.parse::<f64>().ok())
             })
             .unwrap_or(0.0)
     };


### PR DESCRIPTION
## Summary
- always read module name after the OK handshake
- allow empty module names for anonymous module listings
- exercise new handshake behavior in daemon tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: SIGINT after ~80 tests)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(interrupted)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68badaf60e38832382f3e59885a1368f