### PR TITLE
ci: setup homebrew before formula audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Validate interop matrix docs
         run: scripts/check-run-matrix-docs.sh
 
+      - uses: Homebrew/actions/setup-homebrew@v3
+
       - name: Lint Homebrew formula
         run: brew audit --strict --new-formula ./packaging/brew/oc-rsync.rb
 


### PR DESCRIPTION
## Summary
- install Homebrew in lint workflow before auditing formula

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint` *(fails: Interrupted)*
- `cargo test --workspace --no-fail-fast` *(fails: Interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68bafb6017648323a7f83652364b9b80