### PR TITLE
Treat rsync scheme as remote

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1480,6 +1480,19 @@ mod tests {
     }
 
     #[test]
+    fn rsync_url_module_specs_are_remote() {
+        let spec = parse_remote_spec(OsStr::new("rsync://host/mod")).unwrap();
+        match spec {
+            RemoteSpec::Remote { host, module, path } => {
+                assert_eq!(host, "host");
+                assert_eq!(module.as_deref(), Some("mod"));
+                assert_eq!(path.path, PathBuf::from("."));
+            }
+            _ => panic!("expected remote spec"),
+        }
+    }
+
+    #[test]
     fn daemon_double_colon_specs_are_remote() {
         let spec = parse_remote_spec(OsStr::new("host::mod/path")).unwrap();
         match spec {

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -328,6 +328,7 @@ pub(crate) fn parse_remote_spec(input: &OsStr) -> Result<RemoteSpec> {
         let mut mp = mod_path.splitn(2, '/');
         let module = mp.next().unwrap_or("");
         let path = mp.next().unwrap_or("");
+        let path = if path.is_empty() { "." } else { path };
         if host.is_empty() {
             return Err(EngineError::Other("remote host missing".into()));
         }


### PR DESCRIPTION
## Summary
- ensure `rsync://` URLs are always classified as remote sources
- add coverage for module-only `rsync://` URLs

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: could not compile `meta` (test "acl_prune"))*
- `cargo nextest run --test daemon --no-fail-fast --all-features daemon_preserves_hard_links_remote_source` *(fails: test run cancelled after >13min)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb603ad360832394f7c1ea8e5d0b8d