### PR TITLE
test: snapshot --help output

### DIFF
--- a/tests/golden/help/oc-rsync.help
+++ b/tests/golden/help/oc-rsync.help
@@ -1,141 +1,212 @@
---verbose	increase verbosity
---info=FLAGS	fine-grained informational verbosity
---debug=FLAGS	fine-grained debug verbosity
---stderr=e|a|c	change stderr output mode (default: errors)
---quiet	suppress non-error messages
---no-motd	suppress daemon-mode MOTD
---checksum	skip based on checksum, not mod-time & size
---archive	archive mode is -rlptgoD (no -A,-X,-U,-N,-H)
---no-OPTION	turn off an implied OPTION (e.g. --no-D)
---recursive	recurse into directories
---relative	use relative path names
---no-implied-dirs	don't send implied dirs with --relative
---backup	make backups (see --suffix & --backup-dir)
---backup-dir=DIR	make backups into hierarchy based in DIR
---suffix=SUFFIX	backup suffix (default ~ w/o --backup-dir)
---update	skip files that are newer on the receiver
---inplace	update destination files in-place
---append	append data onto shorter files
---append-verify	--append w/old data in file checksum
---dirs	transfer directories without recursing
---old-dirs	works like --dirs when talking to old rsync
---mkpath	create destination's missing path components
---links	copy symlinks as symlinks
---copy-links	transform symlink into referent file/dir
---copy-unsafe-links	only "unsafe" symlinks are transformed
---safe-links	ignore symlinks that point outside the tree
---munge-links	munge symlinks to make them safe & unusable
---copy-dirlinks	transform symlink to dir into referent dir
---keep-dirlinks	treat symlinked dir on receiver as dir
---hard-links	preserve hard links
---perms	preserve permissions
---executability	preserve executability
---chmod=CHMOD	affect file and/or directory permissions
---acls	preserve ACLs (implies --perms)
---xattrs	preserve extended attributes
---owner	preserve owner (super-user only)
---group	preserve group
---devices	preserve device files (super-user only)
---copy-devices	copy device contents as a regular file
---write-devices	write to devices as files (implies --inplace)
---specials	preserve special files
---times	preserve modification times
---atimes	preserve access (use) times
---open-noatime	avoid changing the atime on opened files
---crtimes	preserve create times (newness)
---omit-dir-times	omit directories from --times
---omit-link-times	omit symlinks from --times
---super	receiver attempts super-user activities
---fake-super	store/recover privileged attrs using xattrs
---sparse	turn sequences of nulls into sparse blocks
---preallocate	allocate dest files before writing them
---dry-run	perform a trial run with no changes made
---whole-file	copy files whole (w/o delta-xfer algorithm)
---checksum-choice=STR	choose the checksum algorithm (aka --cc)
---one-file-system	don't cross filesystem boundaries
---block-size=SIZE	force a fixed checksum block-size
---rsh=COMMAND	specify the remote shell to use
---rsync-path=PROGRAM	specify the rsync to run on remote machine
---existing	skip creating new files on receiver
---ignore-existing	skip updating files that exist on receiver
---remove-source-files	sender removes synchronized files (non-dir)
---del	an alias for --delete-during
---delete	delete extraneous files from dest dirs
---delete-before	receiver deletes before xfer, not during
---delete-during	receiver deletes during the transfer
---delete-delay	find deletions during, delete after
---delete-after	receiver deletes after transfer, not during
---delete-excluded	also delete excluded files from dest dirs
---ignore-missing-args	ignore missing source args without error
---delete-missing-args	delete missing source args from destination
---ignore-errors	delete even if there are I/O errors
---force	force deletion of dirs even if not empty
---max-delete=NUM	don't delete more than NUM files
---max-size=SIZE	don't transfer any file larger than SIZE
---min-size=SIZE	don't transfer any file smaller than SIZE
---max-alloc=SIZE	change a limit relating to memory alloc
---partial	keep partially transferred files
---partial-dir=DIR	put a partially transferred file into DIR
---delay-updates	put all updated files into place at end
---prune-empty-dirs	prune empty directory chains from file-list
---numeric-ids	don't map uid/gid values by user/group name
---usermap=STRING	custom username mapping
---groupmap=STRING	custom groupname mapping
---chown=USER:GROUP	simple username/groupname mapping
---timeout=SECONDS	set I/O timeout in seconds
---contimeout=SECONDS	set daemon connection timeout in seconds
---ignore-times	don't skip files that match size and time
---size-only	skip files that match in size
---modify-window=NUM	set the accuracy for mod-time comparisons
---temp-dir=DIR	create temporary files in directory DIR
---fuzzy	find similar file for basis if no dest file
---compare-dest=DIR	also compare destination files relative to DIR
---copy-dest=DIR	... and include copies of unchanged files
---link-dest=DIR	hardlink to files in DIR when unchanged
---compress	compress file data during the transfer
---compress-choice=STR	choose the compression algorithm (aka --zc)
---compress-level=NUM	explicitly set compression level (aka --zl)
---skip-compress=LIST	skip compressing files with suffix in LIST
---cvs-exclude	auto-ignore files in the same way CVS does
---filter=RULE	add a file-filtering RULE
---exclude=PATTERN	exclude files matching PATTERN
---exclude-from=FILE	read exclude patterns from FILE
---include=PATTERN	don't exclude files matching PATTERN
---include-from=FILE	read include patterns from FILE
---files-from=FILE	read list of source-file names from FILE
---from0	all *-from/filter files are delimited by 0s
---old-args	disable the modern arg-protection idiom
---secluded-args	use the protocol to safely send the args
---trust-sender	trust the remote sender's file list
---copy-as=USER[:GROUP]	specify user & optional group for the copy
---address=ADDRESS	bind address for outgoing socket to daemon
---port=PORT	specify double-colon alternate port number
---sockopts=OPTIONS	specify custom TCP options
---blocking-io	use blocking I/O for the remote shell
---outbuf=N|L|B	set out buffering to None, Line, or Block
---stats	give some file-transfer stats
---8-bit-output	leave high-bit chars unescaped in output
---human-readable	output numbers in a human-readable format
---progress	show progress during transfer
---itemize-changes	output a change-summary for all updates
---remote-option=OPT	send OPTION to the remote side only
---out-format=FORMAT	output updates using the specified FORMAT
---log-file=FILE	log what we're doing to the specified FILE
---log-file-format=FMT	log updates using the specified FMT
---password-file=FILE	read daemon-access password from FILE
---early-input=FILE	use FILE for daemon's early exec input
---list-only	list the files instead of copying them
---bwlimit=RATE	limit socket I/O bandwidth
---stop-after=MINS	Stop rsync after MINS minutes have elapsed
---stop-at=y-m-dTh:m	Stop rsync at the specified point in time
---fsync	fsync every written file
---write-batch=FILE	write a batched update to FILE
---only-write-batch=FILE	like --write-batch but w/o updating dest
---read-batch=FILE	read a batched update from FILE
---protocol=NUM	force an older protocol version to be used
---iconv=CONVERT_SPEC	request charset conversion of filenames
---checksum-seed=NUM	set block/file checksum seed (advanced)
---ipv4	prefer IPv4
---ipv6	prefer IPv6
---version	print the version + other info and exit
---help	show this help (* -h is help only on its own)
+oc-rsync 0.1.0
+Automatic Rust re-implementation by Ofer Chen (2025). Not affiliated with Samba.
+
+rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.
+
+rsync is a file transfer program capable of efficient remote update
+via a fast differencing algorithm.
+
+Usage: rsync [OPTION]... SRC [SRC]... DEST
+  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
+  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
+  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
+  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
+  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
+  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
+The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
+to an rsync daemon, and require SRC or DEST to start with a module name.
+
+Options
+Failed to locate upstream help suffix; displaying unmodified help text.
+
+rsync  version 3.4.1  protocol version 32
+Copyright (C) 1996-2025 by Andrew Tridgell, Wayne Davison, and others.
+Web site: https://rsync.samba.org/
+Capabilities:
+    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
+    socketpairs, symlinks, symtimes, hardlinks, hardlink-specials,
+    hardlink-symlinks, IPv6, atimes, batchfiles, inplace, append, no ACLs,
+    xattrs, optional secluded-args, iconv, prealloc, stop-at, no crtimes
+Optimizations:
+    SIMD-roll, no asm-roll, openssl-crypto, no asm-MD5
+Checksum list:
+    md5 md4 sha1 none
+Compress list:
+    zstd zlibx zlib none
+Daemon auth list:
+    sha512 sha256 sha1 md5 md4
+
+rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
+are welcome to redistribute it under certain conditions.  See the GNU
+General Public Licence for details.
+
+rsync is a file transfer program capable of efficient remote update
+via a fast differencing algorithm.
+
+Usage: rsync [OPTION]... SRC [SRC]... DEST
+  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST:DEST
+  or   rsync [OPTION]... SRC [SRC]... [USER@]HOST::DEST
+  or   rsync [OPTION]... SRC [SRC]... rsync://[USER@]HOST[:PORT]/DEST
+  or   rsync [OPTION]... [USER@]HOST:SRC [DEST]
+  or   rsync [OPTION]... [USER@]HOST::SRC [DEST]
+  or   rsync [OPTION]... rsync://[USER@]HOST[:PORT]/SRC [DEST]
+The ':' usages connect via remote shell, while '::' & 'rsync://' usages connect
+to an rsync daemon, and require SRC or DEST to start with a module name.
+
+Options
+--verbose, -v            increase verbosity
+--info=FLAGS             fine-grained informational verbosity
+--debug=FLAGS            fine-grained debug verbosity
+--stderr=e|a|c           change stderr output mode (default: errors)
+--quiet, -q              suppress non-error messages
+--no-motd                suppress daemon-mode MOTD
+--checksum, -c           skip based on checksum, not mod-time & size
+--archive, -a            archive mode is -rlptgoD (no -A,-X,-U,-N,-H)
+--no-OPTION              turn off an implied OPTION (e.g. --no-D)
+--recursive, -r          recurse into directories
+--relative, -R           use relative path names
+--no-implied-dirs        don't send implied dirs with --relative
+--backup, -b             make backups (see --suffix & --backup-dir)
+--backup-dir=DIR         make backups into hierarchy based in DIR
+--suffix=SUFFIX          backup suffix (default ~ w/o --backup-dir)
+--update, -u             skip files that are newer on the receiver
+--inplace                update destination files in-place
+--append                 append data onto shorter files
+--append-verify          --append w/old data in file checksum
+--dirs, -d               transfer directories without recursing
+--old-dirs, --old-d      works like --dirs when talking to old rsync
+--mkpath                 create destination's missing path components
+--links, -l              copy symlinks as symlinks
+--copy-links, -L         transform symlink into referent file/dir
+--copy-unsafe-links      only "unsafe" symlinks are transformed
+--safe-links             ignore symlinks that point outside the tree
+--munge-links            munge symlinks to make them safe & unusable
+--copy-dirlinks, -k      transform symlink to dir into referent dir
+--keep-dirlinks, -K      treat symlinked dir on receiver as dir
+--hard-links, -H         preserve hard links
+--perms, -p              preserve permissions
+--executability, -E      preserve executability
+--chmod=CHMOD            affect file and/or directory permissions
+--acls, -A               preserve ACLs (implies --perms)
+--xattrs, -X             preserve extended attributes
+--owner, -o              preserve owner (super-user only)
+--group, -g              preserve group
+--devices                preserve device files (super-user only)
+--copy-devices           copy device contents as a regular file
+--write-devices          write to devices as files (implies --inplace)
+--specials               preserve special files
+-D                       same as --devices --specials
+--times, -t              preserve modification times
+--atimes, -U             preserve access (use) times
+--open-noatime           avoid changing the atime on opened files
+--crtimes, -N            preserve create times (newness)
+--omit-dir-times, -O     omit directories from --times
+--omit-link-times, -J    omit symlinks from --times
+--super                  receiver attempts super-user activities
+--fake-super             store/recover privileged attrs using xattrs
+--sparse, -S             turn sequences of nulls into sparse blocks
+--preallocate            allocate dest files before writing them
+--dry-run, -n            perform a trial run with no changes made
+--whole-file, -W         copy files whole (w/o delta-xfer algorithm)
+--checksum-choice=STR    choose the checksum algorithm (aka --cc)
+--one-file-system, -x    don't cross filesystem boundaries
+--block-size=SIZE, -B    force a fixed checksum block-size
+--rsh=COMMAND, -e        specify the remote shell to use
+--rsync-path=PROGRAM     specify the rsync to run on remote machine
+--existing               skip creating new files on receiver
+--ignore-existing        skip updating files that exist on receiver
+--remove-source-files    sender removes synchronized files (non-dir)
+--del                    an alias for --delete-during
+--delete                 delete extraneous files from dest dirs
+--delete-before          receiver deletes before xfer, not during
+--delete-during          receiver deletes during the transfer
+--delete-delay           find deletions during, delete after
+--delete-after           receiver deletes after transfer, not during
+--delete-excluded        also delete excluded files from dest dirs
+--ignore-missing-args    ignore missing source args without error
+--delete-missing-args    delete missing source args from destination
+--ignore-errors          delete even if there are I/O errors
+--force                  force deletion of dirs even if not empty
+--max-delete=NUM         don't delete more than NUM files
+--max-size=SIZE          don't transfer any file larger than SIZE
+--min-size=SIZE          don't transfer any file smaller than SIZE
+--max-alloc=SIZE         change a limit relating to memory alloc
+--partial                keep partially transferred files
+--partial-dir=DIR        put a partially transferred file into DIR
+--delay-updates          put all updated files into place at end
+--prune-empty-dirs, -m   prune empty directory chains from file-list
+--numeric-ids            don't map uid/gid values by user/group name
+--usermap=STRING         custom username mapping
+--groupmap=STRING        custom groupname mapping
+--chown=USER:GROUP       simple username/groupname mapping
+--timeout=SECONDS        set I/O timeout in seconds
+--contimeout=SECONDS     set daemon connection timeout in seconds
+--ignore-times, -I       don't skip files that match size and time
+--size-only              skip files that match in size
+--modify-window=NUM, -@  set the accuracy for mod-time comparisons
+--temp-dir=DIR, -T       create temporary files in directory DIR
+--fuzzy, -y              find similar file for basis if no dest file
+--compare-dest=DIR       also compare destination files relative to DIR
+--copy-dest=DIR          ... and include copies of unchanged files
+--link-dest=DIR          hardlink to files in DIR when unchanged
+--compress, -z           compress file data during the transfer
+--compress-choice=STR    choose the compression algorithm (aka --zc)
+--compress-level=NUM     explicitly set compression level (aka --zl)
+--skip-compress=LIST     skip compressing files with suffix in LIST
+--cvs-exclude, -C        auto-ignore files in the same way CVS does
+--filter=RULE, -f        add a file-filtering RULE
+-F                       same as --filter='dir-merge /.rsync-filter'
+                         repeated: --filter='- .rsync-filter'
+--exclude=PATTERN        exclude files matching PATTERN
+--exclude-from=FILE      read exclude patterns from FILE
+--include=PATTERN        don't exclude files matching PATTERN
+--include-from=FILE      read include patterns from FILE
+--files-from=FILE        read list of source-file names from FILE
+--from0, -0              all *-from/filter files are delimited by 0s
+--old-args               disable the modern arg-protection idiom
+--secluded-args, -s      use the protocol to safely send the args
+--trust-sender           trust the remote sender's file list
+--copy-as=USER[:GROUP]   specify user & optional group for the copy
+--address=ADDRESS        bind address for outgoing socket to daemon
+--port=PORT              specify double-colon alternate port number
+--sockopts=OPTIONS       specify custom TCP options
+--blocking-io            use blocking I/O for the remote shell
+--outbuf=N|L|B           set out buffering to None, Line, or Block
+--stats                  give some file-transfer stats
+--8-bit-output, -8       leave high-bit chars unescaped in output
+--human-readable, -h     output numbers in a human-readable format
+--progress               show progress during transfer
+-P                       same as --partial --progress
+--itemize-changes, -i    output a change-summary for all updates
+--remote-option=OPT, -M  send OPTION to the remote side only
+--out-format=FORMAT      output updates using the specified FORMAT
+--log-file=FILE          log what we're doing to the specified FILE
+--log-file-format=FMT    log updates using the specified FMT
+--password-file=FILE     read daemon-access password from FILE
+--early-input=FILE       use FILE for daemon's early exec input
+--list-only              list the files instead of copying them
+--bwlimit=RATE           limit socket I/O bandwidth
+--stop-after=MINS        Stop rsync after MINS minutes have elapsed
+--stop-at=y-m-dTh:m      Stop rsync at the specified point in time
+--fsync                  fsync every written file
+--write-batch=FILE       write a batched update to FILE
+--only-write-batch=FILE  like --write-batch but w/o updating dest
+--read-batch=FILE        read a batched update from FILE
+--protocol=NUM           force an older protocol version to be used
+--iconv=CONVERT_SPEC     request charset conversion of filenames
+--checksum-seed=NUM      set block/file checksum seed (advanced)
+--ipv4, -4               prefer IPv4
+--ipv6, -6               prefer IPv6
+--version, -V            print the version + other info and exit
+--help, -h (*)           show this help (* -h is help only on its own)
+
+Use "rsync --daemon --help" to see the daemon-mode command-line options.
+Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
+See https://rsync.samba.org/ for updates, bug reports, and answers
+
+Use "rsync --daemon --help" to see the daemon-mode command-line options.
+Please see the rsync(1) and rsyncd.conf(5) manpages for full documentation.
+For project updates and documentation, visit https://github.com/oferchen/oc-rsync.
+

