### PR TITLE
Remove unused assert_cmd prelude import

### DIFF
--- a/crates/cli/tests/multiple_sources.rs
+++ b/crates/cli/tests/multiple_sources.rs
@@ -1,5 +1,4 @@
 // crates/cli/tests/multiple_sources.rs
-use assert_cmd::prelude::*;
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;

--- a/crates/daemon/tests/sequential_connections.rs
+++ b/crates/daemon/tests/sequential_connections.rs
@@ -17,12 +17,14 @@ fn handle_sequential_chrooted_connections() {
         return;
     }
     let dir = tempdir().unwrap();
-    let mut module = Module::default();
-    module.name = "data".to_string();
-    module.path = dir.path().to_path_buf();
-    module.uid = Some(1);
-    module.gid = Some(1);
-    module.use_chroot = true;
+    let module = Module {
+        name: "data".to_string(),
+        path: dir.path().to_path_buf(),
+        uid: Some(1),
+        gid: Some(1),
+        use_chroot: true,
+        ..Default::default()
+    };
     let mut modules = HashMap::new();
     modules.insert(module.name.clone(), module);
     let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));

--- a/crates/engine/tests/resume.rs
+++ b/crates/engine/tests/resume.rs
@@ -28,8 +28,10 @@ fn resume_from_partial_file() {
     partial_data.extend_from_slice(&vec![0u8; 1024]);
     fs::write(dst.join("file.bin.partial"), &partial_data).unwrap();
 
-    let mut opts = SyncOptions::default();
-    opts.partial = true;
+    let opts = SyncOptions {
+        partial: true,
+        ..Default::default()
+    };
     sync(&src, &dst, &Matcher::default(), &available_codecs(), &opts).unwrap();
 
     let out = fs::read(dst.join("file.bin")).unwrap();
@@ -49,8 +51,8 @@ fn resume_large_file_minimal_network_io() {
     let total_len = block_size * total_blocks;
     let partial_len = total_len / 2;
     let mut data = Vec::with_capacity(total_len);
-    data.extend(std::iter::repeat(1u8).take(partial_len));
-    data.extend(std::iter::repeat(2u8).take(total_len - partial_len));
+    data.extend(vec![1u8; partial_len]);
+    data.extend(vec![2u8; total_len - partial_len]);
     fs::write(src.join("big.bin"), &data).unwrap();
 
     fs::write(dst.join("big.bin.partial"), &data[..partial_len]).unwrap();
@@ -77,9 +79,11 @@ fn resume_large_file_minimal_network_io() {
     }
     assert_eq!(sent, data.len() - partial_len);
 
-    let mut opts = SyncOptions::default();
-    opts.partial = true;
-    opts.block_size = block_size;
+    let opts = SyncOptions {
+        partial: true,
+        block_size,
+        ..Default::default()
+    };
     sync(&src, &dst, &Matcher::default(), &available_codecs(), &opts).unwrap();
     assert_eq!(fs::read(dst.join("big.bin")).unwrap(), data);
 }

--- a/crates/engine/tests/streaming.rs
+++ b/crates/engine/tests/streaming.rs
@@ -37,7 +37,7 @@ fn sync_very_large_file_streaming() {
     let dst = tmp.path().join("dst");
     fs::create_dir_all(&src).unwrap();
 
-    let mut data = vec![0u8; 1 * 1024 * 1024];
+    let mut data = vec![0u8; 1024 * 1024];
     for (i, b) in data.iter_mut().enumerate() {
         *b = (i % 256) as u8;
     }

--- a/tests/filter_corpus.rs
+++ b/tests/filter_corpus.rs
@@ -1,6 +1,6 @@
 // tests/filter_corpus.rs
 
-use assert_cmd::{Command, cargo::cargo_bin};
+use assert_cmd::Command;
 use shell_words::split;
 use std::fs;
 use std::path::Path;


### PR DESCRIPTION
## Summary
- remove `assert_cmd::prelude` import from multiple_sources test
- clean up several tests to satisfy Clippy (struct initialization, unused imports, and data generation)

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` *(fails: non-minimal cfg and other warnings)*
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with cc failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7ee7f9708323b7e788ff49e512e9