### PR TITLE
chore: refine packaging metadata and service unit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,24 +111,26 @@ nightly = ["checksums/nightly", "compress/nightly"]
 
 [package.metadata.deb]
 maintainer = "oc-rsync maintainers <maintainers@rsync.rs>"
-depends = "$auto, systemd, libzstd1, zlib1g, libacl1"
+license-file = ["LICENSE-MIT", "0"]
+section = "net"
+priority = "optional"
+depends = "zlib1g, libzstd1"
 assets = [
     ["target/release/oc-rsync", "/usr/bin/oc-rsync", "755"],
-    ["target/release/oc-rsyncd", "/usr/bin/oc-rsyncd", "755"],
     ["packaging/systemd/oc-rsyncd.service", "/lib/systemd/system/oc-rsyncd.service", "644"],
     ["packaging/examples/oc-rsyncd.conf", "/usr/share/doc/oc-rsync/examples/oc-rsyncd.conf", "644"],
     ["packaging/systemd/oc-rsyncd.conf", "/usr/share/doc/oc-rsync/examples/oc-rsyncd.systemd.conf", "644"],
+    ["man/oc-rsync.1", "/usr/share/man/man1/oc-rsync.1", "644"],
+    ["man/oc-rsyncd.8", "/usr/share/man/man8/oc-rsyncd.8", "644"],
+    ["man/oc-rsyncd.conf.5", "/usr/share/man/man5/oc-rsyncd.conf.5", "644"],
 ]
 
 [package.metadata.rpm]
 maintainer = "oc-rsync maintainers <maintainers@rsync.rs>"
-requires = ["systemd", "libzstd1", "zlib1g", "libacl1"]
+requires = ["zlib1g", "libzstd1"]
 
 [package.metadata.rpm.targets.oc-rsync]
 path = "/usr/bin/oc-rsync"
-
-[package.metadata.rpm.targets.oc-rsyncd]
-path = "/usr/bin/oc-rsyncd"
 
 [package.metadata.rpm.files."oc-rsyncd.conf"]
 path = "/usr/share/doc/oc-rsync/examples/oc-rsyncd.conf"
@@ -140,4 +142,16 @@ mode = "644"
 
 [package.metadata.rpm.files."oc-rsyncd.service"]
 path = "/usr/lib/systemd/system/oc-rsyncd.service"
+mode = "644"
+
+[package.metadata.rpm.files."oc-rsync.1"]
+path = "/usr/share/man/man1/oc-rsync.1"
+mode = "644"
+
+[package.metadata.rpm.files."oc-rsyncd.8"]
+path = "/usr/share/man/man8/oc-rsyncd.8"
+mode = "644"
+
+[package.metadata.rpm.files."oc-rsyncd.conf.5"]
+path = "/usr/share/man/man5/oc-rsyncd.conf.5"
 mode = "644"

--- a/packaging/systemd/oc-rsyncd.service
+++ b/packaging/systemd/oc-rsyncd.service
@@ -10,10 +10,10 @@ Type=notify
 NotifyAccess=main
 User=ocrsync
 Group=ocrsync
-RuntimeDirectory=oc-rsync
-LogsDirectory=oc-rsync
-StateDirectory=oc-rsync
-ConfigurationDirectory=oc-rsync
+RuntimeDirectory=oc-rsyncd
+LogsDirectory=oc-rsyncd
+StateDirectory=oc-rsyncd
+ConfigurationDirectory=oc-rsyncd
 ExecStart=/usr/bin/oc-rsync --daemon --no-detach --config=/etc/oc-rsyncd.conf
 # To run the daemon via the dedicated oc-rsyncd binary instead of the main oc-rsync CLI,
 # create a drop-in with the following lines:

--- a/tests/packaging.rs
+++ b/tests/packaging.rs
@@ -38,7 +38,6 @@ fn packaging_includes_service_unit() {
 }
 
 #[test]
-#[ignore]
 fn service_unit_matches_spec() {
     let unit = std::fs::read_to_string("packaging/systemd/oc-rsyncd.service")
         .expect("failed to read service unit");


### PR DESCRIPTION
## Summary
- declare license file and metadata fields for Debian packaging
- drop oc-rsyncd binary from packages and add man pages
- align oc-rsyncd.service with packaging spec

## Testing
- `cargo package --list --allow-dirty --no-verify`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: test run failed)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bb791f3a248323a75a732abbbff8d4