--- a/tests/help_output.rs
+++ b/tests/help_output.rs
@@ -27,21 +27,20 @@ fn dump_help_body_lists_unique_options() {
     }
 }
 #[test]
-fn help_matches_snapshot() {
+fn help_output_matches_golden() {
     let output = Command::cargo_bin("oc-rsync")
         .unwrap()
         .env("COLUMNS", "80")
         .env("LC_ALL", "C")
         .env("LANG", "C")
-        .arg("--dump-help-body")
+        .arg("--help")
         .assert()
         .success()
         .get_output()
         .clone();
 
-    let actual = output.stdout;
     let expected = fs::read("tests/golden/help/oc-rsync.help").unwrap();
-    assert_eq!(actual, expected, "help output does not match snapshot");
+    assert_eq!(output.stdout, expected, "`--help` output mismatch");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- snapshot `oc-rsync --help` and test against golden file
- replace dump-help-body snapshot test with full help output test

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` (fails: method `into_temp_path` not found for `tempfile::TempDir`)
- `make verify-comments`
- `make lint` (fails: method `into_temp_path` not found for `tempfile::TempDir`)
- `cargo nextest run --workspace --no-fail-fast --all-features` (fails: no such command `nextest`)


------
https://chatgpt.com/codex/tasks/task_e_68bb394771748323ac539f344a3ec8eb