### PR TITLE
chore: add header comment for checksum_seed_interop

### DIFF
--- a/tests/checksum_seed_interop.rs
+++ b/tests/checksum_seed_interop.rs
@@ -1,3 +1,4 @@
+// tests/checksum_seed_interop.rs
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;


### PR DESCRIPTION
## Summary
- add missing header comment for `checksum_seed_interop` test

## Testing
- `cargo fmt --all`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 148 tests failed, 4 tests cancelled)*
- `cargo nextest run --workspace --no-fail-fast --all-features` *(terminated after build due to time constraints)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68bb8dc74f88832392ff6d0f1003ad9b