### PR TITLE
Expose compression feature flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,9 +101,11 @@ path = "tools/strip_rs_comments.rs"
 # without requiring feature flags. Individual crates handle runtime
 # detection of platform support.
 [features]
-default = ["xattr", "acl"]
+default = ["xattr", "acl", "zlib", "zstd"]
 xattr = ["engine/xattr"]
 acl = ["engine/acl", "meta/acl", "posix-acl"]
+zlib = ["compress/zlib"]
+zstd = ["compress/zstd"]
 # Enables CLI-only tools
 cli = []
 # Enables AVX-512 implementations requiring a nightly toolchain


### PR DESCRIPTION
## Summary
- forward zlib and zstd features to the compress crate
- enable zlib and zstd by default

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: /usr/bin/ld: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: /usr/bin/ld: cannot find -lacl)*
- `make verify-comments`
- `make lint`
- `cargo build --no-default-features`
- `cargo build --no-default-features --features zlib`
- `cargo build --no-default-features --features zstd`


------
https://chatgpt.com/codex/tasks/task_e_68bb82c32c508323a82aa8f8b730d8d5