### PR TITLE
fix: simplify rule pattern matching

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1145,10 +1145,7 @@ pub fn parse_with_options(
             };
             if m.contains('s') || m.contains('r') || m.contains('p') || m.contains('x') {
                 for rule in &mut sub {
-                    if let Rule::Include(ref mut d)
-                    | Rule::Exclude(ref mut d)
-                    | Rule::Protect(ref mut d) = rule
-                    {
+                    if let Rule::Include(d) | Rule::Exclude(d) | Rule::Protect(d) = rule {
                         if m.contains('s') {
                             d.flags.sender = true;
                         }


### PR DESCRIPTION
## Summary
- simplify rule pattern matching in filter parser

## Testing
- `cargo clippy -p filters --all-targets --all-features -- -D warnings` *(fails: collapsible if statements)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: unsafe env::set_var usage)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: missing -lacl linker library)*
- `make verify-comments`
- `make lint` *(fails: collapsible if statements)*
- `cargo check -p filters`


------
https://chatgpt.com/codex/tasks/task_e_68bba28944f08323a2b28d5702e346b6