### PR TITLE
Use TempDir for remote hard link daemon test

### DIFF
--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -2048,13 +2048,12 @@ fn daemon_preserves_hard_links_remote_source() {
     ] {
         let dst = tempdir().unwrap();
         let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
+        cmd.current_dir(dst.path());
         cmd.arg("-aH");
         if spec.starts_with("127.0.0.1::") {
             cmd.args(["--port", &port.to_string()]);
         }
-        cmd.args([&spec, dst.path().to_str().unwrap()])
-            .assert()
-            .success();
+        cmd.args([&spec, "."]).assert().success();
         let ino1 = fs::metadata(dst.path().join("a")).unwrap().ino();
         let ino2 = fs::metadata(dst.path().join("b")).unwrap().ino();
         assert_eq!(ino1, ino2);


### PR DESCRIPTION
## Summary
- Ensure daemon hard-link test runs with temporary working directory
- Keep remote module setup based on runtime temp paths

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot borrow `dacl` as mutable)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: cannot borrow `dacl` as mutable)*

------
https://chatgpt.com/codex/tasks/task_e_68bb605232fc8323a2405b9e1b4f5b64