### PR TITLE
chore: mark ACL FFI as unsafe

### DIFF
--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -683,7 +683,7 @@ fn remove_default_acl(path: &Path) -> io::Result<()> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
 
-    extern "C" {
+    unsafe extern "C" {
         fn acl_delete_def_file(path_p: *const libc::c_char) -> libc::c_int;
     }
 


### PR DESCRIPTION
## Summary
- use `unsafe extern "C"` in `remove_default_acl`

## Testing
- `cargo check -p meta --features acl`
- `cargo nextest run --workspace --all-features --no-fail-fast` *(fails: binding modifiers may only be written when the default binding mode is move in crates/filters)*
- `make verify-comments`
- `make lint` *(fails: comment lint differences)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9d8375508323a869aea61eba8b8a