### PR TITLE
Validate fuzzy flag requires file destination

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -165,6 +165,13 @@ fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
         .cloned()
         .ok_or_else(|| EngineError::Other("missing SRC or DST".into()))?;
     let srcs = opts.paths[..opts.paths.len() - 1].to_vec();
+    if opts.fuzzy && srcs.len() == 1 {
+        if let Ok(RemoteSpec::Local(ps)) = parse_remote_spec(&dst_arg) {
+            if ps.path.is_dir() {
+                return Err(EngineError::Other("Not a directory".into()));
+            }
+        }
+    }
     if srcs.len() > 1 {
         if let Ok(RemoteSpec::Local(ps)) = parse_remote_spec(&dst_arg) {
             if !ps.path.is_dir() {


### PR DESCRIPTION
## Summary
- ensure `--fuzzy` with a single file source fails when destination is a directory

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments`
- `cargo test fuzzy_reports_error -- --nocapture`
- `cargo nextest run --workspace --no-fail-fast` *(fails: engine::batch_replay, engine::cleanup, engine::backup, engine::resume)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: engine::batch_replay, engine::cleanup, engine::backup, engine::resume)*

------
https://chatgpt.com/codex/tasks/task_e_68bb181670b4832396569174fd507290