### PR TITLE
Use into_path for temp dirs

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1468,13 +1468,14 @@ impl Receiver {
                 auto_tmp = true;
                 dest_parent
             };
+            #[allow(deprecated)]
             let dir_path = Builder::new()
                 .prefix(".oc-rsync-tmp.")
                 .rand_bytes(6)
                 .tempdir_in(tmp_parent)
                 .map_err(|e| io_context(tmp_parent, e))?
-                .into_temp_path()
-                .keep();
+                .into_path();
+            dir_path
         } else if (self.opts.partial || self.opts.append || self.opts.append_verify)
             && existing_partial.is_some()
         {
@@ -1490,12 +1491,13 @@ impl Receiver {
             && !self.opts.write_devices
         {
             auto_tmp = true;
+            #[allow(deprecated)]
             let dir_path = Builder::new()
                 .prefix(".oc-rsync-tmp.")
                 .rand_bytes(6)
                 .tempdir_in(dest_parent)
                 .map_err(|e| io_context(dest_parent, e))?
-                .keep();
+                .into_path();
             tmp_dest = dir_path.join("tmp");
         }
         let mut needs_rename = !self.opts.inplace
@@ -1505,12 +1507,13 @@ impl Receiver {
                 || auto_tmp);
         if self.opts.delay_updates && !self.opts.inplace && !self.opts.write_devices {
             if tmp_dest == dest {
+                #[allow(deprecated)]
                 let dir_path = Builder::new()
                     .prefix(".oc-rsync-tmp.")
                     .rand_bytes(6)
                     .tempdir_in(dest_parent)
                     .map_err(|e| io_context(dest_parent, e))?
-                    .keep();
+                    .into_path();
                 tmp_dest = dir_path.join("tmp");
             }
             needs_rename = true;
@@ -3342,7 +3345,7 @@ mod tests {
         let mut stats = Stats::default();
         sender.start();
         for path in [src.join("inside.txt"), outside.clone()] {
-            if let Some(rel) = path.strip_prefix(&src).ok() {
+            if let Ok(rel) = path.strip_prefix(&src) {
                 let dest_path = dst.join(rel);
                 sender
                     .process_file(&path, &dest_path, rel, &mut receiver, &mut stats)
@@ -3446,7 +3449,7 @@ mod tests {
             tmp.write_all(&chunk).unwrap();
         }
         let path = tmp.path().to_path_buf();
-        let mut sender = Sender::new(
+        let sender = Sender::new(
             RSYNC_BLOCK_SIZE,
             Matcher::default(),
             None,

--- a/crates/engine/tests/append.rs
+++ b/crates/engine/tests/append.rs
@@ -14,8 +14,10 @@ fn append_errors_when_destination_missing() {
     fs::create_dir_all(&dst).unwrap();
     fs::write(src.join("file"), b"data").unwrap();
 
-    let mut opts = SyncOptions::default();
-    opts.append = true;
+    let opts = SyncOptions {
+        append: true,
+        ..Default::default()
+    };
     let err = sync(&src, &dst, &Matcher::default(), &available_codecs(), &opts)
         .expect_err("expected error when appending without destination");
     if let EngineError::Io(e) = err {

--- a/crates/engine/tests/update.rs
+++ b/crates/engine/tests/update.rs
@@ -19,8 +19,10 @@ fn update_skips_newer_dest() {
     let dst_time = FileTime::from_unix_time(2_000_000_000, 0);
     set_file_mtime(src.join("file.txt"), src_time).unwrap();
     set_file_mtime(dst.join("file.txt"), dst_time).unwrap();
-    let mut opts = SyncOptions::default();
-    opts.update = true;
+    let opts = SyncOptions {
+        update: true,
+        ..Default::default()
+    };
     sync(&src, &dst, &Matcher::default(), &available_codecs(), &opts).unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"old");
 }
@@ -38,8 +40,10 @@ fn update_replaces_older_dest() {
     let dst_time = FileTime::from_unix_time(1_000_000_000, 0);
     set_file_mtime(src.join("file.txt"), src_time).unwrap();
     set_file_mtime(dst.join("file.txt"), dst_time).unwrap();
-    let mut opts = SyncOptions::default();
-    opts.update = true;
+    let opts = SyncOptions {
+        update: true,
+        ..Default::default()
+    };
     sync(&src, &dst, &Matcher::default(), &available_codecs(), &opts).unwrap();
     assert_eq!(fs::read(dst.join("file.txt")).unwrap(), b"new");
 }
@@ -52,8 +56,10 @@ fn update_skips_new_files() {
     fs::create_dir_all(&src).unwrap();
     fs::create_dir_all(&dst).unwrap();
     fs::write(src.join("new.txt"), b"new").unwrap();
-    let mut opts = SyncOptions::default();
-    opts.update = true;
+    let opts = SyncOptions {
+        update: true,
+        ..Default::default()
+    };
     sync(&src, &dst, &Matcher::default(), &available_codecs(), &opts).unwrap();
     assert!(!dst.join("new.txt").exists());
 }


### PR DESCRIPTION
## Summary
- replace deprecated `into_temp_path().keep()` with `into_path()` for temp directories
- allow deprecated API to silence warnings
- initialize `SyncOptions` inline in tests

## Testing
- `cargo check -p engine`
- `cargo clippy -p engine --lib -- -D warnings`
- `cargo clippy -p engine --all-targets --all-features -- -D warnings` *(fails: clippy lints in tests)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed)*
- `make verify-comments`
- `make lint` *(fails: closure expected to take 2 arguments, but it takes 1 argument)*

------
https://chatgpt.com/codex/tasks/task_e_68bb39114b688323b46bb3bf7a1090cf