### PR TITLE
test: compare help with upstream

### DIFF
--- a/tests/interop/help.rs
+++ b/tests/interop/help.rs
@@ -1,0 +1,37 @@
+// tests/interop/help.rs
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use std::process::Command as StdCommand;
+
+fn normalize(bytes: &[u8]) -> &[u8] {
+    let needle = b"rsync comes with ABSOLUTELY NO WARRANTY.";
+    let pos = bytes
+        .windows(needle.len())
+        .position(|w| w == needle)
+        .expect("warranty line not found");
+    &bytes[pos..]
+}
+
+#[test]
+fn help_output_matches_upstream() {
+    let ours = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
+        .arg("--help")
+        .output()
+        .unwrap();
+    assert!(ours.status.success());
+
+    let upstream = StdCommand::new("rsync")
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
+        .arg("--help")
+        .output()
+        .expect("failed to run rsync");
+    assert!(upstream.status.success());
+
+    assert_eq!(normalize(&ours.stdout), normalize(&upstream.stdout));
+}
+


### PR DESCRIPTION
## Summary
- ensure `oc-rsync --help` matches upstream `rsync --help` after removing version banners

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cancelled after >400s with 3 tests still running)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(cancelled during build due to time)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb6e17c5dc8323bfa1d5d18d7be3ff