### PR TITLE
Ensure consistent test environment defaults

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -31,3 +31,9 @@ linker = "x86_64-w64-mingw32-gcc"
 ar = "x86_64-w64-mingw32-gcc-ar"
 rustflags = ["-Ctarget-cpu=x86-64-v2"]
 
+[env]
+LC_ALL = "C"
+LANG = "C"
+COLUMNS = "80"
+TZ = "UTC"
+

--- a/tests/remote_utils.rs
+++ b/tests/remote_utils.rs
@@ -1,11 +1,24 @@
 // tests/remote_utils.rs
 
+use std::process::Command;
 use transport::ssh::SshStdioTransport;
 
 pub fn spawn_reader(cmd: &str) -> SshStdioTransport {
-    SshStdioTransport::spawn("sh", ["-c", cmd]).expect("spawn")
+    let mut c = Command::new("sh");
+    c.args(["-c", cmd])
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
+        .env("COLUMNS", "80")
+        .env("TZ", "UTC");
+    SshStdioTransport::spawn_from_command(c, false).expect("spawn")
 }
 
 pub fn spawn_writer(cmd: &str) -> SshStdioTransport {
-    SshStdioTransport::spawn("sh", ["-c", cmd]).expect("spawn")
+    let mut c = Command::new("sh");
+    c.args(["-c", cmd])
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
+        .env("COLUMNS", "80")
+        .env("TZ", "UTC");
+    SshStdioTransport::spawn_from_command(c, false).expect("spawn")
 }


### PR DESCRIPTION
## Summary
- ensure test commands inherit consistent locale, width, and timezone
- set default env variables for all cargo invocations

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(failed: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb82a5aba4832389cc8791b4c17c96