### PR TITLE
Parse RSH env assignments for remote shell

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -481,8 +481,10 @@ fn run_single(
 
     let known_hosts = opts.known_hosts.clone();
     let strict_host_key_checking = !opts.no_host_key_checking;
-    let rsh_raw = opts.rsh.clone().or_else(|| env::var("RSYNC_RSH").ok());
-    let rsh_cmd = parse_rsh(rsh_raw)?;
+    let rsh_cmd = match opts.rsh.clone() {
+        Some(cmd) => cmd,
+        None => parse_rsh(env::var("RSYNC_RSH").ok().or_else(|| env::var("RSH").ok()))?,
+    };
     let rsync_path_cmd = parse_rsync_path(opts.rsync_path.clone())?;
     let mut rsync_env: Vec<(String, String)> = env::vars()
         .filter(|(k, _)| k.starts_with("RSYNC_"))
@@ -1553,9 +1555,9 @@ mod tests {
     #[test]
     fn parses_rsh_flag_and_alias() {
         let opts = ClientOpts::parse_from(["prog", "--rsh", "ssh", "src", "dst"]);
-        assert_eq!(opts.rsh.as_deref(), Some("ssh"));
+        assert_eq!(opts.rsh.unwrap().cmd, vec!["ssh".to_string()]);
         let opts = ClientOpts::parse_from(["prog", "-e", "ssh", "src", "dst"]);
-        assert_eq!(opts.rsh.as_deref(), Some("ssh"));
+        assert_eq!(opts.rsh.unwrap().cmd, vec!["ssh".to_string()]);
     }
 
     #[test]

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -6,7 +6,8 @@ use std::{ffi::OsString, path::PathBuf};
 pub use crate::daemon::DaemonOpts;
 use crate::formatter;
 use crate::utils::{
-    parse_duration, parse_minutes, parse_nonzero_duration, parse_size, parse_stop_at,
+    parse_duration, parse_minutes, parse_nonzero_duration, parse_rsh, parse_size, parse_stop_at,
+    RshCommand,
 };
 use clap::{Arg, ArgAction, Args, CommandFactory, Parser, ValueEnum};
 use logging::{DebugFlag, InfoFlag, StderrMode};
@@ -14,6 +15,10 @@ use protocol::SUPPORTED_PROTOCOLS;
 
 fn parse_lowercase(value: &str) -> Result<String, String> {
     Ok(value.to_ascii_lowercase())
+}
+
+fn parse_rsh_arg(value: &str) -> Result<RshCommand, String> {
+    parse_rsh(Some(value.to_string())).map_err(|e| e.to_string())
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
@@ -580,8 +585,8 @@ pub(crate) struct ClientOpts {
     pub password_file: Option<PathBuf>,
     #[arg(long = "early-input", value_name = "FILE")]
     pub early_input: Option<PathBuf>,
-    #[arg(short = 'e', long, value_name = "COMMAND")]
-    pub rsh: Option<String>,
+    #[arg(short = 'e', long, value_name = "COMMAND", value_parser = parse_rsh_arg)]
+    pub rsh: Option<RshCommand>,
     #[arg(
         short = 'M',
         long = "remote-option",

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -354,8 +354,8 @@ impl SshStdioTransport {
         let program = rsh.first().map(|s| s.as_str()).unwrap_or("ssh");
         if program == "ssh" {
             let mut cmd = Command::new(program);
-            cmd.args(&rsh[1..]);
             cmd.envs(rsh_env.iter().cloned());
+            cmd.args(&rsh[1..]);
             let known_hosts_path = known_hosts.map(Path::to_path_buf).or_else(|| {
                 std::env::var("HOME")
                     .ok()
@@ -417,8 +417,8 @@ impl SshStdioTransport {
             args.extend_from_slice(remote_opts);
             args.push(path.to_string_lossy().into_owned());
             let mut cmd = Command::new(program);
-            cmd.args(args);
             cmd.envs(rsh_env.iter().cloned());
+            cmd.args(args);
             Self::spawn_from_command(cmd, blocking_io)
         }
     }

--- a/tests/rsh.rs
+++ b/tests/rsh.rs
@@ -217,7 +217,7 @@ fn rsh_env_var_assignments_are_honored() {
     let dst_spec = format!("ignored:{}", dst_dir.display());
     let rsh_spec = format!("FOO=bar {}", rsh.display());
     let mut cmd = AssertCommand::cargo_bin("oc-rsync").unwrap();
-    cmd.env("RSYNC_RSH", rsh_spec);
+    cmd.env("RSH", rsh_spec);
     cmd.args([
         "--rsync-path",
         remote_bin.to_str().unwrap(),
@@ -252,7 +252,7 @@ fn rsync_path_respects_rsh_env_var() {
     let src_spec = format!("{}/", src_dir.display());
     let dst_spec = format!("ignored:{}", dst_dir.display());
     let mut cmd = AssertCommand::cargo_bin("oc-rsync").unwrap();
-    cmd.env("RSYNC_RSH", rsh.to_str().unwrap());
+    cmd.env("RSH", rsh.to_str().unwrap());
     cmd.args([
         "--rsync-path",
         remote_bin.to_str().unwrap(),


### PR DESCRIPTION
## Summary
- Parse `--rsh` argument into env pairs and command tokens
- Propagate `RSH` environment variables and apply them before launching remote shell
- Exercise `RSH` and `rsync-path` interaction in tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: SIGINT / missing remote path)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: remote path missing / tests interrupted)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb2bbecdd48323a49930a1b8ed3b62