### PR TITLE
Use direct temp files for atomic replacements

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -3,6 +3,7 @@
 use nix::unistd::{chown, Gid, Uid};
 use std::any::Any;
 use std::collections::{HashMap, VecDeque};
+use std::ffi::OsStr;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 #[cfg(unix)]
@@ -381,6 +382,18 @@ fn remove_basename_partial(dest: &Path) {
     }
 }
 
+fn temp_file_path(parent: &Path, base: &OsStr) -> Result<PathBuf> {
+    #[allow(deprecated)]
+    let tmp = Builder::new()
+        .prefix(&format!(".{}.", base.to_string_lossy()))
+        .rand_bytes(6)
+        .tempfile_in(parent)
+        .map_err(|e| io_context(parent, e))?;
+    let path = tmp.path().to_path_buf();
+    tmp.close().map_err(|e| io_context(&path, e))?;
+    Ok(path)
+}
+
 struct TempFileGuard {
     path: PathBuf,
 }
@@ -401,15 +414,6 @@ impl Drop for TempFileGuard {
             return;
         }
         let _ = fs::remove_file(&self.path);
-        if let Some(parent) = self.path.parent() {
-            if parent
-                .read_dir()
-                .map(|mut i| i.next().is_none())
-                .unwrap_or(false)
-            {
-                let _ = fs::remove_dir(parent);
-            }
-        }
     }
 }
 
@@ -1468,14 +1472,7 @@ impl Receiver {
                 auto_tmp = true;
                 dest_parent
             };
-            let dir = Builder::new()
-                .prefix(".oc-rsync-tmp.")
-                .rand_bytes(6)
-                .tempdir_in(tmp_parent)
-                .map_err(|e| io_context(tmp_parent, e))?;
-            #[allow(deprecated)]
-            let dir_path = dir.into_path();
-            dir_path
+            temp_file_path(tmp_parent, dest.file_name().unwrap_or_default())?
         } else if (self.opts.partial || self.opts.append || self.opts.append_verify)
             && existing_partial.is_some()
         {
@@ -1491,14 +1488,7 @@ impl Receiver {
             && !self.opts.write_devices
         {
             auto_tmp = true;
-            #[allow(deprecated)]
-            let dir_path = Builder::new()
-                .prefix(".oc-rsync-tmp.")
-                .rand_bytes(6)
-                .tempdir_in(dest_parent)
-                .map_err(|e| io_context(dest_parent, e))?
-                .into_path();
-            tmp_dest = dir_path.join("tmp");
+            tmp_dest = temp_file_path(dest_parent, dest.file_name().unwrap_or_default())?;
         }
         let mut needs_rename = !self.opts.inplace
             && ((self.opts.partial || self.opts.append || self.opts.append_verify)
@@ -1507,14 +1497,7 @@ impl Receiver {
                 || auto_tmp);
         if self.opts.delay_updates && !self.opts.inplace && !self.opts.write_devices {
             if tmp_dest == dest {
-                #[allow(deprecated)]
-                let dir_path = Builder::new()
-                    .prefix(".oc-rsync-tmp.")
-                    .rand_bytes(6)
-                    .tempdir_in(dest_parent)
-                    .map_err(|e| io_context(dest_parent, e))?
-                    .into_path();
-                tmp_dest = dir_path.join("tmp");
+                tmp_dest = temp_file_path(dest_parent, dest.file_name().unwrap_or_default())?;
             }
             needs_rename = true;
         }


### PR DESCRIPTION
## Summary
- generate temporary file paths directly in destination or temp dir
- drop obsolete directory cleanup in TempFileGuard

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: linking with `cc`)*
- `cargo test --test cli temp_files_created_in_temp_dir -- --nocapture` *(fails: linking with `cc`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4a9b09208323bdc9a30d4de6bb47