### PR TITLE
chore: configure codecov thresholds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,14 +88,14 @@ jobs:
       - name: Run tests
         run: cargo nextest run --workspace --no-fail-fast
       - name: Test with coverage (95% lines & functions)
-        run: cargo llvm-cov nextest --workspace --fail-under-lines 95 --fail-under-functions 95 --html -- --no-fail-fast
+        run: cargo llvm-cov nextest --workspace --lcov --output-path coverage.lcov --fail-under-lines 95 --fail-under-functions 95 -- --no-fail-fast
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           name: coverage-report
-          path: target/llvm-cov/html
+          files: coverage.lcov
 
   interop:
     needs: test-linux

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,13 @@
+codecov:
+  require_ci_to_pass: true
+
 coverage:
   status:
     project:
       default:
         target: 95%
+        threshold: 1%
     patch:
       default:
         target: 95%
-require_ci_to_pass: true
-verbose: true
+        threshold: 1%


### PR DESCRIPTION
## Summary
- ensure coverage report uploads as `coverage.lcov`
- enforce 95% project and patch coverage in Codecov

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: tcp_handshake_timeout, others interrupted)*
- `make verify-comments` *(fails: additional comments, incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb93a692b883239c6e3c03541af139