### PR TITLE
Simplify Debian license file specification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ nightly = ["checksums/nightly", "compress/nightly"]
 
 [package.metadata.deb]
 maintainer = "Project Maintainers <maintainers@oc-rsync.project>"
-license-file = ["LICENSE-MIT", "0"]
+license-file = "LICENSE-MIT"
 section = "net"
 priority = "optional"
 depends = "zlib1g, libzstd1"


### PR DESCRIPTION
## Summary
- use a single license-file path in Cargo metadata
- verified generated deb package includes the MIT license text

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` *(fails: linking with `cc` failed)*
- `make verify-comments` *(fails: tests/checksum_seed_interop.rs: incorrect header)*
- `make lint`
- `cargo build --release`
- `cargo deb --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68bb8ceb0ee08323bf5aa18d0392fd40