### PR TITLE
feat: isolate interop tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
   interop:
     needs: test-linux
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -110,9 +111,13 @@ jobs:
           cache: true
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev acl attr openssh-server
+        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev acl attr openssh-server rsync
 
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --locked
 
+      - name: Run interop tests
+        run: cargo nextest run --workspace --no-fail-fast --run-ignored=only-tests
   build-matrix:
     needs: [lint, test-linux]
     strategy:

--- a/tests/interop/checksum_seed.rs
+++ b/tests/interop/checksum_seed.rs
@@ -1,3 +1,4 @@
+// tests/interop/checksum_seed.rs
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;
@@ -24,6 +25,7 @@ fn collect(dir: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn checksum_seed_matches_upstream() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");

--- a/tests/interop/filter_complex.rs
+++ b/tests/interop/filter_complex.rs
@@ -6,6 +6,7 @@ use std::process::Command as StdCommand;
 use tempfile::tempdir;
 
 #[test]
+#[ignore = "requires rsync"]
 fn complex_filter_cases_match_rsync() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");

--- a/tests/interop/filter_corpus.rs
+++ b/tests/interop/filter_corpus.rs
@@ -1,4 +1,4 @@
-// tests/filter_corpus.rs
+// tests/interop/filter_corpus.rs
 
 use assert_cmd::Command;
 use shell_words::split;
@@ -47,6 +47,7 @@ fn setup_edge(src: &Path) {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn filter_corpus_parity() {
     let fixture_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/filter_corpus");
     for entry in fs::read_dir(&fixture_dir).unwrap() {
@@ -138,6 +139,7 @@ fn filter_corpus_parity() {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn perdir_rules_excludes_filter_files() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
@@ -182,6 +184,7 @@ fn perdir_rules_excludes_filter_files() {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn ignores_parent_rsync_filter_with_ff() {
     let tmp = tempdir().unwrap();
     let parent = tmp.path();
@@ -238,6 +241,7 @@ fn ignores_parent_rsync_filter_with_ff() {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn perdir_sign_parity() {
     let cases = [
         (
@@ -314,6 +318,7 @@ fn perdir_sign_parity() {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn perdir_stack_parity() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");

--- a/tests/interop/help.rs
+++ b/tests/interop/help.rs
@@ -14,6 +14,7 @@ fn normalize(bytes: &[u8]) -> &[u8] {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn help_output_matches_upstream() {
     let ours = Command::cargo_bin("oc-rsync")
         .unwrap()

--- a/tests/interop/outstanding_flags.rs
+++ b/tests/interop/outstanding_flags.rs
@@ -46,6 +46,7 @@ const FLAGS: &[&str] = &[
 ];
 
 #[test]
+#[ignore = "requires rsync"]
 fn outstanding_flags_help_matches_upstream() {
     for flag in FLAGS {
         let ours = Command::cargo_bin("oc-rsync")

--- a/tests/out_format.rs
+++ b/tests/out_format.rs
@@ -1,6 +1,6 @@
 // tests/out_format.rs
 use assert_cmd::Command as TestCommand;
-use std::{fs, process::Command as StdCommand};
+use std::fs;
 use tempfile::tempdir;
 
 #[test]
@@ -10,9 +10,7 @@ fn out_format_file_matches_rsync() {
     fs::create_dir_all(&src_dir).unwrap();
     fs::write(src_dir.join("a"), b"hi").unwrap();
     let dst_oc = tmp.path().join("dst_oc");
-    let dst_rsync = tmp.path().join("dst_rsync");
     fs::create_dir_all(&dst_oc).unwrap();
-    fs::create_dir_all(&dst_rsync).unwrap();
     let log = tmp.path().join("log.txt");
     let src_arg = format!("{}/", src_dir.display());
 
@@ -31,36 +29,13 @@ fn out_format_file_matches_rsync() {
     let ours = fs::read_to_string(&log).unwrap();
     let ours_msg = ours.lines().find(|l| l.trim() == "send:a").unwrap().trim();
 
-    let theirs_msg = match StdCommand::new("rsync")
-        .args([
-            "-r",
-            "--out-format=%o:%n",
-            &src_arg,
-            dst_rsync.to_str().unwrap(),
-        ])
-        .output()
-    {
-        Ok(output) if output.status.success() => {
-            let binding = String::from_utf8_lossy(&output.stdout);
-            binding
-                .lines()
-                .find(|l| l.trim() == "send:a")
-                .unwrap()
-                .trim()
-                .to_string()
-        }
-        _ => {
-            let binding =
-                fs::read_to_string("tests/golden/out_format/out_format_file_matches_rsync.stdout")
-                    .unwrap();
-            binding
-                .lines()
-                .find(|l| l.trim() == "send:a")
-                .unwrap()
-                .trim()
-                .to_string()
-        }
-    };
+    let binding =
+        fs::read_to_string("tests/golden/out_format/out_format_file_matches_rsync.stdout").unwrap();
+    let theirs_msg = binding
+        .lines()
+        .find(|l| l.trim() == "send:a")
+        .unwrap()
+        .trim();
 
     assert_eq!(ours_msg, theirs_msg);
 }
@@ -74,9 +49,7 @@ fn out_format_symlink_matches_rsync() {
     fs::write(src_dir.join("f"), b"hi").unwrap();
     std::os::unix::fs::symlink("f", src_dir.join("link")).unwrap();
     let dst_oc = tmp.path().join("dst_oc");
-    let dst_rsync = tmp.path().join("dst_rsync");
     fs::create_dir_all(&dst_oc).unwrap();
-    fs::create_dir_all(&dst_rsync).unwrap();
     let log = tmp.path().join("log.txt");
     let src_arg = format!("{}/", src_dir.display());
 
@@ -96,38 +69,10 @@ fn out_format_symlink_matches_rsync() {
     let ours = fs::read_to_string(&log).unwrap();
     let ours_msg = ours.lines().find(|l| l.contains("link")).unwrap().trim();
 
-    let theirs_msg = match StdCommand::new("rsync")
-        .args([
-            "-r",
-            "-l",
-            "--out-format=%i:%n%L",
-            &src_arg,
-            dst_rsync.to_str().unwrap(),
-        ])
-        .output()
-    {
-        Ok(output) if output.status.success() => {
-            let binding = String::from_utf8_lossy(&output.stdout);
-            binding
-                .lines()
-                .find(|l| l.contains("link"))
-                .unwrap()
-                .trim()
-                .to_string()
-        }
-        _ => {
-            let binding = fs::read_to_string(
-                "tests/golden/out_format/out_format_symlink_matches_rsync.stdout",
-            )
+    let binding =
+        fs::read_to_string("tests/golden/out_format/out_format_symlink_matches_rsync.stdout")
             .unwrap();
-            binding
-                .lines()
-                .find(|l| l.contains("link"))
-                .unwrap()
-                .trim()
-                .to_string()
-        }
-    };
+    let theirs_msg = binding.lines().find(|l| l.contains("link")).unwrap().trim();
 
     assert_eq!(ours_msg, theirs_msg);
 }


### PR DESCRIPTION
## Summary
- swap out-of-tree rsync comparisons for fixtures
- ignore rsync-dependent tests and move them under `tests/interop`
- run interop tests in their own optional CI job

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: connection unexpectedly closed)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(terminated early)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb8ce4627883238e67e5272ac14951