### PR TITLE
doc: mark cvs-exclude as partial

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -50,7 +50,7 @@ Classic `rsync` protocol versions 30–32 are supported.
 | `--copy-links` | ✅ | Y | Y | Y | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--copy-unsafe-links` | ✅ | Y | Y | Y | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--crtimes` | ✅ | Y | Y | Y | [crates/engine/tests/attrs.rs](../crates/engine/tests/attrs.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--cvs-exclude` | ✅ | Y | Y | Y | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs)<br>[tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
+| `--cvs-exclude` | ⚠️ | N | Y | Y | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs)<br>[tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) failing: CVS ignore semantics incomplete |
 | `--daemon` | ✅ | Y | Y | Y | [tests/daemon.rs](../tests/daemon.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--debug` | ✅ | Y | Y | Y | [crates/cli/tests/logging_flags.rs](../crates/cli/tests/logging_flags.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--del` | ✅ | Y | Y | Y | [tests/golden/cli_parity/delete.sh](../tests/golden/cli_parity/delete.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | alias for `--delete-during` |


### PR DESCRIPTION
## Summary
- mark `--cvs-exclude` as partially supported in feature matrix
- note failing `tests/cvs_exclude.rs`

## Testing
- `make verify-comments`
- `make lint` *(fails: collapsible if lint and formatting issues)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `cargo test --workspace` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bba9aa6cc08323a38e463da374647c