### PR TITLE
Handle legacy basename partial files

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -995,6 +995,26 @@ fn resumes_from_partial_file() {
     std::fs::create_dir_all(&src_dir).unwrap();
     std::fs::create_dir_all(&dst_dir).unwrap();
     std::fs::write(src_dir.join("a.txt"), b"hello").unwrap();
+    std::fs::write(dst_dir.join("a.txt.partial"), b"he").unwrap();
+
+    let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
+    let src_arg = format!("{}/", src_dir.display());
+    cmd.args(["--partial", &src_arg, dst_dir.to_str().unwrap()]);
+    cmd.assert().success();
+
+    let out = std::fs::read(dst_dir.join("a.txt")).unwrap();
+    assert_eq!(out, b"hello");
+    assert!(!dst_dir.join("a.txt.partial").exists());
+}
+
+#[test]
+fn resumes_from_basename_partial_file() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&dst_dir).unwrap();
+    std::fs::write(src_dir.join("a.txt"), b"hello").unwrap();
     std::fs::write(dst_dir.join("a.partial"), b"he").unwrap();
 
     let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
@@ -1005,6 +1025,7 @@ fn resumes_from_partial_file() {
     let out = std::fs::read(dst_dir.join("a.txt")).unwrap();
     assert_eq!(out, b"hello");
     assert!(!dst_dir.join("a.partial").exists());
+    assert!(!dst_dir.join("a.txt.partial").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- detect legacy `<basename>.partial` files and prefer `<dest>.partial`
- remove stale basename partials after completing transfers
- test partial resume for new and legacy partial filenames

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: engine::batch_replay::replay_is_deterministic, engine::cleanup::removes_temp_dir_after_sync, engine::resume::resume_from_partial_file)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(aborted)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb173b1f7c8323a75bf691ad0c2e6e