### PR TITLE
Restore daemon context between connections

### DIFF
--- a/crates/daemon/tests/sequential_connections.rs
+++ b/crates/daemon/tests/sequential_connections.rs
@@ -1,0 +1,61 @@
+// crates/daemon/tests/sequential_connections.rs
+use daemon::{handle_connection, Handler, Module};
+#[cfg(unix)]
+use nix::unistd::geteuid;
+use protocol::SUPPORTED_PROTOCOLS;
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::sync::Arc;
+use tempfile::tempdir;
+use transport::LocalPipeTransport;
+
+#[test]
+fn handle_sequential_chrooted_connections() {
+    #[cfg(unix)]
+    if geteuid().as_raw() != 0 {
+        eprintln!("skipping handle_sequential_chrooted_connections: requires root");
+        return;
+    }
+    let dir = tempdir().unwrap();
+    let mut module = Module::default();
+    module.name = "data".to_string();
+    module.path = dir.path().to_path_buf();
+    module.uid = Some(1);
+    module.gid = Some(1);
+    module.use_chroot = true;
+    let mut modules = HashMap::new();
+    modules.insert(module.name.clone(), module);
+    let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
+    let cwd = std::env::current_dir().unwrap();
+    for _ in 0..3 {
+        let mut input = Vec::new();
+        input.extend_from_slice(&SUPPORTED_PROTOCOLS[0].to_be_bytes());
+        input.extend_from_slice(b"\n");
+        input.extend_from_slice(b"data\n");
+        input.extend_from_slice(b"\n");
+        let reader = Cursor::new(input);
+        let writer = Cursor::new(Vec::new());
+        let mut transport = LocalPipeTransport::new(reader, writer);
+        handle_connection(
+            &mut transport,
+            &modules,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            &[],
+            "127.0.0.1",
+            0,
+            0,
+            &handler,
+            None,
+        )
+        .expect("connection should succeed");
+        let (_, writer) = transport.into_inner();
+        let out = writer.into_inner();
+        assert_eq!(&out[4..], b"@RSYNCD: OK\n@RSYNCD: OK\n@RSYNCD: EXIT\n",);
+        assert_eq!(std::env::current_dir().unwrap(), cwd);
+    }
+}

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -155,7 +155,7 @@ fn chroot_drops_privileges() {
             assert!(matches!(status, nix::sys::wait::WaitStatus::Exited(_, 0)));
         }
         Ok(ForkResult::Child) => {
-            chroot_and_drop_privileges(dir.path(), 1, 1, true).unwrap();
+            let _ctx = chroot_and_drop_privileges(dir.path(), 1, 1, true).unwrap();
             assert_eq!(std::env::current_dir().unwrap(), PathBuf::from("/"));
             assert_eq!(geteuid().as_raw(), 1);
             assert_eq!(getegid().as_raw(), 1);
@@ -184,7 +184,9 @@ fn chroot_requires_root() {
         }
         Ok(ForkResult::Child) => {
             drop_privileges(1, 1).unwrap();
-            let err = chroot_and_drop_privileges(dir.path(), 1, 1, true).unwrap_err();
+            let err = chroot_and_drop_privileges(dir.path(), 1, 1, true)
+                .err()
+                .unwrap();
             assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
             std::process::exit(0);
         }
@@ -197,7 +199,9 @@ fn chroot_requires_root() {
 #[serial]
 fn chroot_and_drop_privileges_rejects_missing_dir() {
     let missing = Path::new("/does/not/exist");
-    let err = chroot_and_drop_privileges(missing, 0, 0, true).unwrap_err();
+    let err = chroot_and_drop_privileges(missing, 0, 0, true)
+        .err()
+        .unwrap();
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
 }
 


### PR DESCRIPTION
## Summary
- ensure daemon restores working directory and privileges after serving a module
- test sequential chrooted connections succeed

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command)*
- `cargo test --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb60a80d4c8323b6640c6fc25af4c5