### PR TITLE
chore: expand ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,19 @@
 *.dylib
 /docs/build_info.md
 
+# Packaging and coverage outputs
+/dist/
+/coverage.lcov
+/target/debian/
+/target/release/rpmbuild/
+/*.deb
+/*.ddeb
+/*.build
+/*.changes
+/*.dsc
+/*.rpm
+/*.src.rpm
+
 # Upstream rsync sources
 /rsync-*.tar.gz
 /rsync-*/


### PR DESCRIPTION
## Summary
- ignore dist directories, coverage reports, and packaging outputs

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: /usr/bin/ld: cannot find -lacl: No such file or directory)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: /usr/bin/ld: cannot find -lacl: No such file or directory)*
- `make verify-comments`
- `make lint` *(fails: function `temp_file_path` is never used)*

------
https://chatgpt.com/codex/tasks/task_e_68bb52d941e48323b59ee773ef0c117c