### PR TITLE
Preserve symlinked implied dirs when --no-implied-dirs is set

### DIFF
--- a/FLAKES.md
+++ b/FLAKES.md
@@ -13,5 +13,4 @@ This file documents tests marked `#[ignore]` and why they remain excluded from a
 | `tests/filter_corpus.rs::filter_corpus_parity` | Filter corpus parity with upstream not yet validated. |
 | `tests/filter_corpus.rs::perdir_sign_parity` | Per-directory signing parity pending. |
 | `tests/cli.rs::default_umask_masks_permissions` | Umask handling under review. |
-| `tests/no_implied_dirs.rs::preserves_symlinked_implied_dirs` | Symlinked implied directory behavior unfinished. |
 | `tests/remote_remote.rs::remote_remote_via_daemon_paths` | Remote-to-remote transfer through daemon not yet supported. |

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -2858,21 +2858,7 @@ pub fn sync(
                         .map(|m| m.file_type().is_symlink())
                         .unwrap_or(false);
                     if opts.no_implied_dirs {
-                        if dest_is_symlink {
-                            let link_target =
-                                fs::read_link(&dest_path).map_err(|e| io_context(&dest_path, e))?;
-                            let target_path = if link_target.is_absolute() {
-                                normalize_path(&link_target)
-                            } else if let Some(parent) = dest_path.parent() {
-                                normalize_path(parent.join(&link_target))
-                            } else {
-                                normalize_path(&link_target)
-                            };
-                            if !target_path.exists() {
-                                fs::create_dir_all(&target_path)
-                                    .map_err(|e| io_context(&target_path, e))?;
-                            }
-                        } else if !dest_path.exists() {
+                        if dest_meta.is_none() {
                             fs::create_dir_all(&dest_path)
                                 .map_err(|e| io_context(&dest_path, e))?;
                         }

--- a/tests/no_implied_dirs.rs
+++ b/tests/no_implied_dirs.rs
@@ -6,7 +6,6 @@ use std::os::unix::fs::symlink;
 use tempfile::tempdir;
 
 #[test]
-#[ignore]
 fn preserves_symlinked_implied_dirs() {
     let tmp = tempdir().unwrap();
     let src_root = tmp.path().join("src");


### PR DESCRIPTION
## Summary
- avoid dereferencing existing symlinked directories when --no-implied-dirs is used
- enable test verifying symlinked implied directories are preserved
- clean up FLAKES list for the unignored test

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --all-features --workspace --no-fail-fast` *(fails: 748 passed (1 leaky), 135 failed, 10 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bb79180ad083239682fc460e299fb4