### PR TITLE
docs: document cargo-nextest installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,14 +83,12 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
+        run: cargo install cargo-nextest --locked
 
       - name: Run tests
-        run: cargo nextest run --no-fail-fast
+        run: cargo nextest run --workspace --no-fail-fast
       - name: Test with coverage (95% lines & functions)
-        run: cargo llvm-cov nextest --fail-under-lines 95 --fail-under-functions 95 --html -- --no-fail-fast
+        run: cargo llvm-cov nextest --workspace --fail-under-lines 95 --fail-under-functions 95 --html -- --no-fail-fast
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5

--- a/.github/workflows/daily-status.yml
+++ b/.github/workflows/daily-status.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
       - run: cargo install cargo-llvm-cov
-      - run: cargo install cargo-nextest
+      - run: cargo install cargo-nextest --locked
       - run: mkdir -p reports && cargo llvm-cov nextest --workspace --json --summary-only --output-path reports/coverage.json -- --no-fail-fast
       - run: cargo run --package xtask --bin status
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,9 @@ jobs:
         with:
           tool: cargo-llvm-cov
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
+        run: cargo install cargo-nextest --locked
       - name: Test with coverage
-        run: cargo llvm-cov nextest --all-features --fail-under-lines 95 -- --no-fail-fast
+        run: cargo llvm-cov nextest --workspace --all-features --fail-under-lines 95 -- --no-fail-fast
       - name: Validate interop matrix docs
         run: scripts/check-run-matrix-docs.sh
       - name: Cross-compile check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,7 @@ This agent architecture provides a **clean separation of responsibilities** and 
 - Lint with `cargo clippy --all-targets --all-features -- -D warnings`.
 
 ### Mandatory Checks
+- Install `cargo-nextest` with `cargo install cargo-nextest --locked` if it is not already available.
 - Run `cargo nextest run --workspace --no-fail-fast` (and `--all-features`) and ensure all tests pass.
 - Execute `make verify-comments` to validate file header comments.
 - Use `make lint` to confirm formatting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ headers:
 5. A maintainer will review your PR and may request changes.
 
 ## Testing Requirements
-- Install `cargo-nextest` if it's not already installed. Run `./scripts/install-nextest.sh` to verify or install it.
+- Install `cargo-nextest` with `cargo install cargo-nextest --locked` if it's not already installed, or run `./scripts/install-nextest.sh` to verify or install it.
 - Ensure `cargo nextest run --workspace --no-fail-fast` (and `--all-features`) passes locally.
 - Add or update tests for any new code.
 - Prefer small, focused commits that each pass the test suite.

--- a/crates/meta/tests/acl_prune.rs
+++ b/crates/meta/tests/acl_prune.rs
@@ -29,7 +29,7 @@ fn read_prunes_trivial_acls() -> std::io::Result<()> {
 
     let subdir = dir.path().join("d");
     fs::create_dir(&subdir)?;
-    let dacl = PosixACL::new(0o777);
+    let mut dacl = PosixACL::new(0o777);
     dacl.write_default_acl(&subdir).map_err(acl_to_io)?;
     let (_, default_acl) = read_acl(&subdir, false)?;
     assert!(default_acl.is_empty());


### PR DESCRIPTION
## Summary
- document how to install cargo-nextest with `cargo install cargo-nextest --locked`
- ensure CI installs cargo-nextest and runs tests over the workspace
- fix acl_prune test to compile after enabling ACL support

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: 131 failed, slow tests in remote scenarios)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb60d7ee908323a6cf80471d76e4fb