### PR TITLE
Support remote-to-remote via rsync daemon paths

### DIFF
--- a/FLAKES.md
+++ b/FLAKES.md
@@ -10,5 +10,4 @@ This file documents tests marked `#[ignore]` and why they remain excluded from a
 | `tests/daemon_sync_attrs.rs::daemon_excludes_filtered_xattrs` | Same as above. |
 | `tests/daemon_sync_attrs.rs::daemon_excludes_filtered_xattrs_rr_client` | Same as above. |
 | `tests/cli.rs::default_umask_masks_permissions` | Umask handling under review. |
-| `tests/remote_remote.rs::remote_remote_via_daemon_paths` | Remote-to-remote transfer through daemon not yet supported. |
 | `tests/no_implied_dirs.rs::preserves_symlinked_implied_dirs` | Symlinked implied directory behavior unfinished. |

--- a/crates/transport/src/lib.rs
+++ b/crates/transport/src/lib.rs
@@ -168,7 +168,9 @@ pub fn rate_limited<T: Transport>(inner: T, bwlimit: u64) -> RateLimitedTranspor
 #[doc = "Append a daemon path specification to a set of remote options."]
 pub fn daemon_remote_opts(base: &[String], path: &Path) -> Vec<String> {
     let mut opts = base.to_vec();
-    opts.push(path.to_string_lossy().into_owned());
+    if path != Path::new(".") {
+        opts.push(path.to_string_lossy().into_owned());
+    }
     opts
 }
 

--- a/docs/compat_matrix.md
+++ b/docs/compat_matrix.md
@@ -15,7 +15,7 @@
 | Local → Local            | ✅ Full support | Parity with classic rsync |
 | Local → Remote (SSH)     | ✅ Interoperates with classic rsync | Parity with classic rsync |
 | Local → Remote (daemon)  | ✅ Interoperates with classic rsync | Parity with classic rsync |
-| Remote → Remote          | ✅ Interoperates with classic rsync | Parity with classic rsync |
+| Remote → Remote          | ✅ Interoperates with classic rsync | Parity with classic rsync, including `rsync://` daemon paths |
 
 ## Remote Feature Coverage
 

--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -11,7 +11,7 @@ Classic `rsync` protocol versions 30–32 are supported.
 | --- | --- | --- |
 | File list path-delta encoding with uid/gid tables | ✅ | Exercised via `filelist` tests |
 | Challenge-response token authentication | ✅ | Protocol handshake verifies tokens |
-| Remote-to-remote forwarding | ✅ | Bridges two remote endpoints via existing transports, including `rsync://` daemon paths |
+| Remote-to-remote forwarding | ✅ | Bridges two remote endpoints via existing transports, including `rsync://` daemon paths (root and subpaths) |
 
 ## CLI options
 

--- a/tests/remote_remote.rs
+++ b/tests/remote_remote.rs
@@ -236,7 +236,6 @@ fn remote_remote_upstream_to_oc() {
 }
 
 #[test]
-#[ignore]
 fn remote_remote_via_daemon_paths() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");


### PR DESCRIPTION
## Summary
- handle `rsync://` daemon root paths in remote forwarding
- enable remote to remote test via daemon paths
- document daemon-path forwarding support

## Testing
- `cargo fmt --all` *(fails: feature `edition2024` is required)*
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: feature `edition2024` is required)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command `nextest`)*
- `make verify-comments` *(fails: feature `edition2024` is required)*
- `make lint` *(fails: feature `edition2024` is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bb82bcfa0c8323993ca400e65c0cb4