### PR TITLE
docs: note cargo-nextest requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ headers:
 5. A maintainer will review your PR and may request changes.
 
 ## Testing Requirements
+- Install `cargo-nextest` if it's not already installed. Run `./scripts/install-nextest.sh` to verify or install it.
 - Ensure `cargo nextest run --workspace --no-fail-fast` (and `--all-features`) passes locally.
 - Add or update tests for any new code.
 - Prefer small, focused commits that each pass the test suite.

--- a/scripts/install-nextest.sh
+++ b/scripts/install-nextest.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v cargo-nextest >/dev/null 2>&1; then
+  echo "cargo-nextest not found, installing..."
+  cargo install cargo-nextest --locked
+else
+  echo "cargo-nextest already installed"
+fi
+
+cargo nextest --version


### PR DESCRIPTION
## Summary
- document cargo-nextest install requirement in `CONTRIBUTING.md`
- add helper script to install `cargo-nextest` if missing

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68baedff14888323a376dde0cb26486b