### PR TITLE
docs: expand internal feature matrix

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -7,11 +7,11 @@ Classic `rsync` protocol versions 30–32 are supported.
 
 ## Internal features
 
-| Feature | Supported | Notes |
-| --- | --- | --- |
-| File list path-delta encoding with uid/gid tables | ✅ | Exercised via `filelist` tests |
-| Challenge-response token authentication | ✅ | Protocol handshake verifies tokens |
-| Remote-to-remote forwarding | ✅ | Bridges two remote endpoints via existing transports, including `rsync://` daemon paths (root and subpaths) |
+| Feature | Supported | Tests | Source | Notes |
+| --- | --- | --- | --- | --- |
+| File list path-delta encoding with uid/gid tables | ✅ | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) | Exercised via encode/decode roundtrip tests |
+| Challenge-response token authentication | ✅ | [crates/protocol/tests/auth.rs](../crates/protocol/tests/auth.rs) | [crates/protocol/src/server.rs](../crates/protocol/src/server.rs) | Protocol handshake verifies tokens |
+| Remote-to-remote forwarding | ✅ | [tests/remote_remote.rs](../tests/remote_remote.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | Bridges two remote endpoints via existing transports, including `rsync://` daemon paths (root and subpaths) |
 
 ## CLI options
 


### PR DESCRIPTION
## Summary
- document internal features with tests and source links

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `make verify-comments` *(fails: tests/checksum_seed_interop.rs incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb8ccf78b08323b83785322754ff5f