### PR TITLE
Detect xattr and ACL support at runtime

### DIFF
--- a/FLAKES.md
+++ b/FLAKES.md
@@ -6,10 +6,6 @@ This file documents tests marked `#[ignore]` and why they remain excluded from a
 | ---- | ------ |
 | `tests/packaging.rs::service_unit_matches_spec` | Service unit packaging checks require systemd packaging context and are not essential for core sync behavior. |
 | `tests/daemon_config.rs::daemon_config_motd_suppression` | MOTD suppression support incomplete. |
-| `tests/daemon_sync_attrs.rs::daemon_preserves_xattrs` | Requires extended attribute support and `libacl` which is unavailable in this environment. |
-| `tests/daemon_sync_attrs.rs::daemon_preserves_xattrs_rr_daemon` | Same as above. |
-| `tests/daemon_sync_attrs.rs::daemon_excludes_filtered_xattrs` | Same as above. |
-| `tests/daemon_sync_attrs.rs::daemon_excludes_filtered_xattrs_rr_client` | Same as above. |
 | `tests/filter_corpus.rs::filter_corpus_parity` | Filter corpus parity with upstream not yet validated. |
 | `tests/filter_corpus.rs::perdir_sign_parity` | Per-directory signing parity pending. |
 | `tests/cli.rs::default_umask_masks_permissions` | Umask handling under review. |

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -13,7 +13,26 @@ use std::thread::sleep;
 use std::time::Duration;
 use tempfile::tempdir;
 
+use meta::{acls_supported, xattrs_supported};
 use posix_acl::{ACL_READ, ACL_WRITE, PosixACL, Qualifier};
+
+macro_rules! require_xattrs {
+    () => {
+        if !xattrs_supported() {
+            eprintln!("skipping: xattrs unsupported");
+            return;
+        }
+    };
+}
+
+macro_rules! require_acls {
+    () => {
+        if !acls_supported() {
+            eprintln!("skipping: ACLs unsupported");
+            return;
+        }
+    };
+}
 
 #[cfg(unix)]
 fn spawn_daemon(root: &std::path::Path) -> (Child, u16) {
@@ -117,9 +136,10 @@ fn spawn_rsync_daemon_xattr(root: &std::path::Path) -> (Child, u16) {
 
 #[cfg(unix)]
 #[test]
-#[ignore]
 #[serial]
 fn daemon_preserves_xattrs() {
+    require_xattrs!();
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -168,6 +188,7 @@ fn daemon_preserves_xattrs() {
 #[test]
 #[serial]
 fn daemon_preserves_symlink_xattrs_rr_client() {
+    require_xattrs!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -203,6 +224,7 @@ fn daemon_preserves_symlink_xattrs_rr_client() {
 #[test]
 #[serial]
 fn daemon_preserves_xattrs_rr_client() {
+    require_xattrs!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -253,9 +275,9 @@ fn daemon_preserves_xattrs_rr_client() {
 
 #[cfg(unix)]
 #[test]
-#[ignore]
 #[serial]
 fn daemon_preserves_xattrs_rr_daemon() {
+    require_xattrs!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -306,9 +328,10 @@ fn daemon_preserves_xattrs_rr_daemon() {
 
 #[cfg(unix)]
 #[test]
-#[ignore]
 #[serial]
 fn daemon_excludes_filtered_xattrs() {
+    require_xattrs!();
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -353,9 +376,9 @@ fn daemon_excludes_filtered_xattrs() {
 
 #[cfg(unix)]
 #[test]
-#[ignore]
 #[serial]
 fn daemon_excludes_filtered_xattrs_rr_client() {
+    require_xattrs!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -402,6 +425,7 @@ fn daemon_excludes_filtered_xattrs_rr_client() {
 #[test]
 #[serial]
 fn daemon_xattrs_match_rsync_server() {
+    require_xattrs!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv_oc = tmp.path().join("srv_oc");
@@ -448,6 +472,8 @@ fn daemon_xattrs_match_rsync_server() {
 #[serial]
 #[cfg_attr(not(target_os = "linux"), ignore = "requires Linux ACLs")]
 fn daemon_preserves_acls() {
+    require_xattrs!();
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -492,6 +518,7 @@ fn daemon_preserves_acls() {
 #[serial]
 #[cfg_attr(not(target_os = "linux"), ignore = "requires Linux ACLs")]
 fn daemon_preserves_acls_rr_client() {
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -536,6 +563,7 @@ fn daemon_preserves_acls_rr_client() {
 #[serial]
 #[cfg_attr(not(target_os = "linux"), ignore = "requires Linux ACLs")]
 fn daemon_removes_acls() {
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -577,6 +605,7 @@ fn daemon_removes_acls() {
 #[test]
 #[serial]
 fn daemon_ignores_acls_without_flag() {
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -610,6 +639,8 @@ fn daemon_ignores_acls_without_flag() {
 #[test]
 #[serial]
 fn daemon_inherits_default_acls() {
+    require_xattrs!();
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -655,6 +686,7 @@ fn daemon_inherits_default_acls() {
 #[test]
 #[serial]
 fn daemon_inherits_default_acls_rr_client() {
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -700,6 +732,8 @@ fn daemon_inherits_default_acls_rr_client() {
 #[test]
 #[serial]
 fn daemon_acls_match_rsync_server() {
+    require_xattrs!();
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv_oc = tmp.path().join("srv_oc");
@@ -755,6 +789,8 @@ fn daemon_acls_match_rsync_server() {
 #[serial]
 #[cfg_attr(not(target_os = "linux"), ignore = "requires Linux ACLs")]
 fn daemon_acls_match_rsync_client() {
+    require_xattrs!();
+    require_acls!();
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv_oc = tmp.path().join("srv_oc");


### PR DESCRIPTION
## Summary
- add runtime checks for extended attributes and ACL support on Unix
- run daemon sync attribute tests only when support is available
- update flake documentation

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: cannot find -lacl)*


------
https://chatgpt.com/codex/tasks/task_e_68bb78e223848323a063d6d869c97aae