### PR TITLE
Ensure temp files persist until atomic rename

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1415,7 +1415,7 @@ impl Receiver {
             && !self.opts.write_devices
         {
             auto_tmp = true;
-            let mut name = dest.file_name().unwrap_or_default().to_os_string();
+            let mut name = dest.file_stem().unwrap_or_default().to_os_string();
             name.push(".tmp");
             tmp_dest = dest_parent.join(name);
         }
@@ -1423,7 +1423,7 @@ impl Receiver {
             !self.opts.inplace && (self.opts.partial || self.opts.temp_dir.is_some() || auto_tmp);
         if self.opts.delay_updates && !self.opts.inplace && !self.opts.write_devices {
             if tmp_dest == dest {
-                let mut name = dest.file_name().unwrap_or_default().to_os_string();
+                let mut name = dest.file_stem().unwrap_or_default().to_os_string();
                 name.push(".tmp");
                 tmp_dest = dest_parent.join(name);
             }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1190,6 +1190,7 @@ fn destination_is_replaced_atomically() {
     );
 
     child.wait().unwrap();
+    assert!(!tmp_file.exists(), "temp file not removed after transfer",);
     let out = std::fs::read(dst_dir.join("a.txt")).unwrap();
     assert_eq!(out.len(), 50_000);
 }


### PR DESCRIPTION
## Summary
- Name temporary files using the destination's stem plus `.tmp`
- Verify the temporary file is removed after transfer completes

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 728 passed, 126 failed, 20 skipped)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(warnings; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1740c8bc83239e552e6291444d5f