### PR TITLE
Handle daemon handshake timeout

### DIFF
--- a/crates/daemon/tests/no_token.rs
+++ b/crates/daemon/tests/no_token.rs
@@ -32,6 +32,7 @@ fn handle_connection_empty_module_name() {
         0,
         0,
         &handler,
+        None,
     )
     .expect("empty module name should succeed");
 

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -321,6 +321,7 @@ fn module_authentication_and_hosts_enforced() {
         uid,
         gid,
         &handler,
+        None,
     )
     .unwrap();
 
@@ -339,6 +340,7 @@ fn module_authentication_and_hosts_enforced() {
         uid,
         gid,
         &handler,
+        None,
     )
     .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
@@ -357,6 +359,7 @@ fn module_authentication_and_hosts_enforced() {
         uid,
         gid,
         &handler,
+        None,
     )
     .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
@@ -389,6 +392,7 @@ fn host_deny_blocks_connection() {
         0,
         0,
         &handler,
+        None,
     )
     .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
@@ -430,6 +434,7 @@ fn daemon_refuses_configured_option() {
         0,
         0,
         &handler,
+        None,
     )
     .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
@@ -462,6 +467,7 @@ fn daemon_refuses_numeric_ids_option() {
         0,
         0,
         &handler,
+        None,
     )
     .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
@@ -495,6 +501,7 @@ fn daemon_refuses_no_numeric_ids_option() {
         0,
         0,
         &handler,
+        None,
     )
     .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
@@ -532,6 +539,7 @@ fn rejects_missing_token() {
         0,
         0,
         &handler,
+        None,
     )
     .unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
@@ -575,6 +583,7 @@ fn anonymous_module_listing_only_shows_listed_modules() {
         0,
         0,
         &handler,
+        None,
     )
     .unwrap();
 

--- a/tests/golden/messages/timeout/daemon_handshake.rsync.stderr
+++ b/tests/golden/messages/timeout/daemon_handshake.rsync.stderr
@@ -1,0 +1,1 @@
+@ERROR: timeout waiting for daemon connection


### PR DESCRIPTION
## Summary
- enforce daemon handshake deadline and emit upstream timeout message
- surface handshake timeouts to clients as exit code 30
- add golden fixture and test for timeout diagnostic text

## Testing
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2bd3cf6c8323a02f4cb5b8d5874e