### PR TITLE
chore: include rpm source paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,15 +139,15 @@ requires = ["zlib", "libzstd"]
 [package.metadata.rpm.targets.oc-rsync]
 path = "/usr/bin/oc-rsync"
 
-[package.metadata.rpm.files."oc-rsyncd.conf"]
+[package.metadata.rpm.files.".rpm/oc-rsyncd.conf"]
 path = "/usr/share/doc/oc-rsync/examples/oc-rsyncd.conf"
 mode = "644"
 
-[package.metadata.rpm.files."oc-rsyncd.systemd.conf"]
+[package.metadata.rpm.files.".rpm/oc-rsyncd.systemd.conf"]
 path = "/usr/share/doc/oc-rsync/examples/oc-rsyncd.systemd.conf"
 mode = "644"
 
-[package.metadata.rpm.files."oc-rsyncd.service"]
+[package.metadata.rpm.files.".rpm/oc-rsyncd.service"]
 path = "/usr/lib/systemd/system/oc-rsyncd.service"
 mode = "644"
 


### PR DESCRIPTION
## Summary
- include `.rpm` directory in rpm file mappings

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: collapsible-if warnings in daemon and engine)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `make verify-comments`
- `make lint` *(fails: collapsible-if warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf54707308323a8a325a789963aff