### PR TITLE
fix tmp dest parent directory creation

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1433,16 +1433,15 @@ impl Receiver {
                 Err(_) => Box::new(Cursor::new(Vec::new())),
             }
         };
-        if let Some(parent) = tmp_dest.parent() {
-            let created = !parent.exists();
-            fs::create_dir_all(parent).map_err(|e| io_context(parent, e))?;
-            #[cfg(unix)]
-            if created {
-                if let Some((uid, gid)) = self.opts.copy_as {
-                    let gid = gid.map(Gid::from_raw);
-                    chown(parent, Some(Uid::from_raw(uid)), gid)
-                        .map_err(|e| io_context(parent, std::io::Error::from(e)))?;
-                }
+        let parent = tmp_dest.parent().unwrap_or_else(|| Path::new("."));
+        let created = !parent.exists();
+        fs::create_dir_all(parent).map_err(|e| io_context(parent, e))?;
+        #[cfg(unix)]
+        if created {
+            if let Some((uid, gid)) = self.opts.copy_as {
+                let gid = gid.map(Gid::from_raw);
+                chown(parent, Some(Uid::from_raw(uid)), gid)
+                    .map_err(|e| io_context(parent, std::io::Error::from(e)))?;
             }
         }
         #[cfg(unix)]


### PR DESCRIPTION
## Summary
- ensure tmp destination's parent directory exists before writing

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command `nextest`)*
- `make verify-comments` *(fails: build.rs: additional comments)*
- `make lint`
- `cargo test --test checksum_seed_cli` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68baf846a0e88323b43f48b2d1d2aa5d