### PR TITLE
Wrap unsafe SIMD intrinsics in checksums

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -200,16 +200,16 @@ pub unsafe fn rolling_checksum_sse42(data: &[u8], seed: u32) -> u32 {
     let mut offset: u64 = 0;
 
     let zero = _mm_setzero_si128();
-    let idx_lo = _mm_loadu_si128(IDX_LO.as_ptr() as *const __m128i);
-    let idx_hi = _mm_loadu_si128(IDX_HI.as_ptr() as *const __m128i);
+    let idx_lo = unsafe { _mm_loadu_si128(IDX_LO.as_ptr() as *const __m128i) };
+    let idx_hi = unsafe { _mm_loadu_si128(IDX_HI.as_ptr() as *const __m128i) };
 
     let mut i = 0;
     while i + 16 <= n {
-        let chunk = _mm_loadu_si128(data.as_ptr().add(i) as *const __m128i);
+        let chunk = unsafe { _mm_loadu_si128(data.as_ptr().add(i) as *const __m128i) };
 
         let sad = _mm_sad_epu8(chunk, zero);
         let mut tmp_sum = [0u64; 2];
-        _mm_storeu_si128(tmp_sum.as_mut_ptr() as *mut __m128i, sad);
+        unsafe { _mm_storeu_si128(tmp_sum.as_mut_ptr() as *mut __m128i, sad) };
         let chunk_sum = tmp_sum[0] + tmp_sum[1];
         sum_bytes += chunk_sum;
 
@@ -218,9 +218,9 @@ pub unsafe fn rolling_checksum_sse42(data: &[u8], seed: u32) -> u32 {
         let prod_lo = _mm_madd_epi16(lo, idx_lo);
         let prod_hi = _mm_madd_epi16(hi, idx_hi);
         let mut tmp = [0i32; 4];
-        _mm_storeu_si128(tmp.as_mut_ptr() as *mut __m128i, prod_lo);
+        unsafe { _mm_storeu_si128(tmp.as_mut_ptr() as *mut __m128i, prod_lo) };
         let sum_lo: i64 = tmp.iter().map(|&v| v as i64).sum();
-        _mm_storeu_si128(tmp.as_mut_ptr() as *mut __m128i, prod_hi);
+        unsafe { _mm_storeu_si128(tmp.as_mut_ptr() as *mut __m128i, prod_hi) };
         let sum_hi: i64 = tmp.iter().map(|&v| v as i64).sum();
         let chunk_idx_sum = sum_lo + sum_hi;
 
@@ -261,16 +261,16 @@ pub unsafe fn rolling_checksum_avx2(data: &[u8], seed: u32) -> u32 {
     let mut offset: u64 = 0;
 
     let zero = _mm256_setzero_si256();
-    let idx_lo = _mm256_loadu_si256(IDX_LO.as_ptr() as *const __m256i);
-    let idx_hi = _mm256_loadu_si256(IDX_HI.as_ptr() as *const __m256i);
+    let idx_lo = unsafe { _mm256_loadu_si256(IDX_LO.as_ptr() as *const __m256i) };
+    let idx_hi = unsafe { _mm256_loadu_si256(IDX_HI.as_ptr() as *const __m256i) };
 
     let mut i = 0;
     while i + 32 <= n {
-        let chunk = _mm256_loadu_si256(data.as_ptr().add(i) as *const __m256i);
+        let chunk = unsafe { _mm256_loadu_si256(data.as_ptr().add(i) as *const __m256i) };
 
         let sad = _mm256_sad_epu8(chunk, zero);
         let mut tmp_sum = [0u64; 4];
-        _mm256_storeu_si256(tmp_sum.as_mut_ptr() as *mut __m256i, sad);
+        unsafe { _mm256_storeu_si256(tmp_sum.as_mut_ptr() as *mut __m256i, sad) };
         let chunk_sum = tmp_sum.iter().sum::<u64>();
         sum_bytes += chunk_sum;
 
@@ -281,9 +281,9 @@ pub unsafe fn rolling_checksum_avx2(data: &[u8], seed: u32) -> u32 {
         let prod_lo = _mm256_madd_epi16(lo, idx_lo);
         let prod_hi = _mm256_madd_epi16(hi, idx_hi);
         let mut tmp = [0i32; 8];
-        _mm256_storeu_si256(tmp.as_mut_ptr() as *mut __m256i, prod_lo);
+        unsafe { _mm256_storeu_si256(tmp.as_mut_ptr() as *mut __m256i, prod_lo) };
         let sum_lo: i64 = tmp.iter().map(|&v| v as i64).sum();
-        _mm256_storeu_si256(tmp.as_mut_ptr() as *mut __m256i, prod_hi);
+        unsafe { _mm256_storeu_si256(tmp.as_mut_ptr() as *mut __m256i, prod_hi) };
         let sum_hi: i64 = tmp.iter().map(|&v| v as i64).sum();
         let chunk_idx_sum = sum_lo + sum_hi;
 
@@ -328,16 +328,16 @@ pub unsafe fn rolling_checksum_avx512(data: &[u8], seed: u32) -> u32 {
     let mut offset: u64 = 0;
 
     let zero = _mm512_setzero_si512();
-    let idx_lo = _mm512_loadu_si512(IDX_LO.as_ptr() as *const __m512i);
-    let idx_hi = _mm512_loadu_si512(IDX_HI.as_ptr() as *const __m512i);
+    let idx_lo = unsafe { _mm512_loadu_si512(IDX_LO.as_ptr() as *const __m512i) };
+    let idx_hi = unsafe { _mm512_loadu_si512(IDX_HI.as_ptr() as *const __m512i) };
 
     let mut i = 0;
     while i + 64 <= n {
-        let chunk = _mm512_loadu_si512(data.as_ptr().add(i) as *const __m512i);
+        let chunk = unsafe { _mm512_loadu_si512(data.as_ptr().add(i) as *const __m512i) };
 
         let sad = _mm512_sad_epu8(chunk, zero);
         let mut tmp_sum = [0u64; 8];
-        _mm512_storeu_si512(tmp_sum.as_mut_ptr() as *mut __m512i, sad);
+        unsafe { _mm512_storeu_si512(tmp_sum.as_mut_ptr() as *mut __m512i, sad) };
         let chunk_sum = tmp_sum.iter().sum::<u64>();
         sum_bytes += chunk_sum;
 
@@ -348,9 +348,9 @@ pub unsafe fn rolling_checksum_avx512(data: &[u8], seed: u32) -> u32 {
         let prod_lo = _mm512_madd_epi16(lo, idx_lo);
         let prod_hi = _mm512_madd_epi16(hi, idx_hi);
         let mut tmp = [0i32; 16];
-        _mm512_storeu_si512(tmp.as_mut_ptr() as *mut __m512i, prod_lo);
+        unsafe { _mm512_storeu_si512(tmp.as_mut_ptr() as *mut __m512i, prod_lo) };
         let sum_lo: i64 = tmp.iter().map(|&v| v as i64).sum();
-        _mm512_storeu_si512(tmp.as_mut_ptr() as *mut __m512i, prod_hi);
+        unsafe { _mm512_storeu_si512(tmp.as_mut_ptr() as *mut __m512i, prod_hi) };
         let sum_hi: i64 = tmp.iter().map(|&v| v as i64).sum();
         let chunk_idx_sum = sum_lo + sum_hi;
 


### PR DESCRIPTION
## Summary
- wrap SSE4.2, AVX2 and AVX512 intrinsics with explicit `unsafe` blocks

## Testing
- `cargo clippy -p checksums`
- `make verify-comments`
- `make lint` *(fails: rustfmt wants to reorder imports in xtask/src/bin/comment_lint.rs)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command `nextest`)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9d8662208323ba59edbe4b197611