### PR TITLE
Fix makedev conversions in archive tests

### DIFF
--- a/tests/archive.rs
+++ b/tests/archive.rs
@@ -10,8 +10,6 @@ use oc_rsync::meta::{makedev, Mode, SFlag};
 #[cfg(unix)]
 use sha2::{Digest, Sha256};
 #[cfg(unix)]
-use std::convert::TryInto;
-#[cfg(unix)]
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::{symlink, FileTypeExt, MetadataExt, PermissionsExt};
@@ -63,7 +61,7 @@ fn archive_matches_combination_and_rsync() {
         &src.join("dev"),
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o644),
-        makedev(1, 7).try_into().unwrap(),
+        u64::try_from(makedev(1, 7)).unwrap(),
     )
     .unwrap();
 
@@ -145,11 +143,12 @@ fn archive_respects_no_options() {
     .unwrap();
     symlink("dir/file", src.join("link")).unwrap();
     meta::mkfifo(&src.join("fifo"), Mode::from_bits_truncate(0o644)).unwrap();
+    #[allow(clippy::useless_conversion)]
     meta::mknod(
         &src.join("dev"),
         SFlag::S_IFCHR,
         Mode::from_bits_truncate(0o644),
-        makedev(1, 7),
+        u64::try_from(makedev(1, 7)).unwrap(),
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary
- ensure device creation tests convert makedev result to `u64`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: no function or associated item named `with_seed` found for struct `xxhash_rust::xxh64::Xxh64`)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: no function or associated item named `with_seed` found for struct `Xxh64`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68baee71a468832383c260dab158bd49