### PR TITLE
docs: refresh compatibility transcript

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -34,7 +34,7 @@ kept up to date from their results.
 |---------|----------------|
 | 30 | [protocol override test](../crates/cli/src/lib.rs#L1958-L2030) |
 | 31 | [server handshake test](../crates/protocol/tests/server.rs#L1-L80) |
-| 32 | [rsync 3.3.0 transcript](../tests/interop/wire/rsync-3.3.0.log) |
+| 32 | [rsync 3.4.1 transcript](../tests/interop/wire/rsync-3.4.1.log) |
 
 ## Interoperability caveats
 


### PR DESCRIPTION
## Summary
- update compatibility docs to point protocol 32 example at rsync 3.4.1 transcript
- scan document for stale version numbers

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: mismatched closing delimiter in crates/daemon/src/lib.rs:1007)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: mismatched closing delimiter in crates/daemon/src/lib.rs:1007)*
- `make verify-comments`
- `make lint` *(fails: mismatched closing delimiter in crates/daemon/src/lib.rs:1007)*

------
https://chatgpt.com/codex/tasks/task_e_68bb74486eb48323bf9ebd7c8475bae4