### PR TITLE
Propagate log file clone errors in logging setup

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -142,7 +142,7 @@ pub fn run(matches: &clap::ArgMatches) -> Result<()> {
         return run_daemon(opts.daemon, matches);
     }
     let log_file_fmt = opts.log_file_format.clone().map(|s| parse_escapes(&s));
-    init_logging(matches, log_file_fmt);
+    init_logging(matches, log_file_fmt)?;
     let probe_opts =
         ProbeOpts::from_arg_matches(matches).map_err(|e| EngineError::Other(e.to_string()))?;
     if matches.contains_id("probe") {

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::env;
 use std::ffi::OsString;
 use std::time::{Duration, SystemTime};
-use std::{ffi::OsStr, path::PathBuf};
+use std::{ffi::OsStr, io, path::PathBuf};
 
 use clap::ArgMatches;
 use encoding_rs::Encoding;
@@ -155,7 +155,7 @@ pub fn parse_logging_flags(matches: &ArgMatches) -> (Vec<InfoFlag>, Vec<DebugFla
     (info, debug)
 }
 
-pub(crate) fn init_logging(matches: &ArgMatches, log_file_fmt: Option<String>) {
+pub(crate) fn init_logging(matches: &ArgMatches, log_file_fmt: Option<String>) -> io::Result<()> {
     let verbose = matches.get_count("verbose");
     let quiet = matches.get_flag("quiet");
     let log_file = matches.get_one::<PathBuf>("client-log-file").cloned();
@@ -182,7 +182,7 @@ pub(crate) fn init_logging(matches: &ArgMatches, log_file_fmt: Option<String>) {
         .colored(true)
         .timestamps(false)
         .build();
-    logging::init(cfg);
+    logging::init(cfg)
 }
 
 pub(crate) fn locale_charset() -> Option<String> {

--- a/crates/cli/tests/logging_flags.rs
+++ b/crates/cli/tests/logging_flags.rs
@@ -22,7 +22,7 @@ fn make_sub(
         .colored(true)
         .timestamps(false)
         .build();
-    logging::subscriber(cfg)
+    logging::subscriber(cfg).unwrap()
 }
 
 #[test]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -129,7 +129,7 @@ pub fn init_logging(
     syslog: bool,
     journald: bool,
     quiet: bool,
-) {
+) -> io::Result<()> {
     let cfg = SubscriberConfig::builder()
         .format(LogFormat::Text)
         .verbose(0)
@@ -143,7 +143,7 @@ pub fn init_logging(
         .colored(false)
         .timestamps(true)
         .build();
-    logging::init(cfg);
+    logging::init(cfg)
 }
 
 #[derive(Debug)]
@@ -1311,7 +1311,7 @@ pub fn run_daemon(
         syslog,
         journald,
         quiet,
-    );
+    )?;
 
     if let Some(addr) = address {
         if let Some(AddressFamily::V4) = family {

--- a/crates/logging/tests/journald.rs
+++ b/crates/logging/tests/journald.rs
@@ -26,7 +26,7 @@ fn journald_emits_message() {
         .colored(true)
         .timestamps(false)
         .build();
-    init(cfg);
+    init(cfg).unwrap();
     info!(target: "test", "hi");
     let mut buf = [0u8; 256];
     let (n, _) = server.recv_from(&mut buf).unwrap();

--- a/crates/logging/tests/levels.rs
+++ b/crates/logging/tests/levels.rs
@@ -17,7 +17,7 @@ fn info_not_emitted_by_default() {
         .colored(true)
         .timestamps(false)
         .build();
-    let sub = subscriber(cfg);
+    let sub = subscriber(cfg).unwrap();
     with_default(sub, || {
         assert!(!tracing::enabled!(Level::INFO));
     });
@@ -37,7 +37,7 @@ fn verbose_enables_info() {
         .colored(true)
         .timestamps(false)
         .build();
-    let sub = subscriber(cfg);
+    let sub = subscriber(cfg).unwrap();
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -57,7 +57,7 @@ fn debug_enables_debug() {
         .colored(true)
         .timestamps(false)
         .build();
-    let sub = subscriber(cfg);
+    let sub = subscriber(cfg).unwrap();
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -77,7 +77,7 @@ fn debug_with_two_v() {
         .colored(true)
         .timestamps(false)
         .build();
-    let sub = subscriber(cfg);
+    let sub = subscriber(cfg).unwrap();
     with_default(sub, || {
         assert!(tracing::enabled!(Level::DEBUG));
     });
@@ -97,7 +97,7 @@ fn info_flag_enables_info() {
         .colored(true)
         .timestamps(false)
         .build();
-    let sub = subscriber(cfg);
+    let sub = subscriber(cfg).unwrap();
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });
@@ -117,7 +117,7 @@ fn json_verbose_enables_info() {
         .colored(true)
         .timestamps(false)
         .build();
-    let sub = subscriber(cfg);
+    let sub = subscriber(cfg).unwrap();
     with_default(sub, || {
         assert!(tracing::enabled!(Level::INFO));
     });

--- a/crates/logging/tests/log_file_error.rs
+++ b/crates/logging/tests/log_file_error.rs
@@ -1,0 +1,13 @@
+// crates/logging/tests/log_file_error.rs
+use logging::{subscriber, SubscriberConfig};
+use tempfile::tempdir;
+
+#[test]
+fn log_file_error_propagates() {
+    let dir = tempdir().unwrap();
+    // Using a directory path as the log file should fail to open.
+    let cfg = SubscriberConfig::builder()
+        .log_file(Some((dir.path().to_path_buf(), None)))
+        .build();
+    assert!(subscriber(cfg).is_err());
+}

--- a/crates/logging/tests/syslog.rs
+++ b/crates/logging/tests/syslog.rs
@@ -26,7 +26,7 @@ fn syslog_emits_message() {
         .colored(true)
         .timestamps(false)
         .build();
-    init(cfg);
+    init(cfg).unwrap();
     info!(target: "test", "hello");
     let mut buf = [0u8; 256];
     let (n, _) = server.recv_from(&mut buf).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,7 +214,7 @@ pub fn synchronize_with_config<P: AsRef<Path>>(src: P, dst: P, cfg: &SyncConfig)
         .colored(cfg.colored)
         .timestamps(cfg.timestamps)
         .build();
-    let sub = subscriber(sub_cfg);
+    let sub = subscriber(sub_cfg)?;
     with_default(sub, || -> Result<()> {
         let opts = SyncOptions {
             perms: cfg.perms,

--- a/tests/daemon_journald.rs
+++ b/tests/daemon_journald.rs
@@ -23,7 +23,7 @@ fn daemon_journald_emits_message() {
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
     set_env_var("OC_RSYNC_JOURNALD_PATH", &path);
-    init_logging(None, None, false, true, false);
+    init_logging(None, None, false, true, false).unwrap();
     warn!(target: "test", "daemon journald");
     let mut buf = [0u8; 256];
     let (n, _) = server.recv_from(&mut buf).unwrap();

--- a/tests/daemon_syslog.rs
+++ b/tests/daemon_syslog.rs
@@ -23,7 +23,7 @@ fn daemon_syslog_emits_message() {
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
     set_env_var("OC_RSYNC_SYSLOG_PATH", &path);
-    init_logging(None, None, true, false, false);
+    init_logging(None, None, true, false, false).unwrap();
     warn!(target: "test", "daemon syslog");
     let mut buf = [0u8; 256];
     let (n, _) = server.recv_from(&mut buf).unwrap();


### PR DESCRIPTION
## Summary
- bubble up log file cloning failures during subscriber setup
- allow log initialization to return io::Result
- test logging fails when log file path is invalid

## Testing
- `make lint`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: daemon::sequential_connections handle_sequential_chrooted_connections, engine::append append_errors_when_destination_missing, engine::auto_tmp hides_temp_files, engine::batch_replay replay_is_deterministic, engine::cleanup cleans_up_temp_dir_on_rename_failure, engine::cleanup removes_partial_dir_after_sync, engine::resume resume_from_partial_file)*
- `make verify-comments` *(fails: crates/logging/src/lib.rs: additional comments; tests/checksum_seed_interop.rs: incorrect header)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8de0b7008323a4eac534ae691231