### PR TITLE
Map transient connection errors to timeout

### DIFF
--- a/src/bin/oc-rsync/main.rs
+++ b/src/bin/oc-rsync/main.rs
@@ -9,16 +9,18 @@ use std::io::ErrorKind;
 fn exit_code_from_engine_error(e: &EngineError) -> ExitCode {
     match e {
         EngineError::Io(err) => match err.kind() {
-            ErrorKind::TimedOut | ErrorKind::WouldBlock => ExitCode::ConnTimeout,
-            ErrorKind::ConnectionRefused
+            ErrorKind::TimedOut
+            | ErrorKind::WouldBlock
+            | ErrorKind::ConnectionRefused
             | ErrorKind::AddrNotAvailable
             | ErrorKind::NetworkUnreachable
             | ErrorKind::ConnectionAborted
             | ErrorKind::ConnectionReset
             | ErrorKind::NotConnected
             | ErrorKind::HostUnreachable
-            | ErrorKind::NetworkDown => ExitCode::SocketIo,
-            _ => ExitCode::Protocol,
+            | ErrorKind::NetworkDown => ExitCode::ConnTimeout,
+            ErrorKind::UnexpectedEof | ErrorKind::InvalidData => ExitCode::Protocol,
+            _ => ExitCode::SocketIo,
         },
         EngineError::MaxAlloc => ExitCode::Malloc,
         EngineError::Exit(code, _) => *code,


### PR DESCRIPTION
## Summary
- map connection-related IO errors to `ExitCode::ConnTimeout`
- treat unexpected EOF/invalid data as protocol issues, leaving other IO errors as socket I/O

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments` *(fails: crates/logging/src/lib.rs: additional comments)*
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: transport::ssh_backpressure::backpressure_blocks_until_read panicked)*
- `cargo test --bin oc-rsync`


------
https://chatgpt.com/codex/tasks/task_e_68bb94c9cea08323b0cfa224f7ed7b42