### PR TITLE
Simplify walk tests and fix clippy warnings

### DIFF
--- a/crates/filters/tests/rsync_parity.rs
+++ b/crates/filters/tests/rsync_parity.rs
@@ -20,7 +20,7 @@ fn parity_with_stock_rsync() {
     let rules = parse(": /.rsync-filter\n- .rsync-filter\n", &mut v, 0).unwrap();
     let matcher = Matcher::new(rules).with_root(&root);
 
-    let rsync_included = vec!["keep.log".to_string(), "sub/keep.tmp".to_string()];
+    let rsync_included = ["keep.log".to_string(), "sub/keep.tmp".to_string()];
 
     let files = [
         "a.tmp",

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -485,7 +485,7 @@ mod tests {
         t.send(b"ok").unwrap();
 
         t.last = Instant::now() - dur;
-        let err = t.send(b"fail").err().expect("timeout error");
+        let err = t.send(b"fail").expect_err("timeout error");
         assert_eq!(err.kind(), io::ErrorKind::TimedOut);
     }
 }

--- a/crates/walk/tests/walk.rs
+++ b/crates/walk/tests/walk.rs
@@ -30,19 +30,19 @@ fn walk_includes_files_dirs_and_symlinks() {
             entries.push((path, e.file_type));
         }
     }
-    assert!(entries.iter().any(|(p, t)| p == &root && t.is_dir()));
+    assert!(entries.iter().any(|(p, t)| p == root && t.is_dir()));
     assert!(entries
         .iter()
-        .any(|(p, t)| p == &root.join("dir") && t.is_dir()));
+        .any(|(p, t)| p.as_path() == root.join("dir").as_path() && t.is_dir()));
     assert!(entries
         .iter()
-        .any(|(p, t)| p == &root.join("dir/large.txt") && t.is_file()));
+        .any(|(p, t)| p.as_path() == root.join("dir/large.txt").as_path() && t.is_file()));
     assert!(entries
         .iter()
-        .any(|(p, t)| p == &link_path && t.is_symlink()));
+        .any(|(p, t)| p == link_path.as_path() && t.is_symlink()));
     assert!(entries
         .iter()
-        .any(|(p, t)| p == &root.join("small.txt") && t.is_file()));
+        .any(|(p, t)| p.as_path() == root.join("small.txt").as_path() && t.is_file()));
 }
 
 #[test]
@@ -58,8 +58,7 @@ fn walk_preserves_order_and_bounds_batches() {
 
     let mut paths = Vec::new();
     let mut state = String::new();
-    let mut walker = walk(root, 2, false, false);
-    while let Some(batch) = walker.next() {
+    for batch in walk(root, 2, false, false) {
         let batch = batch.unwrap();
         assert!(batch.len() <= 2);
         for e in batch {
@@ -111,8 +110,7 @@ fn walk_skips_cross_device_entries() {
 
     let mut state = String::new();
     let mut found_pts = false;
-    let mut walker = walk(root, 100, false, false);
-    while let Some(batch) = walker.next() {
+    for batch in walk(root, 100, false, false) {
         let batch = batch.unwrap();
         for e in batch {
             let path = e.apply(&mut state);
@@ -127,9 +125,8 @@ fn walk_skips_cross_device_entries() {
     }
     assert!(found_pts, "expected to see /dev/pts without restriction");
 
-    let mut walker = walk(root, 100, false, true);
     state.clear();
-    while let Some(batch) = walker.next() {
+    for batch in walk(root, 100, false, true) {
         let batch = batch.unwrap();
         for e in batch {
             let path = e.apply(&mut state);


### PR DESCRIPTION
## Summary
- compare `Path` values without extra references in walk tests
- iterate over walker batches using `for` loops
- clean up clippy warnings in tests

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: field assignment outside of initializer in crates/engine/tests/resume.rs)*
- `cargo clippy -p walk --all-targets -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed: cannot find -lacl)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb60cbe6d48323acc94169c360d0a9