### PR TITLE
refactor: remove unsafe transmute in CLI test

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1811,10 +1811,8 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
-    #[allow(clippy::transmute)]
     fn exit_code_handles_unknown_error_kind() {
-        let kind: clap::error::ErrorKind = unsafe { std::mem::transmute(u8::MAX) };
+        let kind = clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand;
         assert_eq!(exit_code_from_error_kind(kind), ExitCode::SyntaxOrUsage);
     }
 


### PR DESCRIPTION
## Summary
- replace unsafe `transmute` in CLI test with safe `ErrorKind` variant

## Testing
- `cargo test -p oc-rsync-cli` *(fails: branding::tests::env_or_option_respects_precedence, tests::malformed_daemon_spec_is_error, tests::malformed_rsync_url_is_error, tests::parses_8_bit_output, tests::parses_blocking_io, tests::parses_checksum_choice_and_alias, tests::parses_client_flags, tests::parses_early_input, tests::parses_internal_server_sender_flags, tests::parses_protocol_version, tests::parses_rsh_flag_and_alias, tests::parses_rsync_path_and_alias, tests::parses_skip_compress_list, tests::parses_skip_flags, tests::run_client_errors_when_no_paths_provided)*
- `cargo nextest --version` *(fails: no such command: `nextest`)*
- `make verify-comments` *(fails: tests/checksum_seed_interop.rs: incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb8dd924588323a86b7b9ffacc5de0