### PR TITLE
daemon: isolate connections and honor hard-link requests

### DIFF
--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -333,7 +333,7 @@ pub(crate) fn run_daemon(opts: DaemonOpts, matches: &ArgMatches) -> Result<()> {
         None
     };
 
-    let handler: Arc<daemon::Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<daemon::Handler> = Arc::new(|_, _| Ok(()));
     let quiet = matches.get_flag("quiet");
 
     daemon::run_daemon(

--- a/crates/daemon/tests/no_token.rs
+++ b/crates/daemon/tests/no_token.rs
@@ -16,7 +16,7 @@ fn handle_connection_empty_module_name() {
     let mut transport = LocalPipeTransport::new(reader, writer);
 
     let modules: HashMap<String, Module> = HashMap::new();
-    let handler: Arc<Handler> = Arc::new(|_t| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
 
     handle_connection(
         &mut transport,

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -305,7 +305,7 @@ fn module_authentication_and_hosts_enforced() {
     };
     let mut modules = HashMap::new();
     modules.insert(module.name.clone(), module);
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
     let mut ok_t = pipe_transport("alice", "data");
     handle_connection(
         &mut ok_t,
@@ -373,7 +373,7 @@ fn host_deny_blocks_connection() {
     };
     let mut modules = HashMap::new();
     modules.insert(module.name.clone(), module);
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
     let mut t = pipe_transport("", "data");
     let err = handle_connection(
         &mut t,
@@ -414,7 +414,7 @@ fn daemon_refuses_configured_option() {
     };
     let mut modules = HashMap::new();
     modules.insert(module.name.clone(), module);
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
     let mut t = pipe_transport_opts("", "data", &["--delete"]);
     let err = handle_connection(
         &mut t,
@@ -446,7 +446,7 @@ fn daemon_refuses_numeric_ids_option() {
     };
     let mut modules = HashMap::new();
     modules.insert(module.name.clone(), module);
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
     let mut t = pipe_transport_opts("", "data", &["--numeric-ids"]);
     let err = handle_connection(
         &mut t,
@@ -479,7 +479,7 @@ fn daemon_refuses_no_numeric_ids_option() {
     };
     let mut modules = HashMap::new();
     modules.insert(module.name.clone(), module);
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
     let mut t = pipe_transport_opts("", "data", &["--no-numeric-ids"]);
     let err = handle_connection(
         &mut t,
@@ -516,7 +516,7 @@ fn rejects_missing_token() {
     };
     let mut modules = HashMap::new();
     modules.insert(module.name.clone(), module);
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
     let mut t = pipe_transport("", "data");
     let err = handle_connection(
         &mut t,
@@ -559,7 +559,7 @@ fn anonymous_module_listing_only_shows_listed_modules() {
         ..Module::default()
     };
     modules.insert("private".into(), private);
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
 
     handle_connection(
         &mut transport,

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -882,9 +882,10 @@ fn daemon_preserves_hard_links_rr_client() {
     let (mut child, port) = spawn_daemon(&srv);
     wait_for_daemon(port);
     let src_arg = format!("{}/", src.display());
+    let dest = format!("rsync://127.0.0.1:{port}/mod");
     Command::cargo_bin("oc-rsync")
         .unwrap()
-        .args(["-aH", &src_arg, &format!("rsync://127.0.0.1:{port}/mod")])
+        .args(["-aH", &src_arg, &dest])
         .assert()
         .success();
     let meta1 = fs::symlink_metadata(srv.join("a")).unwrap();


### PR DESCRIPTION
## Summary
- chroot and drop privileges per connection by waiting for each child to exit
- forward client options to handlers so `--hard-links` works in daemon mode
- regression tests for sequential connections and daemon hard-link preservation

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command `nextest`)*
- `cargo test --workspace --no-fail-fast` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2bd0e3f48323856e0d774bd941e5