### PR TITLE
Use file stem for auto tmp name

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1415,16 +1415,20 @@ impl Receiver {
             && !self.opts.write_devices
         {
             auto_tmp = true;
-            let mut name = dest.file_name().unwrap_or_default().to_os_string();
-            name.push(".tmp");
+            let stem = dest
+                .file_stem()
+                .unwrap_or_else(|| dest.file_name().unwrap_or_default());
+            let name = format!("{}.tmp", stem.to_string_lossy());
             tmp_dest = dest_parent.join(name);
         }
         let mut needs_rename =
             !self.opts.inplace && (self.opts.partial || self.opts.temp_dir.is_some() || auto_tmp);
         if self.opts.delay_updates && !self.opts.inplace && !self.opts.write_devices {
             if tmp_dest == dest {
-                let mut name = dest.file_name().unwrap_or_default().to_os_string();
-                name.push(".tmp");
+                let stem = dest
+                    .file_stem()
+                    .unwrap_or_else(|| dest.file_name().unwrap_or_default());
+                let name = format!("{}.tmp", stem.to_string_lossy());
                 tmp_dest = dest_parent.join(name);
             }
             needs_rename = true;

--- a/crates/engine/tests/auto_tmp.rs
+++ b/crates/engine/tests/auto_tmp.rs
@@ -1,0 +1,45 @@
+// crates/engine/tests/auto_tmp.rs
+use std::fs;
+use std::thread;
+use std::time::Duration;
+
+use compress::available_codecs;
+use engine::{sync, SyncOptions};
+use filters::Matcher;
+use tempfile::tempdir;
+
+#[test]
+fn uses_file_stem_for_auto_tmp() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+
+    let data = vec![0u8; 100 * 1024 * 1024];
+    fs::write(src.join("a.txt"), &data).unwrap();
+
+    let handle = {
+        let src = src.clone();
+        let dst = dst.clone();
+        thread::spawn(move || {
+            sync(
+                &src,
+                &dst,
+                &Matcher::default(),
+                &available_codecs(),
+                &SyncOptions::default(),
+            )
+            .unwrap();
+        })
+    };
+
+    let tmp_path = dst.join("a.tmp");
+    while !handle.is_finished() && !tmp_path.exists() {
+        thread::sleep(Duration::from_millis(10));
+    }
+    assert!(tmp_path.exists());
+    handle.join().unwrap();
+    assert!(dst.join("a.txt").exists());
+    assert!(!tmp_path.exists());
+}


### PR DESCRIPTION
## Summary
- derive temporary destination name from file stem
- test auto tmp naming uses stem

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` (fails: replay_is_deterministic, removes_temp_dir_after_sync, backups_use_custom_suffix, resume_from_partial_file)
- `make lint`
- `make verify-comments` *(failed: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1808b7208323932ccf346fbb7919