### PR TITLE
Update clap and nix dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "checksums"
@@ -232,9 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -380,7 +380,7 @@ version = "0.1.0"
 dependencies = [
  "ipnet",
  "logging",
- "nix 0.27.1",
+ "nix",
  "protocol",
  "sd-notify",
  "tempfile",
@@ -467,7 +467,7 @@ dependencies = [
  "logging",
  "memmap2",
  "meta",
- "nix 0.27.1",
+ "nix",
  "posix-acl",
  "protocol",
  "tempfile",
@@ -895,7 +895,7 @@ dependencies = [
  "caps",
  "filetime",
  "libc",
- "nix 0.27.1",
+ "nix",
  "posix-acl",
  "tempfile",
  "tracing",
@@ -914,20 +914,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -993,7 +982,7 @@ dependencies = [
  "libc",
  "logging",
  "meta",
- "nix 0.27.1",
+ "nix",
  "oc-rsync-cli",
  "pkg-config",
  "posix-acl",
@@ -1030,7 +1019,7 @@ dependencies = [
  "insta",
  "logging",
  "meta",
- "nix 0.27.1",
+ "nix",
  "once_cell",
  "protocol",
  "regex",
@@ -1701,7 +1690,7 @@ dependencies = [
  "checksums",
  "compress",
  "ipnet",
- "nix 0.28.0",
+ "nix",
  "protocol",
  "socket2",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,13 @@ rustc_lexer = "0.1"
 logging = { path = "crates/logging" }
 tracing = "0.1"
 filetime = "0.2"
-clap = { version = "4" }
+clap = { version = "4.5.47" }
 oc-rsync-cli = { path = "crates/cli" }
 libc = "0.2"
 meta = { path = "crates/meta" }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.27", features = ["user", "fs"] }
+nix = { version = "0.30.1", features = ["user", "fs"] }
 
 [dev-dependencies]
 tempfile = "3"
@@ -61,7 +61,7 @@ hex = "0.4"
 walkdir = "2"
 
 [target.'cfg(unix)'.dev-dependencies]
-nix = { version = "0.27", features = ["user", "fs", "process"] }
+nix = { version = "0.30.1", features = ["user", "fs", "process"] }
 users = "0.11"
 xattr = "1.3"
 posix-acl = "1.2"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4.5.47", features = ["derive", "env"] }
 engine = { path = "../engine" }
 protocol = { path = "../protocol" }
 filters = { path = "../filters" }
@@ -22,7 +22,7 @@ regex = "1"
 once_cell = "1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.27", features = ["user", "fs"] }
+nix = { version = "0.30.1", features = ["user", "fs"] }
 users = "0.11"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 transport = { path = "../transport" }
-nix = { version = "0.27", features = ["user", "fs", "process"] }
+nix = { version = "0.30.1", features = ["user", "fs", "process"] }
 protocol = { path = "../protocol" }
 ipnet = "2"
 logging = { path = "../logging" }

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -11,7 +11,7 @@ filters = { path = "../filters" }
 compress = { path = "../compress" }
 filelist = { path = "../filelist" }
 protocol = { path = "../protocol" }
-nix = { version = "0.27", features = ["user", "fs"] }
+nix = { version = "0.30.1", features = ["user", "fs"] }
 meta = { path = "../meta" }
 logging = { path = "../logging" }
 libc = "0.2"

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4.5.47", features = ["derive"] }
 time = { version = "0.3", features = ["macros", "formatting", "local-offset"] }
 
 [dev-dependencies]

--- a/crates/meta/Cargo.toml
+++ b/crates/meta/Cargo.toml
@@ -9,7 +9,7 @@ libc = "0.2"
 tracing = "0.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.27", features = ["fs", "user"] }
+nix = { version = "0.30.1", features = ["fs", "user"] }
 users = "0.11"
 xattr = "1.5"
 posix-acl = "1.2"

--- a/crates/meta/tests/chmod.rs
+++ b/crates/meta/tests/chmod.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 
 use meta::{normalize_mode, parse_chmod, Metadata, Options};
+use nix::fcntl::AT_FDCWD;
 use nix::sys::stat::{fchmodat, FchmodatFlags, Mode};
 use tempfile::tempdir;
 
@@ -13,7 +14,7 @@ fn chmod_numeric_mode_normalized() -> std::io::Result<()> {
     fs::write(&path, b"test")?;
 
     fchmodat(
-        None,
+        AT_FDCWD,
         &path,
         Mode::from_bits_truncate(0o600),
         FchmodatFlags::NoFollowSymlink,

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -5,6 +5,7 @@ use std::os::unix::fs::PermissionsExt;
 
 use filetime::FileTime;
 use meta::{Metadata, Options};
+use nix::fcntl::AT_FDCWD;
 use nix::unistd::{chown, geteuid, Gid, Uid};
 use std::time::SystemTime;
 use tempfile::tempdir;
@@ -25,7 +26,7 @@ fn roundtrip_full_metadata() -> std::io::Result<()> {
     let mtime = FileTime::from_unix_time(1_000_000, 123_456_789);
     let atime = FileTime::from_system_time(SystemTime::now());
     nix::sys::stat::fchmodat(
-        None,
+        AT_FDCWD,
         &src,
         nix::sys::stat::Mode::from_bits_truncate(mode),
         nix::sys::stat::FchmodatFlags::NoFollowSymlink,
@@ -33,7 +34,7 @@ fn roundtrip_full_metadata() -> std::io::Result<()> {
     filetime::set_file_times(&src, atime, mtime)?;
 
     nix::sys::stat::fchmodat(
-        None,
+        AT_FDCWD,
         &dst,
         nix::sys::stat::Mode::from_bits_truncate(0o600),
         nix::sys::stat::FchmodatFlags::NoFollowSymlink,
@@ -75,13 +76,13 @@ fn default_skips_owner_group_perms() -> std::io::Result<()> {
     fs::write(&dst, b"world")?;
 
     nix::sys::stat::fchmodat(
-        None,
+        AT_FDCWD,
         &src,
         nix::sys::stat::Mode::from_bits_truncate(0o741),
         nix::sys::stat::FchmodatFlags::NoFollowSymlink,
     )?;
     nix::sys::stat::fchmodat(
-        None,
+        AT_FDCWD,
         &dst,
         nix::sys::stat::Mode::from_bits_truncate(0o600),
         nix::sys::stat::FchmodatFlags::NoFollowSymlink,

--- a/crates/transport/Cargo.toml
+++ b/crates/transport/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 protocol = { path = "../protocol" }
 compress = { path = "../compress" }
-nix = { version = "0.28", default-features = false, features = ["poll", "fs"] }
+nix = { version = "0.30.1", default-features = false, features = ["poll", "fs"] }
 socket2 = { version = "0.5", features = ["all"] }
 checksums = { path = "../checksums" }
 ipnet = "2"

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -517,6 +517,8 @@ fn inner_pipe(inner: Option<&mut InnerPipe>) -> io::Result<&mut InnerPipe> {
 }
 
 fn set_fd_blocking(fd: RawFd, blocking: bool) -> io::Result<()> {
+    use std::os::fd::BorrowedFd;
+    let fd = unsafe { BorrowedFd::borrow_raw(fd) };
     let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL).map_err(io::Error::from)?);
     let mut new_flags = flags;
     if blocking {

--- a/crates/transport/tests/blocking_io.rs
+++ b/crates/transport/tests/blocking_io.rs
@@ -3,7 +3,6 @@
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use std::net::TcpListener;
 #[cfg(unix)]
-use std::os::fd::AsRawFd;
 use std::thread;
 use transport::{ssh::SshStdioTransport, tcp::TcpTransport, Transport};
 
@@ -13,9 +12,8 @@ fn ssh_blocking_mode() {
     let mut t = SshStdioTransport::spawn("sh", ["-c", "cat"]).expect("spawn");
     t.set_blocking_io(true).expect("set");
     let (reader, writer) = t.into_inner().expect("inner");
-    let rflags =
-        OFlag::from_bits_truncate(fcntl(reader.get_ref().as_raw_fd(), FcntlArg::F_GETFL).unwrap());
-    let wflags = OFlag::from_bits_truncate(fcntl(writer.as_raw_fd(), FcntlArg::F_GETFL).unwrap());
+    let rflags = OFlag::from_bits_truncate(fcntl(reader.get_ref(), FcntlArg::F_GETFL).unwrap());
+    let wflags = OFlag::from_bits_truncate(fcntl(&writer, FcntlArg::F_GETFL).unwrap());
     assert!(!rflags.contains(OFlag::O_NONBLOCK));
     assert!(!wflags.contains(OFlag::O_NONBLOCK));
 }
@@ -25,9 +23,8 @@ fn ssh_blocking_mode() {
 fn ssh_nonblocking_default() {
     let t = SshStdioTransport::spawn("sh", ["-c", "cat"]).expect("spawn");
     let (reader, writer) = t.into_inner().expect("inner");
-    let rflags =
-        OFlag::from_bits_truncate(fcntl(reader.get_ref().as_raw_fd(), FcntlArg::F_GETFL).unwrap());
-    let wflags = OFlag::from_bits_truncate(fcntl(writer.as_raw_fd(), FcntlArg::F_GETFL).unwrap());
+    let rflags = OFlag::from_bits_truncate(fcntl(reader.get_ref(), FcntlArg::F_GETFL).unwrap());
+    let wflags = OFlag::from_bits_truncate(fcntl(&writer, FcntlArg::F_GETFL).unwrap());
     assert!(rflags.contains(OFlag::O_NONBLOCK));
     assert!(wflags.contains(OFlag::O_NONBLOCK));
 }
@@ -43,8 +40,8 @@ fn tcp_blocking_mode() {
     let mut t =
         TcpTransport::connect(&addr.ip().to_string(), addr.port(), None, None).expect("connect");
     t.set_blocking_io(true).expect("set");
-    let fd = t.into_inner().as_raw_fd();
-    let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL).unwrap());
+    let stream = t.into_inner();
+    let flags = OFlag::from_bits_truncate(fcntl(&stream, FcntlArg::F_GETFL).unwrap());
     assert!(!flags.contains(OFlag::O_NONBLOCK));
     handle.join().unwrap();
 }
@@ -59,8 +56,8 @@ fn tcp_nonblocking_default() {
     });
     let t =
         TcpTransport::connect(&addr.ip().to_string(), addr.port(), None, None).expect("connect");
-    let fd = t.into_inner().as_raw_fd();
-    let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL).unwrap());
+    let stream = t.into_inner();
+    let flags = OFlag::from_bits_truncate(fcntl(&stream, FcntlArg::F_GETFL).unwrap());
     assert!(flags.contains(OFlag::O_NONBLOCK));
     handle.join().unwrap();
 }

--- a/tests/cli_flags.rs
+++ b/tests/cli_flags.rs
@@ -6,8 +6,6 @@ use oc_rsync_cli::cli_command;
 use predicates::str::contains;
 use std::fs;
 use std::net::TcpListener;
-#[cfg(unix)]
-use std::os::fd::AsRawFd;
 use std::path::Path;
 use std::thread;
 use std::time::Duration;
@@ -44,8 +42,7 @@ fn blocking_io_nonblocking_by_default() {
     #[cfg(unix)]
     {
         let stream = t.into_inner();
-        let fd = stream.as_raw_fd();
-        let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL).unwrap());
+        let flags = OFlag::from_bits_truncate(fcntl(&stream, FcntlArg::F_GETFL).unwrap());
         assert!(flags.contains(OFlag::O_NONBLOCK));
     }
     #[cfg(not(unix))]
@@ -68,8 +65,7 @@ fn blocking_io_flag_enables_blocking_mode() {
     #[cfg(unix)]
     {
         let stream = t.into_inner();
-        let fd = stream.as_raw_fd();
-        let flags = OFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFL).unwrap());
+        let flags = OFlag::from_bits_truncate(fcntl(&stream, FcntlArg::F_GETFL).unwrap());
         assert!(!flags.contains(OFlag::O_NONBLOCK));
     }
     #[cfg(not(unix))]

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -828,6 +828,7 @@ fn daemon_acls_match_rsync_client() {
 #[serial]
 #[cfg_attr(not(target_os = "linux"), ignore = "requires Linux uid/gid semantics")]
 fn daemon_preserves_uid_gid_perms() {
+    use nix::fcntl::AT_FDCWD;
     use nix::sys::stat::{fchmodat, FchmodatFlags, Mode};
     use nix::unistd::{chown, Gid, Uid};
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -845,7 +846,7 @@ fn daemon_preserves_uid_gid_perms() {
     let file = src.join("file");
     fs::write(&file, b"hi").unwrap();
     fchmodat(
-        None,
+        AT_FDCWD,
         &file,
         Mode::from_bits_truncate(0o741),
         FchmodatFlags::NoFollowSymlink,


### PR DESCRIPTION
## Summary
- bump `clap` to 4.5.47 and `nix` to 0.30.1 across the workspace
- adjust code for `nix` API updates and trait-bound changes

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 120 failed, 28 skipped)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(warnings only, see log)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68baede3fbd083238f39d90dff2f6844