### PR TITLE
chore: adopt Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "oc-rsync"
 version = "0.1.0"
 description = "Pure-Rust reimplementation of rsync (protocol v32)"
 license = "Apache-2.0 OR MIT"
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -27,25 +27,23 @@ fn main() {
                 Err(_) => {
                     let mut lib_dir: Option<PathBuf> = None;
 
-                    if let Ok(output) = Command::new("ldconfig").arg("-p").output() {
-                        if output.status.success() {
-                            let stdout = String::from_utf8_lossy(&output.stdout);
-                            for line in stdout.lines() {
-                                if line.contains("libacl.so") {
-                                    if let Some(path) = line.split("=>").nth(1) {
-                                        let path = path.trim();
-                                        if let Some(dir) = Path::new(path).parent() {
-                                            lib_dir = Some(dir.to_path_buf());
-                                            break;
-                                        }
-                                    }
-                                }
+                    if let Ok(output) = Command::new("ldconfig").arg("-p").output()
+                        && output.status.success()
+                    {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        for line in stdout.lines() {
+                            if line.contains("libacl.so")
+                                && let Some(path) = line.split("=>").nth(1)
+                                && let Some(dir) = Path::new(path.trim()).parent()
+                            {
+                                lib_dir = Some(dir.to_path_buf());
+                                break;
                             }
                         }
                     }
 
-                    if lib_dir.is_none() {
-                        if let Ok(output) = Command::new("find")
+                    if lib_dir.is_none()
+                        && let Ok(output) = Command::new("find")
                             .args([
                                 "/usr/lib",
                                 "/usr/lib64",
@@ -59,15 +57,13 @@ fn main() {
                             .arg("-print")
                             .arg("-quit")
                             .output()
+                        && output.status.success()
+                    {
+                        let stdout = String::from_utf8_lossy(&output.stdout);
+                        if let Some(path) = stdout.lines().next()
+                            && let Some(dir) = Path::new(path.trim()).parent()
                         {
-                            if output.status.success() {
-                                let stdout = String::from_utf8_lossy(&output.stdout);
-                                if let Some(path) = stdout.lines().next() {
-                                    if let Some(dir) = Path::new(path.trim()).parent() {
-                                        lib_dir = Some(dir.to_path_buf());
-                                    }
-                                }
-                            }
+                            lib_dir = Some(dir.to_path_buf());
                         }
                     }
 

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -137,12 +137,18 @@ mod tests {
     #[test]
     #[serial]
     fn env_or_option_respects_precedence() {
-        std::env::remove_var("BUILD_REVISION");
+        unsafe {
+            std::env::remove_var("BUILD_REVISION");
+        }
         assert_eq!(env_or_option("BUILD_REVISION"), Some("unknown".to_string()));
 
-        std::env::set_var("BUILD_REVISION", "runtime");
+        unsafe {
+            std::env::set_var("BUILD_REVISION", "runtime");
+        }
         assert_eq!(env_or_option("BUILD_REVISION"), Some("runtime".to_string()));
-        std::env::remove_var("BUILD_REVISION");
+        unsafe {
+            std::env::remove_var("BUILD_REVISION");
+        }
 
         assert_eq!(env_or_option("NON_EXISTENT_KEY"), None);
     }
@@ -150,7 +156,9 @@ mod tests {
     #[test]
     #[serial]
     fn program_name_defaults_when_unset() {
-        std::env::remove_var("OC_RSYNC_BRAND_NAME");
+        unsafe {
+            std::env::remove_var("OC_RSYNC_BRAND_NAME");
+        }
         if option_env!("OC_RSYNC_BRAND_NAME").is_none() {
             assert_eq!(program_name(), "oc-rsync");
         }

--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -375,12 +375,18 @@ pub fn render_help(cmd: &Command) -> String {
 
 pub fn dump_help_body(cmd: &Command) -> String {
     let prev = std::env::var("COLUMNS").ok();
-    std::env::set_var("COLUMNS", "80");
+    unsafe {
+        std::env::set_var("COLUMNS", "80");
+    }
     let help = render_help(cmd);
     if let Some(v) = prev {
-        std::env::set_var("COLUMNS", v);
+        unsafe {
+            std::env::set_var("COLUMNS", v);
+        }
     } else {
-        std::env::remove_var("COLUMNS");
+        unsafe {
+            std::env::remove_var("COLUMNS");
+        }
     }
     let mut out = String::new();
     let mut in_options = false;

--- a/crates/cli/tests/branding.rs
+++ b/crates/cli/tests/branding.rs
@@ -5,38 +5,50 @@ use serial_test::serial;
 #[test]
 #[serial]
 fn help_uses_program_name() {
-    std::env::set_var("OC_RSYNC_BRAND_NAME", "myrsync");
-    std::env::set_var("COLUMNS", "80");
+    unsafe {
+        std::env::set_var("OC_RSYNC_BRAND_NAME", "myrsync");
+        std::env::set_var("COLUMNS", "80");
+    }
     let version = branding::brand_version();
     let help = render_help(&cli_command());
     let first = help.lines().next().unwrap();
     assert_eq!(first, format!("myrsync {}", version));
-    std::env::remove_var("OC_RSYNC_BRAND_NAME");
-    std::env::remove_var("COLUMNS");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_BRAND_NAME");
+        std::env::remove_var("COLUMNS");
+    }
 }
 
 #[test]
 #[serial]
 fn upstream_name_does_not_replace_rsyncd_conf() {
-    std::env::set_var("OC_RSYNC_UPSTREAM_NAME", "ursync");
-    std::env::set_var("COLUMNS", "80");
+    unsafe {
+        std::env::set_var("OC_RSYNC_UPSTREAM_NAME", "ursync");
+        std::env::set_var("COLUMNS", "80");
+    }
     let help = render_help(&cli_command());
     assert!(help.contains("rsyncd.conf"));
     assert!(!help.contains("ursyncd.conf"));
-    std::env::remove_var("OC_RSYNC_UPSTREAM_NAME");
-    std::env::remove_var("COLUMNS");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_UPSTREAM_NAME");
+        std::env::remove_var("COLUMNS");
+    }
 }
 
 #[test]
 #[serial]
 fn upstream_name_only_replaces_standalone_rsync() {
-    std::env::set_var("OC_RSYNC_UPSTREAM_NAME", "ursync");
-    std::env::set_var(
-        "OC_RSYNC_HELP_HEADER",
-        "rsync rsyncs /path/rsync/bin rsync://host\n",
-    );
-    std::env::set_var("OC_RSYNC_HELP_FOOTER", "");
-    std::env::set_var("COLUMNS", "120");
+    unsafe {
+        std::env::set_var("OC_RSYNC_UPSTREAM_NAME", "ursync");
+        std::env::set_var(
+            "OC_RSYNC_HELP_HEADER",
+            "rsync rsyncs /path/rsync/bin rsync://host\n",
+        );
+    }
+    unsafe {
+        std::env::set_var("OC_RSYNC_HELP_FOOTER", "");
+        std::env::set_var("COLUMNS", "120");
+    }
 
     let help = render_help(&cli_command());
 
@@ -45,8 +57,10 @@ fn upstream_name_only_replaces_standalone_rsync() {
     assert!(!help.contains("/path/ursync/bin"));
     assert!(!help.contains("ursync://host"));
 
-    std::env::remove_var("OC_RSYNC_UPSTREAM_NAME");
-    std::env::remove_var("OC_RSYNC_HELP_HEADER");
-    std::env::remove_var("OC_RSYNC_HELP_FOOTER");
-    std::env::remove_var("COLUMNS");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_UPSTREAM_NAME");
+        std::env::remove_var("OC_RSYNC_HELP_HEADER");
+        std::env::remove_var("OC_RSYNC_HELP_FOOTER");
+        std::env::remove_var("COLUMNS");
+    }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1465,13 +1465,14 @@ impl Receiver {
                 auto_tmp = true;
                 dest_parent
             };
+            #[allow(deprecated)]
             let dir_path = Builder::new()
                 .prefix(".oc-rsync-tmp.")
                 .rand_bytes(6)
                 .tempdir_in(tmp_parent)
                 .map_err(|e| io_context(tmp_parent, e))?
-                .into_temp_path()
-                .keep();
+                .into_path();
+            dir_path
         } else if (self.opts.partial || self.opts.append || self.opts.append_verify)
             && existing_partial.is_some()
         {
@@ -1487,12 +1488,13 @@ impl Receiver {
             && !self.opts.write_devices
         {
             auto_tmp = true;
+            #[allow(deprecated)]
             let dir_path = Builder::new()
                 .prefix(".oc-rsync-tmp.")
                 .rand_bytes(6)
                 .tempdir_in(dest_parent)
                 .map_err(|e| io_context(dest_parent, e))?
-                .keep();
+                .into_path();
             tmp_dest = dir_path.join("tmp");
         }
         let mut needs_rename = !self.opts.inplace
@@ -1502,12 +1504,13 @@ impl Receiver {
                 || auto_tmp);
         if self.opts.delay_updates && !self.opts.inplace && !self.opts.write_devices {
             if tmp_dest == dest {
+                #[allow(deprecated)]
                 let dir_path = Builder::new()
                     .prefix(".oc-rsync-tmp.")
                     .rand_bytes(6)
                     .tempdir_in(dest_parent)
                     .map_err(|e| io_context(dest_parent, e))?
-                    .keep();
+                    .into_path();
                 tmp_dest = dir_path.join("tmp");
             }
             needs_rename = true;

--- a/crates/logging/tests/formatter.rs
+++ b/crates/logging/tests/formatter.rs
@@ -29,7 +29,9 @@ impl<'a> fmt::writer::MakeWriter<'a> for VecWriter {
 
 #[test]
 fn respects_columns_env_var() {
-    std::env::set_var("COLUMNS", "40");
+    unsafe {
+        std::env::set_var("COLUMNS", "40");
+    }
     let writer = VecWriter::default();
     let layer = fmt::layer()
         .with_target(false)
@@ -45,5 +47,7 @@ fn respects_columns_env_var() {
     let out = String::from_utf8(writer.0.lock().unwrap().clone()).unwrap();
     let expected = include_str!("../../../tests/golden/logging/wrap_40.txt");
     assert_eq!(out, expected);
-    std::env::remove_var("COLUMNS");
+    unsafe {
+        std::env::remove_var("COLUMNS");
+    }
 }

--- a/crates/logging/tests/journald.rs
+++ b/crates/logging/tests/journald.rs
@@ -11,7 +11,9 @@ fn journald_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path);
+    unsafe {
+        std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path);
+    }
     let cfg = SubscriberConfig::builder()
         .format(LogFormat::Text)
         .verbose(1)
@@ -31,5 +33,7 @@ fn journald_emits_message() {
     let msg = std::str::from_utf8(&buf[..n]).unwrap();
     let expected = "PRIORITY=6\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=hi\n";
     assert_eq!(msg, expected);
-    std::env::remove_var("OC_RSYNC_JOURNALD_PATH");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_JOURNALD_PATH");
+    }
 }

--- a/crates/logging/tests/syslog.rs
+++ b/crates/logging/tests/syslog.rs
@@ -11,7 +11,9 @@ fn syslog_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path);
+    unsafe {
+        std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path);
+    }
     let cfg = SubscriberConfig::builder()
         .format(LogFormat::Text)
         .verbose(1)
@@ -31,5 +33,7 @@ fn syslog_emits_message() {
     let msg = std::str::from_utf8(&buf[..n]).unwrap();
     let expected = format!("<14>rsync[{}]: hello", std::process::id());
     assert_eq!(msg, expected);
-    std::env::remove_var("OC_RSYNC_SYSLOG_PATH");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_SYSLOG_PATH");
+    }
 }

--- a/src/bin/oc-rsync/main.rs
+++ b/src/bin/oc-rsync/main.rs
@@ -2,7 +2,7 @@
 mod stdio;
 
 use oc_rsync_cli::options::OutBuf;
-use oc_rsync_cli::{cli_command, EngineError};
+use oc_rsync_cli::{EngineError, cli_command};
 use protocol::ExitCode;
 use std::io::ErrorKind;
 
@@ -44,11 +44,11 @@ fn main() {
         print!("{}", oc_rsync_cli::dump_help_body(&cmd));
         return;
     }
-    if let Some(mode) = matches.get_one::<OutBuf>("outbuf") {
-        if let Err(err) = stdio::set_std_buffering(*mode) {
-            eprintln!("failed to set stdio buffers: {err}");
-            std::process::exit(u8::from(ExitCode::FileIo) as i32);
-        }
+    if let Some(mode) = matches.get_one::<OutBuf>("outbuf")
+        && let Err(err) = stdio::set_std_buffering(*mode)
+    {
+        eprintln!("failed to set stdio buffers: {err}");
+        std::process::exit(u8::from(ExitCode::FileIo) as i32);
     }
     if let Err(e) = oc_rsync_cli::run(&matches) {
         eprintln!("{e}");

--- a/src/bin/oc-rsync/stdio.rs
+++ b/src/bin/oc-rsync/stdio.rs
@@ -4,7 +4,7 @@ use std::io::{self, ErrorKind};
 use std::ptr::{self, NonNull};
 
 #[cfg(not(target_os = "windows"))]
-extern "C" {
+unsafe extern "C" {
     #[cfg_attr(target_os = "macos", link_name = "__stdoutp")]
     static mut stdout: *mut libc::FILE;
     #[cfg_attr(target_os = "macos", link_name = "__stderrp")]

--- a/tests/bin_branding.rs
+++ b/tests/bin_branding.rs
@@ -4,7 +4,9 @@ use predicates::str::contains;
 
 #[test]
 fn errors_use_program_name() {
-    std::env::set_var("OC_RSYNC_BRAND_NAME", "myrsync");
+    unsafe {
+        std::env::set_var("OC_RSYNC_BRAND_NAME", "myrsync");
+    }
     Command::cargo_bin("oc-rsync")
         .unwrap()
         .arg("--bogus")
@@ -12,7 +14,9 @@ fn errors_use_program_name() {
         .failure()
         .stderr(contains("myrsync:"))
         .stderr(contains("myrsync error:"));
-    std::env::remove_var("OC_RSYNC_BRAND_NAME");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_BRAND_NAME");
+    }
 }
 
 #[test]

--- a/tests/daemon_config.rs
+++ b/tests/daemon_config.rs
@@ -1,7 +1,7 @@
 // tests/daemon_config.rs
 
 use assert_cmd::prelude::*;
-use assert_cmd::{cargo::cargo_bin, Command};
+use assert_cmd::{Command, cargo::cargo_bin};
 use daemon::{load_config, parse_config};
 use protocol::LATEST_VERSION;
 use serial_test::serial;
@@ -399,13 +399,19 @@ fn load_config_default_path() {
     fs::write(&cfg_path, "port = 873\n").unwrap();
     let var = "OC_RSYNC_CONFIG_PATH";
     let prev = std::env::var(var).ok();
-    std::env::set_var(var, &cfg_path);
+    unsafe {
+        std::env::set_var(var, &cfg_path);
+    }
     let cfg = load_config(None).unwrap();
     assert_eq!(cfg.port, Some(873));
     if let Some(v) = prev {
-        std::env::set_var(var, v);
+        unsafe {
+            std::env::set_var(var, v);
+        }
     } else {
-        std::env::remove_var(var);
+        unsafe {
+            std::env::remove_var(var);
+        }
     }
 }
 

--- a/tests/daemon_journald.rs
+++ b/tests/daemon_journald.rs
@@ -11,7 +11,9 @@ fn daemon_journald_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path);
+    unsafe {
+        std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path);
+    }
     init_logging(None, None, false, true, false);
     warn!(target: "test", "daemon journald");
     let mut buf = [0u8; 256];
@@ -19,5 +21,7 @@ fn daemon_journald_emits_message() {
     let msg = std::str::from_utf8(&buf[..n]).unwrap();
     let expected = "PRIORITY=4\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=daemon journald\n";
     assert_eq!(msg, expected);
-    std::env::remove_var("OC_RSYNC_JOURNALD_PATH");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_JOURNALD_PATH");
+    }
 }

--- a/tests/daemon_syslog.rs
+++ b/tests/daemon_syslog.rs
@@ -11,7 +11,9 @@ fn daemon_syslog_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path);
+    unsafe {
+        std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path);
+    }
     init_logging(None, None, true, false, false);
     warn!(target: "test", "daemon syslog");
     let mut buf = [0u8; 256];
@@ -19,5 +21,7 @@ fn daemon_syslog_emits_message() {
     let msg = std::str::from_utf8(&buf[..n]).unwrap();
     let expected = format!("<12>rsync[{}]: daemon syslog", std::process::id());
     assert_eq!(msg, expected);
-    std::env::remove_var("OC_RSYNC_SYSLOG_PATH");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_SYSLOG_PATH");
+    }
 }

--- a/tests/sync_config.rs
+++ b/tests/sync_config.rs
@@ -1,9 +1,9 @@
 // tests/sync_config.rs
 
-use filetime::{set_file_times, FileTime};
-use oc_rsync::{synchronize, synchronize_with_config, SyncConfig};
+use filetime::{FileTime, set_file_times};
+use oc_rsync::{SyncConfig, synchronize, synchronize_with_config};
 use std::{fs, path::Path};
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 
 fn setup_dirs() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
     let dir = tempdir().unwrap();
@@ -55,7 +55,7 @@ fn sync_creates_destination() {
 #[cfg(unix)]
 #[test]
 fn defaults_do_not_preserve_permissions_or_ownership() {
-    use nix::unistd::{chown, Gid, Uid};
+    use nix::unistd::{Gid, Uid, chown};
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
     let (_dir, src_dir, dst_dir) = setup_dirs();
@@ -78,8 +78,8 @@ fn defaults_do_not_preserve_permissions_or_ownership() {
 #[cfg(unix)]
 #[test]
 fn defaults_skip_devices_and_specials() {
-    use nix::unistd::{mkfifo, Uid};
-    use oc_rsync::meta::{makedev, mknod, Mode, SFlag};
+    use nix::unistd::{Uid, mkfifo};
+    use oc_rsync::meta::{Mode, SFlag, makedev, mknod};
     use std::convert::TryInto;
 
     let (_dir, src_dir, dst_dir) = setup_dirs();
@@ -216,7 +216,7 @@ fn sync_preserves_directory_metadata() {
 #[cfg(unix)]
 #[test]
 fn sync_preserves_ownership() {
-    use nix::unistd::{chown, Gid, Uid};
+    use nix::unistd::{Gid, Uid, chown};
     use std::os::unix::fs::MetadataExt;
 
     if !Uid::effective().is_root() {
@@ -296,11 +296,15 @@ fn custom_syslog_and_journald_settings() {
 
     let syslog_path = dir.path().join("syslog.sock");
     let syslog_server = UnixDatagram::bind(&syslog_path).unwrap();
-    std::env::set_var("OC_RSYNC_SYSLOG_PATH", &syslog_path);
+    unsafe {
+        std::env::set_var("OC_RSYNC_SYSLOG_PATH", &syslog_path);
+    }
 
     let journald_path = dir.path().join("journald.sock");
     let journald_server = UnixDatagram::bind(&journald_path).unwrap();
-    std::env::set_var("OC_RSYNC_JOURNALD_PATH", &journald_path);
+    unsafe {
+        std::env::set_var("OC_RSYNC_JOURNALD_PATH", &journald_path);
+    }
 
     let cfg = SyncConfig::builder()
         .verbose(1)
@@ -318,6 +322,8 @@ fn custom_syslog_and_journald_settings() {
     let jour_msg = std::str::from_utf8(&buf[..n]).unwrap();
     assert!(jour_msg.contains("MESSAGE"));
 
-    std::env::remove_var("OC_RSYNC_SYSLOG_PATH");
-    std::env::remove_var("OC_RSYNC_JOURNALD_PATH");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_SYSLOG_PATH");
+        std::env::remove_var("OC_RSYNC_JOURNALD_PATH");
+    }
 }

--- a/tests/timeout.rs
+++ b/tests/timeout.rs
@@ -10,15 +10,15 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use assert_cmd::Command;
-use daemon::{handle_connection, Handler, Module};
+use daemon::{Handler, Module, handle_connection};
 use engine::{EngineError, SyncOptions};
 use oc_rsync_cli::spawn_daemon_session;
 use predicates::str::contains;
-use protocol::{Demux, ExitCode, CAP_CODECS};
+use protocol::{CAP_CODECS, Demux, ExitCode};
 use tempfile::tempdir;
 use transport::{
-    rate_limited, ssh::SshStdioTransport, LocalPipeTransport, TcpTransport, TimeoutTransport,
-    Transport,
+    LocalPipeTransport, TcpTransport, TimeoutTransport, Transport, rate_limited,
+    ssh::SshStdioTransport,
 };
 
 #[test]
@@ -184,7 +184,7 @@ fn daemon_handshake_timeout_message() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     let modules: HashMap<String, Module> = HashMap::new();
-    let handler: Arc<Handler> = Arc::new(|_| Ok(()));
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
     thread::spawn(move || {
         let (stream, _) = listener.accept().unwrap();
         let transport = TcpTransport::from_stream(stream);

--- a/tools/flag_matrix.rs
+++ b/tools/flag_matrix.rs
@@ -52,10 +52,10 @@ fn parse_help(
             .filter(|t| t.starts_with("--"))
             .max_by_key(|t| t.len())
             .cloned();
-        if desc.contains("alias for") {
-            if let Some(idx) = desc.find("--") {
-                canonical = Some(clean_flag(&desc[idx..]));
-            }
+        if desc.contains("alias for")
+            && let Some(idx) = desc.find("--")
+        {
+            canonical = Some(clean_flag(&desc[idx..]));
         }
         let Some(canonical) = canonical else {
             continue;


### PR DESCRIPTION
## Summary
- switch crate to Rust 2024 edition
- collapse nested conditionals and adjust FFI and tempdir handling
- wrap environment variable setters/removers in unsafe blocks

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: tests::sync_skips_outside_paths, append_errors_when_destination_missing, etc.)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(failed: multiple engine tests; run interrupted)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb36349eb08323bcbd1c49d4ff7cba