### PR TITLE
Use streaming for file checksum

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1014,8 +1014,18 @@ impl Sender {
     }
 
     fn strong_file_checksum(&self, path: &Path) -> Result<Vec<u8>> {
-        let data = fs::read(path).map_err(|e| io_context(path, e))?;
-        Ok(self.cfg.checksum(&data).strong)
+        let file = File::open(path).map_err(|e| io_context(path, e))?;
+        let mut reader = BufReader::new(file);
+        let mut buf = [0u8; 8192];
+        let mut hasher = self.cfg.strong_hasher();
+        loop {
+            let n = reader.read(&mut buf).map_err(|e| io_context(path, e))?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+        }
+        Ok(hasher.finalize())
     }
 
     fn metadata_unchanged(&self, path: &Path, dest: &Path) -> bool {
@@ -2908,7 +2918,10 @@ mod tests {
     use super::*;
     use checksums::rolling_checksum;
     use compress::available_codecs;
-    use tempfile::tempdir;
+    use filters::Matcher;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::{tempdir, NamedTempFile};
 
     #[test]
     fn delta_roundtrip() {
@@ -3214,5 +3227,25 @@ mod tests {
         let file = std::fs::OpenOptions::new().read(true).open(&path).unwrap();
         let err = preallocate(&file, 1).unwrap_err();
         assert_eq!(err.raw_os_error(), Some(libc::EBADF));
+    }
+
+    #[test]
+    fn large_file_strong_checksum_matches() {
+        let mut tmp = NamedTempFile::new().unwrap();
+        let chunk = [0u8; 1024];
+        for _ in 0..(11 * 1024) {
+            tmp.write_all(&chunk).unwrap();
+        }
+        let path = tmp.path().to_path_buf();
+        let mut sender = Sender::new(
+            RSYNC_BLOCK_SIZE,
+            Matcher::default(),
+            None,
+            SyncOptions::default(),
+        );
+        let new_sum = sender.strong_file_checksum(&path).unwrap();
+        let data = fs::read(&path).unwrap();
+        let old_sum = sender.cfg.checksum(&data).strong;
+        assert_eq!(new_sum, old_sum);
     }
 }


### PR DESCRIPTION
## Summary
- stream file contents when computing strong checksum
- allow incremental strong hashing via `ChecksumConfig::strong_hasher`
- test large-file checksum against in-memory approach

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*
- `make verify-comments` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: lock file version 4 requires `-Znext-lockfile-bump`)*

------
https://chatgpt.com/codex/tasks/task_e_68baeb84a7148323af62a7869130d743