### PR TITLE
docs: rename upstream protocols

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ use std::{env, fs, path::Path, path::PathBuf, process::Command};
 use time::OffsetDateTime;
 
 const UPSTREAM_VERSION: &str = "3.4.1";
-const UPSTREAM_PROTOCOLS: &[u32] = &[32, 31, 30];
+const SUPPORTED_PROTOCOLS: &[u32] = &[32, 31, 30];
 const BRANDING_VARS: &[&str] = &[
     "OC_RSYNC_NAME",
     "OC_RSYNC_VERSION",
@@ -77,14 +77,14 @@ fn main() {
         println!("cargo:rustc-cfg=libacl_missing");
     }
 
-    let protocols = UPSTREAM_PROTOCOLS
+    let protocols = SUPPORTED_PROTOCOLS
         .iter()
         .map(|p| p.to_string())
         .collect::<Vec<_>>()
         .join(",");
 
     println!("cargo:rustc-env=UPSTREAM_VERSION={UPSTREAM_VERSION}");
-    println!("cargo:rustc-env=UPSTREAM_PROTOCOLS={protocols}");
+    println!("cargo:rustc-env=SUPPORTED_PROTOCOLS={protocols}");
     println!("cargo:rustc-env=BUILD_REVISION={revision}");
     println!("cargo:rustc-env=OFFICIAL_BUILD={official}");
 

--- a/crates/cli/src/version.rs
+++ b/crates/cli/src/version.rs
@@ -1,15 +1,15 @@
 // crates/cli/src/version.rs
-use protocol::SUPPORTED_PROTOCOLS;
+use protocol::SUPPORTED_PROTOCOLS as SUPPORTED_PROTOCOL_LIST;
 
 use crate::branding;
 
-pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOLS[0];
+pub const RSYNC_PROTOCOL: u32 = SUPPORTED_PROTOCOL_LIST[0];
 
 const UPSTREAM_VERSION: &str = match option_env!("UPSTREAM_VERSION") {
     Some(v) => v,
     None => "unknown",
 };
-const UPSTREAM_PROTOCOLS: &str = match option_env!("UPSTREAM_PROTOCOLS") {
+const SUPPORTED_PROTOCOLS: &str = match option_env!("SUPPORTED_PROTOCOLS") {
     Some(v) => v,
     None => "32,31,30",
 };
@@ -33,7 +33,7 @@ pub fn render_version_lines() -> Vec<String> {
         env!("CARGO_PKG_VERSION"),
         RSYNC_PROTOCOL
     ));
-    let proto = UPSTREAM_PROTOCOLS
+    let proto = SUPPORTED_PROTOCOLS
         .split(',')
         .next()
         .and_then(|s| s.parse::<u32>().ok())

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -12,7 +12,7 @@ fn banner_is_static() {
             SUPPORTED_PROTOCOLS[0],
         ),
         {
-            let proto = option_env!("UPSTREAM_PROTOCOLS")
+            let proto = option_env!("SUPPORTED_PROTOCOLS")
                 .unwrap_or("32,31,30")
                 .split(',')
                 .next()

--- a/docs/UPSTREAM.md
+++ b/docs/UPSTREAM.md
@@ -13,7 +13,7 @@ When connecting to a peer, the highest shared version from this list is selected
 
 ```
 UPSTREAM_VERSION=3.4.1
-UPSTREAM_PROTOCOLS=[32,31,30]
+SUPPORTED_PROTOCOLS=[32,31,30]
 ```
 
-The build scripts for `oc-rsync` and `oc-rsyncd` embed these values into the binaries by exporting them as compile-time environment variables (for example `cargo:rustc-env=UPSTREAM_VERSION=…` and `cargo:rustc-env=UPSTREAM_PROTOCOLS=…`) in `build.rs`.
+The build scripts for `oc-rsync` and `oc-rsyncd` embed these values into the binaries by exporting them as compile-time environment variables (for example `cargo:rustc-env=UPSTREAM_VERSION=…` and `cargo:rustc-env=SUPPORTED_PROTOCOLS=…`) in `build.rs`.


### PR DESCRIPTION
## Summary
- rename `UPSTREAM_PROTOCOLS` to `SUPPORTED_PROTOCOLS` in upstream docs
- align build script and CLI to new `SUPPORTED_PROTOCOLS` env var

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: append_errors_when_destination_missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6dfc06b48323bd5b94a45339c5c2