### PR TITLE
Allow differing path types for sync helpers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,11 @@ impl SyncConfigBuilder {
     }
 }
 
-pub fn synchronize_with_config<P: AsRef<Path>>(src: P, dst: P, cfg: &SyncConfig) -> Result<()> {
+pub fn synchronize_with_config<S: AsRef<Path>, D: AsRef<Path>>(
+    src: S,
+    dst: D,
+    cfg: &SyncConfig,
+) -> Result<()> {
     let src = src.as_ref();
     let dst = dst.as_ref();
     let sub_cfg = SubscriberConfig::builder()
@@ -238,6 +242,6 @@ pub fn synchronize_with_config<P: AsRef<Path>>(src: P, dst: P, cfg: &SyncConfig)
     })
 }
 
-pub fn synchronize<P: AsRef<Path>>(src: P, dst: P) -> Result<()> {
+pub fn synchronize<S: AsRef<Path>, D: AsRef<Path>>(src: S, dst: D) -> Result<()> {
     synchronize_with_config(src, dst, &SyncConfig::default())
 }


### PR DESCRIPTION
## Summary
- allow source and destination to be different path types
- update `synchronize` helper to use new generics

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: daemon::sequential_connections::handle_sequential_chrooted_connections, engine::append::append_errors_when_destination_missing, and others; interrupted)*
- `make verify-comments` *(fails: tests/checksum_seed_interop.rs incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb8cfcf7f88323b72e158863f26a33