### PR TITLE
Harden systemd unit and align directories

### DIFF
--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -10,10 +10,10 @@ Type=notify
 NotifyAccess=main
 User=ocrsync
 Group=ocrsync
-RuntimeDirectory=oc-rsyncd
-LogsDirectory=oc-rsyncd
-StateDirectory=oc-rsyncd
-ConfigurationDirectory=oc-rsyncd
+RuntimeDirectory=oc-rsync
+LogsDirectory=oc-rsync
+StateDirectory=oc-rsync
+ConfigurationDirectory=oc-rsync
 ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf
 # To run the daemon via the dedicated oc-rsyncd binary instead of the main oc-rsync CLI,
 # create a drop-in with the following lines:
@@ -27,6 +27,15 @@ ProtectHome=true
 CapabilityBoundingSet=CAP_DAC_READ_SEARCH CAP_FOWNER CAP_CHOWN CAP_DAC_OVERRIDE
 AmbientCapabilities=CAP_DAC_READ_SEARCH CAP_FOWNER CAP_CHOWN CAP_DAC_OVERRIDE
 RestrictNamespaces=yes
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+PrivateDevices=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add sandboxing directives (PrivateTmp, kernel protection, AF restriction, syscalls)
- use `oc-rsync` for Runtime/Logs/State/Configuration directories

## Testing
- `systemd-analyze verify packaging/systemd/oc-rsyncd.service` *(fails: Command /usr/bin/oc-rsync is not executable: No such file or directory)*
- `make verify-comments`
- `make lint` *(fails: could not compile `engine`)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: could not compile `engine`)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: could not compile `engine`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb394db7188323924ecc865a2bbffa