### PR TITLE
Remove partial files after successful sync

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1582,6 +1582,17 @@ impl Receiver {
                     .push((src.to_path_buf(), tmp_dest.clone(), dest.clone()));
             } else {
                 atomic_rename(&tmp_dest, &dest)?;
+                if (self.opts.partial || self.opts.partial_dir.is_some()) && partial != tmp_dest {
+                    let _ = fs::remove_file(&partial);
+                    if let Some(stem) = dest.file_stem() {
+                        let mut name = stem.to_os_string();
+                        name.push(".partial");
+                        let alt = dest.with_file_name(name);
+                        if alt != partial {
+                            let _ = fs::remove_file(alt);
+                        }
+                    }
+                }
                 if let Some(tmp_parent) = tmp_dest.parent() {
                     if dest.parent() != Some(tmp_parent)
                         && tmp_parent


### PR DESCRIPTION
## Summary
- delete leftover `.partial` files after atomic rename succeeds
- add regression test ensuring `.partial` remnants are removed when using `--temp-dir`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: replay_is_deterministic, removes_temp_dir_after_sync, resume_from_partial_file)*
- `cargo test --test cli -- --nocapture resumes_from_partial_file`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb18029ba483238e837296af6a85ac