### PR TITLE
Simplify rule match in filters

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1145,9 +1145,9 @@ pub fn parse_with_options(
             };
             if m.contains('s') || m.contains('r') || m.contains('p') || m.contains('x') {
                 for rule in &mut sub {
-                    if let Rule::Include(ref mut d)
-                    | Rule::Exclude(ref mut d)
-                    | Rule::Protect(ref mut d) = rule
+                    if let Rule::Include(d)
+                    | Rule::Exclude(d)
+                    | Rule::Protect(d) = rule
                     {
                         if m.contains('s') {
                             d.flags.sender = true;


### PR DESCRIPTION
## Summary
- simplify filter rule matching by removing explicit `ref mut`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --workspace -- -D warnings` *(fails: this `if` statement can be collapsed)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed: exit status: 1)*
- `make verify-comments`
- `make lint` *(fails: formatting check showed diffs)*
- `cargo test --workspace` *(fails: linking with `cc` failed: exit status: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bba22f13dc83238ef9dee7ca3c3d00