### PR TITLE
Remove legacy protocol 29

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::{env, fs, path::Path, path::PathBuf, process::Command};
 use time::OffsetDateTime;
 
 const UPSTREAM_VERSION: &str = "3.4.1";
-const UPSTREAM_PROTOCOLS: &[u32] = &[32, 31, 30, 29];
+const UPSTREAM_PROTOCOLS: &[u32] = &[32, 31, 30];
 const BRANDING_VARS: &[&str] = &[
     "OC_RSYNC_BRAND_NAME",
     "OC_RSYNC_BRAND_TAGLINE",

--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -11,7 +11,7 @@ const UPSTREAM_VERSION: &str = match option_env!("UPSTREAM_VERSION") {
 };
 const UPSTREAM_PROTOCOLS: &str = match option_env!("UPSTREAM_PROTOCOLS") {
     Some(v) => v,
-    None => "32,31,30,29",
+    None => "32,31,30",
 };
 
 const CAPABILITIES: &[&str] = &[

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -13,7 +13,7 @@ fn banner_is_static() {
         ),
         {
             let proto = option_env!("UPSTREAM_PROTOCOLS")
-                .unwrap_or("32,31,30,29")
+                .unwrap_or("32,31,30")
                 .split(',')
                 .next()
                 .unwrap_or("0");

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -50,10 +50,9 @@ pub use server::Server;
 pub const V32: u32 = 32;
 pub const V31: u32 = 31;
 pub const V30: u32 = 30;
-pub const V29: u32 = 29;
-pub const SUPPORTED_PROTOCOLS: &[u32] = &[V32, V31, V30, V29];
+pub const SUPPORTED_PROTOCOLS: &[u32] = &[V32, V31, V30];
 pub const LATEST_VERSION: u32 = V32;
-pub const MIN_VERSION: u32 = V29;
+pub const MIN_VERSION: u32 = V30;
 
 pub const CAP_CODECS: u32 = 1 << 0;
 pub const CAP_ZSTD: u32 = 1 << 1;

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -2,7 +2,7 @@
 use compress::{available_codecs, encode_codecs, Codec};
 use protocol::{
     ExitCode, Server, CAP_ACLS, CAP_CODECS, CAP_XATTRS, CAP_ZSTD, SUPPORTED_CAPS,
-    SUPPORTED_PROTOCOLS, V29,
+    SUPPORTED_PROTOCOLS, V30,
 };
 use std::io::Cursor;
 use std::time::Duration;
@@ -41,7 +41,7 @@ fn server_negotiates_version() {
 
 #[test]
 fn server_accepts_legacy_version() {
-    let legacy = V29;
+    let legacy = V30;
     let payload = encode_codecs(&available_codecs());
     let codecs_frame = protocol::Message::Codecs(payload.clone()).to_frame(0, None);
     let mut codecs_buf = Vec::new();

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -6,15 +6,14 @@ The following upstream protocol versions are recognized:
 - 32
 - 31
 - 30
-- 29
 
-When connecting to a peer, the highest shared version from this list is selected. Versions earlier than 29 are not supported.
+When connecting to a peer, the highest shared version from this list is selected. Versions earlier than 30 are not supported.
 
 ## Version constants
 
 ```
 UPSTREAM_VERSION=3.4.1
-UPSTREAM_PROTOCOLS=[32,31,30,29]
+UPSTREAM_PROTOCOLS=[32,31,30]
 ```
 
 The build scripts for `oc-rsync` and `oc-rsyncd` embed these values into the binaries by exporting them as compile-time environment variables (for example `cargo:rustc-env=UPSTREAM_VERSION=…` and `cargo:rustc-env=UPSTREAM_PROTOCOLS=…`) in `build.rs`.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -8,7 +8,7 @@ into CI, and their results populate the detailed matrix in
 
 ## Protocol versions
 
-`oc-rsync` interoperates with classic `rsync` using protocol versions 29
+`oc-rsync` interoperates with classic `rsync` using protocol versions 30
 through 32.
 
 ## Tested platforms
@@ -32,7 +32,6 @@ kept up to date from their results.
 
 | Version | Tests/Fixtures |
 |---------|----------------|
-| 29 | [version negotiation test](../crates/protocol/tests/protocol.rs#L40-L45) |
 | 30 | [protocol override test](../crates/cli/src/lib.rs#L1958-L2030) |
 | 31 | [server handshake test](../crates/protocol/tests/server.rs#L1-L80) |
 | 32 | [rsync 3.3.0 transcript](../tests/interop/wire/rsync-3.3.0.log) |

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -3,7 +3,7 @@
 This table tracks the implementation status of rsync 3.4.x command-line options.
 Behavioral differences from upstream rsync are tracked in [gaps.md](gaps.md).
 
-Classic `rsync` protocol versions 29–32 are supported.
+Classic `rsync` protocol versions 30–32 are supported.
 
 ## Internal features
 


### PR DESCRIPTION
## Summary
- drop protocol 29 from UPSTREAM_PROTOCOLS
- update docs and tests to cover only protocols 30–32

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: no method named `into_temp_path` in engine)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: no method named `into_temp_path` in engine)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: no method named `into_temp_path` in engine)*
- `make verify-comments`
- `make lint` *(fails: no method named `into_temp_path` in engine)*

------
https://chatgpt.com/codex/tasks/task_e_68bb365babf08323b70b238cd6866a00