### PR TITLE
refactor: centralize exit code mapping

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -75,6 +75,27 @@ pub fn exit_code_from_error_kind(kind: clap::error::ErrorKind) -> ExitCode {
     }
 }
 
+pub fn exit_code_from_engine_error(e: &EngineError) -> ExitCode {
+    use std::io::ErrorKind;
+    match e {
+        EngineError::Io(err) => match err.kind() {
+            ErrorKind::TimedOut | ErrorKind::WouldBlock => ExitCode::ConnTimeout,
+            ErrorKind::ConnectionRefused
+            | ErrorKind::AddrNotAvailable
+            | ErrorKind::NetworkUnreachable
+            | ErrorKind::ConnectionAborted
+            | ErrorKind::ConnectionReset
+            | ErrorKind::NotConnected
+            | ErrorKind::HostUnreachable
+            | ErrorKind::NetworkDown => ExitCode::SocketIo,
+            _ => ExitCode::Protocol,
+        },
+        EngineError::MaxAlloc => ExitCode::Malloc,
+        EngineError::Exit(code, _) => *code,
+        _ => ExitCode::Protocol,
+    }
+}
+
 pub fn handle_clap_error(cmd: &clap::Command, e: clap::Error) -> ! {
     use clap::error::ErrorKind;
     let kind = e.kind();
@@ -1814,6 +1835,63 @@ mod tests {
     fn exit_code_handles_unknown_error_kind() {
         let kind = clap::error::ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand;
         assert_eq!(exit_code_from_error_kind(kind), ExitCode::SyntaxOrUsage);
+    }
+
+    #[test]
+    fn maps_error_kinds_to_exit_codes() {
+        use clap::error::ErrorKind::*;
+        let cases = [
+            (InvalidValue, ExitCode::Unsupported),
+            (UnknownArgument, ExitCode::SyntaxOrUsage),
+            (InvalidSubcommand, ExitCode::SyntaxOrUsage),
+            (NoEquals, ExitCode::SyntaxOrUsage),
+            (ValueValidation, ExitCode::SyntaxOrUsage),
+            (TooManyValues, ExitCode::SyntaxOrUsage),
+            (TooFewValues, ExitCode::SyntaxOrUsage),
+            (WrongNumberOfValues, ExitCode::SyntaxOrUsage),
+            (ArgumentConflict, ExitCode::SyntaxOrUsage),
+            (MissingRequiredArgument, ExitCode::SyntaxOrUsage),
+            (MissingSubcommand, ExitCode::SyntaxOrUsage),
+            (InvalidUtf8, ExitCode::SyntaxOrUsage),
+            (
+                DisplayHelpOnMissingArgumentOrSubcommand,
+                ExitCode::SyntaxOrUsage,
+            ),
+            (DisplayHelp, ExitCode::Ok),
+            (DisplayVersion, ExitCode::Ok),
+            (Io, ExitCode::FileIo),
+            (Format, ExitCode::FileIo),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(exit_code_from_error_kind(kind), expected);
+        }
+    }
+
+    #[test]
+    fn transient_network_errors_map_to_conn_timeout() {
+        use std::io::ErrorKind;
+        let kinds = [
+            ErrorKind::TimedOut,
+            ErrorKind::ConnectionRefused,
+            ErrorKind::AddrNotAvailable,
+            ErrorKind::NetworkUnreachable,
+            ErrorKind::WouldBlock,
+            ErrorKind::ConnectionAborted,
+            ErrorKind::ConnectionReset,
+            ErrorKind::NotConnected,
+            ErrorKind::HostUnreachable,
+            ErrorKind::NetworkDown,
+        ];
+
+        for kind in kinds {
+            let err = EngineError::Io(std::io::Error::from(kind));
+            assert_eq!(
+                exit_code_from_engine_error(&err),
+                ExitCode::ConnTimeout,
+                "{kind:?} did not map to ConnTimeout",
+            );
+        }
     }
 
     #[test]

--- a/src/bin/oc-rsync/main.rs
+++ b/src/bin/oc-rsync/main.rs
@@ -2,29 +2,8 @@
 mod stdio;
 
 use oc_rsync_cli::options::OutBuf;
-use oc_rsync_cli::{EngineError, cli_command};
+use oc_rsync_cli::{cli_command, exit_code_from_engine_error};
 use protocol::ExitCode;
-use std::io::ErrorKind;
-
-fn exit_code_from_engine_error(e: &EngineError) -> ExitCode {
-    match e {
-        EngineError::Io(err) => match err.kind() {
-            ErrorKind::TimedOut | ErrorKind::WouldBlock => ExitCode::ConnTimeout,
-            ErrorKind::ConnectionRefused
-            | ErrorKind::AddrNotAvailable
-            | ErrorKind::NetworkUnreachable
-            | ErrorKind::ConnectionAborted
-            | ErrorKind::ConnectionReset
-            | ErrorKind::NotConnected
-            | ErrorKind::HostUnreachable
-            | ErrorKind::NetworkDown => ExitCode::SocketIo,
-            _ => ExitCode::Protocol,
-        },
-        EngineError::MaxAlloc => ExitCode::Malloc,
-        EngineError::Exit(code, _) => *code,
-        _ => ExitCode::Protocol,
-    }
-}
 
 fn main() {
     let args: Vec<_> = std::env::args_os().collect();
@@ -49,71 +28,5 @@ fn main() {
         eprintln!("{e}");
         let code = exit_code_from_engine_error(&e);
         std::process::exit(u8::from(code) as i32);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use clap::error::ErrorKind::*;
-    use oc_rsync_cli::exit_code_from_error_kind;
-    use protocol::ExitCode;
-    use std::io::ErrorKind;
-
-    use super::exit_code_from_engine_error;
-    use oc_rsync_cli::EngineError;
-
-    #[test]
-    fn maps_error_kinds_to_exit_codes() {
-        let cases = [
-            (InvalidValue, ExitCode::Unsupported),
-            (UnknownArgument, ExitCode::SyntaxOrUsage),
-            (InvalidSubcommand, ExitCode::SyntaxOrUsage),
-            (NoEquals, ExitCode::SyntaxOrUsage),
-            (ValueValidation, ExitCode::SyntaxOrUsage),
-            (TooManyValues, ExitCode::SyntaxOrUsage),
-            (TooFewValues, ExitCode::SyntaxOrUsage),
-            (WrongNumberOfValues, ExitCode::SyntaxOrUsage),
-            (ArgumentConflict, ExitCode::SyntaxOrUsage),
-            (MissingRequiredArgument, ExitCode::SyntaxOrUsage),
-            (MissingSubcommand, ExitCode::SyntaxOrUsage),
-            (InvalidUtf8, ExitCode::SyntaxOrUsage),
-            (
-                DisplayHelpOnMissingArgumentOrSubcommand,
-                ExitCode::SyntaxOrUsage,
-            ),
-            (DisplayHelp, ExitCode::Ok),
-            (DisplayVersion, ExitCode::Ok),
-            (Io, ExitCode::FileIo),
-            (Format, ExitCode::FileIo),
-        ];
-
-        for (kind, expected) in cases {
-            assert_eq!(exit_code_from_error_kind(kind), expected);
-        }
-    }
-
-    #[test]
-    fn transient_network_errors_map_to_conn_timeout() {
-        let kinds = [
-            ErrorKind::TimedOut,
-            ErrorKind::ConnectionRefused,
-            ErrorKind::AddrNotAvailable,
-            ErrorKind::NetworkUnreachable,
-            ErrorKind::WouldBlock,
-            ErrorKind::ConnectionAborted,
-            ErrorKind::ConnectionReset,
-            ErrorKind::NotConnected,
-            ErrorKind::HostUnreachable,
-            ErrorKind::NetworkDown,
-        ];
-
-        for kind in kinds {
-            let err = EngineError::Io(std::io::Error::from(kind));
-            assert_eq!(
-                exit_code_from_engine_error(&err),
-                ExitCode::ConnTimeout,
-                "{kind:?} did not map to ConnTimeout",
-            );
-        }
     }
 }


### PR DESCRIPTION
## Summary
- move engine error to exit-code mapper into cli library and expose it
- drop duplicated mapping logic from `oc-rsync` binary
- add tests around error-to-exit-code conversion

## Testing
- `cargo test --workspace` *(fails: handle_sequential_chrooted_connections)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: 733 passed, 146 failed, 8 not run)*
- `make verify-comments` *(fails: additional comments / incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb94cc55c08323b03249e391ea1141