### PR TITLE
chore: define binary file attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Mark common binary formats as binary and disable Git-LFS filters
+*.bin   -text -filter -diff -merge
+*.exe   -text -filter -diff -merge
+*.dll   -text -filter -diff -merge
+*.so    -text -filter -diff -merge
+*.dylib -text -filter -diff -merge
+*.zip   -text -filter -diff -merge
+*.tar   -text -filter -diff -merge
+*.gz    -text -filter -diff -merge
+*.tgz   -text -filter -diff -merge
+*.bz2   -text -filter -diff -merge
+*.xz    -text -filter -diff -merge
+*.7z    -text -filter -diff -merge
+*.rar   -text -filter -diff -merge
+*.png   -text -filter -diff -merge
+*.jpg   -text -filter -diff -merge
+*.jpeg  -text -filter -diff -merge
+*.gif   -text -filter -diff -merge
+*.bmp   -text -filter -diff -merge
+*.pdf   -text -filter -diff -merge


### PR DESCRIPTION
## Summary
- mark common binary extensions as non-text and disable LFS filters

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: function `temp_file_path` is never used)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint` *(fails: function `temp_file_path` is never used)*

------
https://chatgpt.com/codex/tasks/task_e_68bb52f5fd608323b1a15a05879d6b96