### PR TITLE
ci: run interop tests with upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,20 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev acl attr openssh-server
 
+      - name: Build oc-rsync (release)
+        run: |
+          cargo build --release --bin oc-rsync --features="acl xattr"
+          mkdir -p target/debug
+          cp target/release/oc-rsync target/debug/oc-rsync
+
+      - name: Build upstream rsync 3.4.1
+        run: echo "UPSTREAM_RSYNC=$(tests/interop/build_upstream.sh)" >> $GITHUB_ENV
+
+      - name: Run interop matrix
+        env:
+          UPSTREAM_RSYNC: ${{ env.UPSTREAM_RSYNC }}
+        run: tests/interop/run_matrix.sh
+
 
   build-matrix:
     needs: [lint, test-linux]


### PR DESCRIPTION
## Summary
- build release oc-rsync and upstream rsync in interop job
- run matrix interop tests between oc-rsync and upstream

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: 149 failed, 8 interrupted)*
- `make verify-comments` *(fails: tests/checksum_seed_interop.rs incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb8cbc4f148323b9f94a3da5508622