### PR TITLE
feat(cli): drop unsafe env var overrides

### DIFF
--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -351,18 +351,12 @@ pub fn render_help(_cmd: &Command) -> String {
 
 pub fn dump_help_body(cmd: &Command) -> String {
     let prev = std::env::var("COLUMNS").ok();
-    unsafe {
-        std::env::set_var("COLUMNS", "80");
-    }
+    std::env::set_var("COLUMNS", "80");
     let help = render_help(cmd);
     if let Some(v) = prev {
-        unsafe {
-            std::env::set_var("COLUMNS", v);
-        }
+        std::env::set_var("COLUMNS", v);
     } else {
-        unsafe {
-            std::env::remove_var("COLUMNS");
-        }
+        std::env::remove_var("COLUMNS");
     }
 
     let mut out = String::new();

--- a/crates/cli/tests/help_formatting.rs
+++ b/crates/cli/tests/help_formatting.rs
@@ -26,6 +26,7 @@ fn extract_options(help: &str) -> String {
 }
 
 #[test]
+#[serial]
 fn dump_help_body_lists_unique_options() {
     let output = dump_help_body(&cli_command());
     let mut seen = HashSet::new();

--- a/tests/checksum_seed_interop.rs
+++ b/tests/checksum_seed_interop.rs
@@ -1,3 +1,4 @@
+// tests/checksum_seed_interop.rs
 use assert_cmd::Command;
 use std::collections::BTreeMap;
 use std::fs;


### PR DESCRIPTION
## Summary
- remove unsafe env var calls in CLI formatter
- serialize dump_help_body test and fix missing file header comment

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(failed: SIGINT and slow tests)*
- `cargo nextest run --no-fail-fast --test help_output dump_help_body_lists_unique_options dump_help_body_60_matches_golden dump_help_body_100_matches_golden` *(failed: dump_help_body_60_matches_golden)*
- `cargo nextest run --no-fail-fast -p oc-rsync-cli --test help_formatting` *(failed: help_wrapping_matches_upstream)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8ceeda348323bb7d534a205c7979