### PR TITLE
chore: remove unused stdout buffering helper

### DIFF
--- a/src/bin/oc-rsync/stdio.rs
+++ b/src/bin/oc-rsync/stdio.rs
@@ -70,14 +70,3 @@ pub fn set_std_buffering(mode: OutBuf) -> io::Result<()> {
     let err = stderr_stream()?;
     set_stream_buffer(err.as_ptr(), mode)
 }
-
-#[allow(dead_code)]
-pub fn set_stdout_buffering(mode: OutBuf) -> io::Result<()> {
-    let mode = match mode {
-        OutBuf::N => libc::_IONBF,
-        OutBuf::L => libc::_IOLBF,
-        OutBuf::B => libc::_IOFBF,
-    };
-    let stream = stdout_stream()?;
-    set_stream_buffer(stream.as_ptr(), mode)
-}


### PR DESCRIPTION
## Summary
- remove unused `set_stdout_buffering` function and its `dead_code` allowance
- keep `set_std_buffering` for controlling stdout and stderr buffering

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: engine::batch_replay, engine::cleanup, engine::backup, filters tests)*
- `cargo nextest run --all-features --workspace --no-fail-fast` *(aborted after build start)*


------
https://chatgpt.com/codex/tasks/task_e_68baedef62b08323b57eab8da9549a3e