### PR TITLE
ci: build rpm with cargo-rpm and add sbom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,17 +222,26 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 
       - name: Install packaging tools
-        run: cargo install cargo-deb cargo-generate-rpm || true
+        run: cargo install cargo-deb cargo-rpm || true
+
+      - name: Install cyclonedx-rust-cargo
+        run: cargo install cyclonedx-rust-cargo || true
 
       - name: Build packages
         run: |
           cargo deb -p oc-rsync
-          cargo generate-rpm
+          cargo rpm build --release
+
+      - name: Generate SBOM
+        run: |
+          mkdir -p target/sbom
+          cyclonedx-rust-cargo --output target/sbom/oc-rsync.cdx.json
 
       - uses: actions/upload-artifact@v4
         with:
           name: oc-rsync-packages
           path: |
             target/debian/*.deb
-            target/generate-rpm/*.rpm
+            target/release/rpms/*.rpm
+            target/sbom/oc-rsync.cdx.json
             


### PR DESCRIPTION
## Summary
- use cargo-rpm for rpm packages
- generate CycloneDX SBOM and upload with packages

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: replay_is_deterministic, removes_temp_dir_after_sync, backups_use_custom_suffix, resume_from_partial_file)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: replay_is_deterministic, removes_temp_dir_after_sync, backups_use_custom_suffix, resume_from_partial_file)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb2bf8488c8323af27d06bff3b39d5