### PR TITLE
Use std::os::fd in SSH transport

### DIFF
--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -4,7 +4,7 @@ use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
 use std::ffi::OsStr;
 use std::io::{self, BufReader, Read, Write};
-use std::os::unix::io::{AsRawFd, BorrowedFd, RawFd};
+use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Summary
- use `std::os::fd` for `AsRawFd`, `BorrowedFd`, and `RawFd` in SSH transport

## Testing
- `cargo fmt --all`
- `cargo check -p transport` *(fails: unresolved import `posix_acl`)*
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: cannot find -lacl)*
- `make verify-comments` *(fails: build.rs additional comments)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68baf8ba197c83238d7b7afdde519ea8