### PR TITLE
Handle missing ACL libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ build = "build.rs"
 [dependencies]
 protocol = { path = "crates/protocol" }
 checksums = { path = "crates/checksums" }
-engine = { path = "crates/engine" }
+engine = { path = "crates/engine", default-features = false }
 filters = { path = "crates/filters" }
 compress = { path = "crates/compress" }
 serde = { version = "1", features = ["derive"] }
@@ -40,10 +40,11 @@ filetime = "0.2"
 clap = { version = "4" }
 oc-rsync-cli = { path = "crates/cli" }
 libc = "0.2"
-meta = { path = "crates/meta" }
+meta = { path = "crates/meta", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.27", features = ["user", "fs"] }
+posix-acl = { version = "1.2", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -64,7 +65,6 @@ walkdir = "2"
 nix = { version = "0.27", features = ["user", "fs", "process"] }
 users = "0.11"
 xattr = "1.3"
-posix-acl = "1.2"
 
 [build-dependencies]
 time = { version = "0.3", default-features = false, features = ["std"] }
@@ -97,7 +97,7 @@ path = "tools/strip_rs_comments.rs"
 [features]
 default = ["xattr", "acl"]
 xattr = ["engine/xattr"]
-acl = ["engine/acl"]
+acl = ["engine/acl", "meta/acl", "posix-acl"]
 # Enables CLI-only tools
 cli = []
 # Enables AVX-512 implementations requiring a nightly toolchain

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 Run `scripts/preflight.sh` to verify these dependencies before building. Then
 install from crates.io or build from a local checkout:
 
+If `libacl1-dev` isn't available, disable ACL support with
+
+```bash
+cargo build --no-default-features --features xattr
+```
+
 ```bash
 # install from crates.io
 cargo install oc-rsync

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -12,20 +12,20 @@ compress = { path = "../compress" }
 filelist = { path = "../filelist" }
 protocol = { path = "../protocol" }
 nix = { version = "0.27", features = ["user", "fs"] }
-meta = { path = "../meta" }
+meta = { path = "../meta", default-features = false }
 logging = { path = "../logging" }
 libc = "0.2"
 memmap2 = "0.9"
 tempfile = "3"
 tracing = "0.1"
 transport = { path = "../transport" }
+posix-acl = { version = "1.2", optional = true }
 
 [dev-dependencies]
 compress = { path = "../compress" }
 criterion = { version = "0.5", default-features = false }
 filetime = "0.2"
 xattr = "1.3"
-posix-acl = "1.2"
 encoding_rs = "0.8"
 
 [[bench]]
@@ -48,4 +48,4 @@ harness = false
 default = ["zstd", "xattr", "acl"]
 zstd = []
 xattr = []
-acl = []
+acl = ["meta/acl", "posix-acl"]

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -12,10 +12,14 @@ tracing = "0.1"
 nix = { version = "0.27", features = ["fs", "user"] }
 users = "0.11"
 xattr = "1.5"
-posix-acl = "1.2"
+posix-acl = { version = "1.2", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "0.5"
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = []
+acl = ["posix-acl"]

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,3 +18,10 @@ sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 
 Run `scripts/preflight.sh` to verify these dependencies before compiling.
 
+If your system lacks the `libacl` development package, build without ACL
+support using:
+
+```bash
+cargo build --no-default-features --features xattr
+```
+

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -15,8 +15,10 @@ if ! ldconfig -p 2>/dev/null | grep -q 'libz\.so'; then
   missing+=("zlib (install zlib1g-dev)")
 fi
 
+missing_optional=()
+
 if ! ldconfig -p 2>/dev/null | grep -q libacl; then
-  missing+=("libacl (install libacl1-dev)")
+  missing_optional+=("libacl (install libacl1-dev or disable the 'acl' feature)")
 fi
 
 if ((${#missing[@]})); then
@@ -25,6 +27,13 @@ if ((${#missing[@]})); then
     echo "  - $dep" >&2
   done
   exit 1
+fi
+
+if ((${#missing_optional[@]})); then
+  echo "Warning: missing optional build dependencies:" >&2
+  for dep in "${missing_optional[@]}"; do
+    echo "  - $dep" >&2
+  done
 fi
 
 echo "All required linkers and libraries are present."

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -1,26 +1,18 @@
 // tests/daemon_sync_attrs.rs
+#![cfg(all(unix, feature = "acl"))]
 
-#[cfg(unix)]
 use assert_cmd::{
     cargo::{cargo_bin, CommandCargoExt},
     Command,
 };
-#[cfg(unix)]
 use serial_test::serial;
-#[cfg(unix)]
 use std::fs;
-#[cfg(unix)]
 use std::net::{TcpListener, TcpStream};
-#[cfg(unix)]
 use std::process::{Child, Command as StdCommand};
-#[cfg(unix)]
 use std::thread::sleep;
-#[cfg(unix)]
 use std::time::Duration;
-#[cfg(unix)]
 use tempfile::tempdir;
 
-#[cfg(unix)]
 use posix_acl::{PosixACL, Qualifier, ACL_READ, ACL_WRITE};
 
 #[cfg(unix)]

--- a/tests/local_sync_tree.rs
+++ b/tests/local_sync_tree.rs
@@ -159,7 +159,7 @@ fn sync_preserves_symlink_xattrs() {
     assert_eq!(&val[..], b"val");
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "acl"))]
 #[test]
 fn sync_preserves_acls() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -234,7 +234,7 @@ fn sync_xattrs_match_rsync() {
     assert_eq!(val_oc, val_rs);
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "acl"))]
 #[test]
 fn sync_acls_match_rsync() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -278,7 +278,7 @@ fn sync_acls_match_rsync() {
     assert_eq!(dacl_oc.entries(), dacl_rs.entries());
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "acl"))]
 #[test]
 fn sync_removes_acls() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -314,7 +314,7 @@ fn sync_removes_acls() {
     assert!(dacl_dst.entries().is_empty());
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "acl"))]
 #[test]
 fn sync_removes_acls_match_rsync() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};
@@ -364,7 +364,7 @@ fn sync_removes_acls_match_rsync() {
     assert_eq!(dacl_oc.entries(), dacl_rs.entries());
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "acl"))]
 #[test]
 fn sync_ignores_acls_without_flag() {
     use posix_acl::{PosixACL, Qualifier, ACL_READ};


### PR DESCRIPTION
## Summary
- Only link to libacl when it’s present and warn otherwise
- Skip ACL-based tests when the feature isn't enabled
- Document installing libacl or disabling the `acl` feature

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: cannot find -lacl)*
- `make verify-comments` *(fails: build.rs additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68baedd4f0b88323b70a73659baaaf87