### PR TITLE
test: add safe env helper

### DIFF
--- a/tests/bin_branding.rs
+++ b/tests/bin_branding.rs
@@ -3,26 +3,21 @@ use assert_cmd::Command;
 use predicates::str::contains;
 use serial_test::serial;
 
-fn set_env(key: &str, value: &str) {
-    unsafe { std::env::set_var(key, value) }
-}
-
-fn remove_env(key: &str) {
-    unsafe { std::env::remove_var(key) }
-}
+mod util;
+use util::env::with_env_var;
 
 #[test]
 #[serial]
 fn errors_use_program_name() {
-    set_env("OC_RSYNC_NAME", "myrsync");
-    Command::cargo_bin("oc-rsync")
-        .unwrap()
-        .arg("--bogus")
-        .assert()
-        .failure()
-        .stderr(contains("myrsync:"))
-        .stderr(contains("myrsync error:"));
-    remove_env("OC_RSYNC_NAME");
+    with_env_var("OC_RSYNC_NAME", "myrsync", || {
+        Command::cargo_bin("oc-rsync")
+            .unwrap()
+            .arg("--bogus")
+            .assert()
+            .failure()
+            .stderr(contains("myrsync:"))
+            .stderr(contains("myrsync error:"));
+    });
 }
 
 #[test]

--- a/tests/checksum_seed_interop.rs
+++ b/tests/checksum_seed_interop.rs
@@ -1,3 +1,4 @@
+// tests/checksum_seed_interop.rs
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;

--- a/tests/daemon_config.rs
+++ b/tests/daemon_config.rs
@@ -5,7 +5,6 @@ use daemon::{Handler, handle_connection, load_config, parse_config};
 use protocol::LATEST_VERSION;
 use serial_test::serial;
 use std::collections::HashMap;
-use std::ffi::OsStr;
 use std::fs;
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
@@ -18,13 +17,8 @@ use std::thread::sleep;
 use std::time::Duration;
 use transport::{LocalPipeTransport, TcpTransport, Transport};
 
-fn set_env_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, val: V) {
-    unsafe { std::env::set_var(key, val) }
-}
-
-fn remove_env_var<K: AsRef<OsStr>>(key: K) {
-    unsafe { std::env::remove_var(key) }
-}
+mod util;
+use util::env::with_env_var;
 
 fn read_port(child: &mut Child) -> u16 {
     let stdout = child.stdout.as_mut().unwrap();
@@ -481,15 +475,10 @@ fn load_config_default_path() {
     let cfg_path = dir.path().join("rsyncd.conf");
     fs::write(&cfg_path, "port = 873\n").unwrap();
     let var = "OC_RSYNC_CONFIG_PATH";
-    let prev = std::env::var(var).ok();
-    set_env_var(var, &cfg_path);
-    let cfg = load_config(None).unwrap();
-    assert_eq!(cfg.port, Some(873));
-    if let Some(v) = prev {
-        set_env_var(var, v);
-    } else {
-        remove_env_var(var);
-    }
+    with_env_var(var, &cfg_path, || {
+        let cfg = load_config(None).unwrap();
+        assert_eq!(cfg.port, Some(873));
+    });
 }
 
 #[test]

--- a/tests/daemon_journald.rs
+++ b/tests/daemon_journald.rs
@@ -3,18 +3,12 @@
 
 use daemon::init_logging;
 use serial_test::serial;
-use std::ffi::OsStr;
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::warn;
 
-fn set_env_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, val: V) {
-    unsafe { std::env::set_var(key, val) }
-}
-
-fn remove_env_var<K: AsRef<OsStr>>(key: K) {
-    unsafe { std::env::remove_var(key) }
-}
+mod util;
+use util::env::with_env_var;
 
 #[test]
 #[serial]
