### PR TITLE
Hide temporary files via scoped directory and cleanup guard

### DIFF
--- a/crates/engine/tests/cleanup.rs
+++ b/crates/engine/tests/cleanup.rs
@@ -1,5 +1,7 @@
 // crates/engine/tests/cleanup.rs
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use compress::available_codecs;
 use engine::{sync, SyncOptions};
@@ -57,4 +59,33 @@ fn removes_temp_dir_after_sync() {
 
     assert!(dst.join("file").exists());
     assert!(!tmpdir.exists());
+}
+
+#[test]
+#[cfg(unix)]
+fn cleans_up_temp_dir_on_rename_failure() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    fs::write(src.join("file"), b"hi").unwrap();
+    let tmpdir = tmp.path().join("tmpdir");
+    fs::create_dir_all(&tmpdir).unwrap();
+    let mut perms = fs::metadata(&dst).unwrap().permissions();
+    perms.set_mode(0o500);
+    fs::set_permissions(&dst, perms).unwrap();
+    let res = sync(
+        &src,
+        &dst,
+        &Matcher::default(),
+        &available_codecs(),
+        &SyncOptions {
+            temp_dir: Some(tmpdir.clone()),
+            ..Default::default()
+        },
+    );
+    assert!(res.is_err());
+    fs::set_permissions(&dst, fs::Permissions::from_mode(0o700)).unwrap();
+    assert!(fs::read_dir(&tmpdir).unwrap().next().is_none());
 }


### PR DESCRIPTION
## Summary
- Place temp files inside a unique hidden directory instead of visible `*.tmp`
- Use `TempFileGuard` to clean up temp files on errors and disarm after rename
- Add tests ensuring temp files are hidden and cleaned up on rename failure

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- ⚠️ `cargo nextest run --workspace --no-fail-fast` *(cargo-nextest unavailable)*
- ⚠️ `cargo nextest run --workspace --all-features --no-fail-fast` *(cargo-nextest unavailable)*


------
https://chatgpt.com/codex/tasks/task_e_68bb2bb63540832390b34f6f38bc11b2