### PR TITLE
Require dot before skip suffix in compression

### DIFF
--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -82,16 +82,16 @@ pub const DEFAULT_SKIP_COMPRESS: &[&str] = &[
 ];
 
 pub fn should_compress(path: &Path, skip: &[String]) -> bool {
-    let name = match path.file_name().and_then(|n| n.to_str()) {
-        Some(name) => name.to_ascii_lowercase(),
+    let ext = match path.extension().and_then(|e| e.to_str()) {
+        Some(ext) => ext.to_ascii_lowercase(),
         None => return true,
     };
 
     if skip.is_empty() {
-        return !DEFAULT_SKIP_COMPRESS.iter().any(|s| name.ends_with(s));
+        return !DEFAULT_SKIP_COMPRESS.iter().any(|s| ext == *s);
     }
 
-    !skip.iter().any(|s| name.ends_with(s))
+    !skip.iter().any(|s| ext == s.to_ascii_lowercase())
 }
 
 #[cfg(feature = "zlib")]

--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -89,6 +89,7 @@ fn should_compress_respects_default_list() {
     assert!(should_compress(Path::new("file.txt"), &[]));
     assert!(!should_compress(Path::new("archive.gz"), &[]));
     assert!(!should_compress(Path::new("IMAGE.JpG"), &[]));
+    assert!(should_compress(Path::new("archivegz"), &[]));
 }
 
 #[test]
@@ -97,6 +98,13 @@ fn should_compress_handles_mixed_case_patterns() {
         Path::new("file.TXT"),
         &["txt".to_string()]
     ));
+}
+
+#[test]
+fn should_compress_requires_dot_with_custom_patterns() {
+    let skip = vec!["gz".to_string()];
+    assert!(!should_compress(Path::new("archive.gz"), &skip));
+    assert!(should_compress(Path::new("archivegz"), &skip));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- ensure compression skip list matches only file extensions
- test for skip patterns with and without a preceding dot

## Testing
- `make verify-comments` *(fails: tests/checksum_seed_interop.rs: incorrect header)*
- `make lint`
- `make test` *(fails: cannot find -lacl)*
- `cargo test --workspace --quiet` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8dcb8f588323957e6ee6352ca8c2