@@ -22,13 +16,13 @@ fn daemon_journald_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    set_env_var("OC_RSYNC_JOURNALD_PATH", &path);
-    init_logging(None, None, false, true, false);
-    warn!(target: "test", "daemon journald");
-    let mut buf = [0u8; 256];
-    let (n, _) = server.recv_from(&mut buf).unwrap();
-    let msg = std::str::from_utf8(&buf[..n]).unwrap();
-    let expected = "PRIORITY=4\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=daemon journald\n";
-    assert_eq!(msg, expected);
-    remove_env_var("OC_RSYNC_JOURNALD_PATH");
+    with_env_var("OC_RSYNC_JOURNALD_PATH", &path, || {
+        init_logging(None, None, false, true, false);
+        warn!(target: "test", "daemon journald");
+        let mut buf = [0u8; 256];
+        let (n, _) = server.recv_from(&mut buf).unwrap();
+        let msg = std::str::from_utf8(&buf[..n]).unwrap();
+        let expected = "PRIORITY=4\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=daemon journald\n";
+        assert_eq!(msg, expected);
+    });
 }

--- a/tests/daemon_syslog.rs
+++ b/tests/daemon_syslog.rs
@@ -3,18 +3,12 @@
 
 use daemon::init_logging;
 use serial_test::serial;
-use std::ffi::OsStr;
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::warn;
 
-fn set_env_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, val: V) {
-    unsafe { std::env::set_var(key, val) }
-}
-
-fn remove_env_var<K: AsRef<OsStr>>(key: K) {
-    unsafe { std::env::remove_var(key) }
-}
+mod util;
+use util::env::with_env_var;
 
 #[test]
 #[serial]
@@ -22,13 +16,13 @@ fn daemon_syslog_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    set_env_var("OC_RSYNC_SYSLOG_PATH", &path);
-    init_logging(None, None, true, false, false);
-    warn!(target: "test", "daemon syslog");
-    let mut buf = [0u8; 256];
-    let (n, _) = server.recv_from(&mut buf).unwrap();
-    let msg = std::str::from_utf8(&buf[..n]).unwrap();
-    let expected = format!("<12>rsync[{}]: daemon syslog", std::process::id());
-    assert_eq!(msg, expected);
-    remove_env_var("OC_RSYNC_SYSLOG_PATH");
+    with_env_var("OC_RSYNC_SYSLOG_PATH", &path, || {
+        init_logging(None, None, true, false, false);
+        warn!(target: "test", "daemon syslog");
+        let mut buf = [0u8; 256];
+        let (n, _) = server.recv_from(&mut buf).unwrap();
+        let msg = std::str::from_utf8(&buf[..n]).unwrap();
+        let expected = format!("<12>rsync[{}]: daemon syslog", std::process::id());
+        assert_eq!(msg, expected);
+    });
 }

--- a/tests/util/env.rs
+++ b/tests/util/env.rs
@@ -1,0 +1,33 @@
+// tests/util/env.rs
+use std::ffi::{OsStr, OsString};
+
+pub fn with_env_var<K, V, F, R>(key: K, value: V, f: F) -> R
+where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+    F: FnOnce() -> R,
+{
+    let key = key.as_ref().to_os_string();
+    let prev = std::env::var_os(&key);
+    unsafe { std::env::set_var(&key, value) };
+    struct Guard {
+        key: OsString,
+        prev: Option<OsString>,
+    }
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            if let Some(val) = &self.prev {
+                unsafe { std::env::set_var(&self.key, val) };
+            } else {
+                unsafe { std::env::remove_var(&self.key) };
+            }
+        }
+    }
+    let guard = Guard {
+        key: key.clone(),
+        prev,
+    };
+    let result = f();
+    drop(guard);
+    result
+}

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,0 +1,2 @@
+// tests/util/mod.rs
+pub mod env;


### PR DESCRIPTION
## Summary
- add safe `with_env_var` to manage test env variables
- use helper in tests instead of `unsafe` environment calls

## Testing
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8de774308323b4f3296f7dbbd197