### PR TITLE
docs: note partial help parity

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -33,7 +33,7 @@ when available. Do not exceed functionality of upstream at <https://rsync.samba.
 ## Parser Parity
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
-| Comprehensive flag parsing and help text parity | ✅ | [tests/cli.rs](../tests/cli.rs)<br>[tests/help_output.rs](../tests/help_output.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
+| Comprehensive flag parsing and help text parity | Partial | [tests/cli.rs](../tests/cli.rs)<br>[tests/help_output.rs](../tests/help_output.rs)<br>missing `--help` snapshot ([#1274](https://github.com/oferchen/oc-rsync/issues/1274)) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | Composite `--archive` flag expansion | ✅ | [tests/archive.rs](../tests/archive.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | Remote-only option parsing (`--remote-option`) | ✅ | [tests/interop/remote_option.rs](../tests/interop/remote_option.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | `--version` output parity | ✅ | [tests/version_output.rs](../tests/version_output.rs) | [crates/cli/src/version.rs](../crates/cli/src/version.rs) |

--- a/tests/help_output.rs
+++ b/tests/help_output.rs
@@ -113,3 +113,9 @@ fn invalid_numeric_value_matches_snapshot() {
     let expected = fs::read("tests/golden/help/oc-rsync.invalid-timeout.stderr").unwrap();
     assert_eq!(output.stderr, expected, "invalid timeout stderr mismatch");
 }
+
+#[test]
+#[ignore]
+fn help_flag_matches_snapshot() {
+    todo!("snapshot `oc-rsync --help` output (#1274)");
+}


### PR DESCRIPTION
## Summary
- mark comprehensive help parity as partial and note missing `--help` snapshot coverage
- add ignored test placeholder for `oc-rsync --help` snapshot

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: no method named `into_temp_path` for `TempDir`)*
- `make lint` *(fails: no method named `into_temp_path` for `TempDir`)*
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: no method named `into_temp_path` for `TempDir`)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: no method named `into_temp_path` for `TempDir`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb39545e7483238e89fa3317f028eb