### PR TITLE
Handle null-delimited stdin filters

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1636,7 +1636,7 @@ pub fn parse_list(input: &[u8], from0: bool) -> Vec<String> {
 fn read_path_or_stdin(path: &Path) -> io::Result<Vec<u8>> {
     if path == Path::new("-") {
         let mut buf = Vec::new();
-        std::io::stdin().read_to_end(&mut buf)?;
+        std::io::stdin().lock().read_to_end(&mut buf)?;
         Ok(buf)
     } else {
         fs::read(path)
@@ -1690,7 +1690,13 @@ pub fn parse_file(
     depth: usize,
 ) -> Result<Vec<Rule>, ParseError> {
     let data = read_path_or_stdin(path)?;
-    parse_from_bytes(&data, from0, visited, depth, Some(path.to_path_buf()))
+    let from0 = from0 || path == Path::new("-");
+    let source = if path == Path::new("-") {
+        None
+    } else {
+        Some(path.to_path_buf())
+    };
+    parse_from_bytes(&data, from0, visited, depth, source)
 }
 
 pub fn parse_rule_list_from_bytes(

--- a/crates/filters/tests/stdin_from0.rs
+++ b/crates/filters/tests/stdin_from0.rs
@@ -1,0 +1,88 @@
+// crates/filters/tests/stdin_from0.rs
+use filters::{parse_file, Matcher};
+use std::collections::HashSet;
+use std::fs;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use tempfile::{tempdir, tempfile};
+
+#[cfg(unix)]
+use std::os::unix::io::IntoRawFd;
+
+#[cfg(unix)]
+#[test]
+fn null_separated_filters_from_stdin_match_rsync() {
+    let mut tmpfile = tempfile().unwrap();
+    tmpfile.write_all(b"+ foo\0+ bar\0- *\0").unwrap();
+    tmpfile.seek(SeekFrom::Start(0)).unwrap();
+
+    let stdin_fd = unsafe { libc::dup(0) };
+    let file_fd = tmpfile.into_raw_fd();
+    assert!(unsafe { libc::dup2(file_fd, 0) } >= 0);
+    unsafe { libc::close(file_fd) };
+
+    let mut visited = HashSet::new();
+    let rules = parse_file(Path::new("-"), false, &mut visited, 0).unwrap();
+    let matcher = Matcher::new(rules);
+
+    assert!(matcher.is_included("foo").unwrap());
+    assert!(matcher.is_included("bar").unwrap());
+    assert!(!matcher.is_included("baz").unwrap());
+
+    assert!(unsafe { libc::dup2(stdin_fd, 0) } >= 0);
+    unsafe { libc::close(stdin_fd) };
+
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("foo"), "").unwrap();
+    fs::write(src.join("bar"), "").unwrap();
+    fs::write(src.join("baz"), "").unwrap();
+    let dest = tmp.path().join("dest");
+    fs::create_dir_all(&dest).unwrap();
+
+    let mut child = Command::new("rsync")
+        .arg("-r")
+        .arg("-n")
+        .arg("-i")
+        .arg("--from0")
+        .arg("--filter=merge,-")
+        .arg(format!("{}/", src.display()))
+        .arg(dest.to_str().unwrap())
+        .stdin(Stdio::piped())
+        .spawn()
+        .unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        stdin.write_all(b"+ foo\0+ bar\0- *\0").unwrap();
+    }
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut rsync_included = Vec::new();
+    for line in stdout.lines() {
+        if line.starts_with("sending ") || line.starts_with("sent ") || line.starts_with("total ") {
+            continue;
+        }
+        if let Some(name) = line.split_whitespace().last() {
+            rsync_included.push(name.to_string());
+        }
+    }
+    assert_eq!(
+        matcher.is_included("foo").unwrap(),
+        rsync_included.contains(&"foo".to_string())
+    );
+    assert_eq!(
+        matcher.is_included("bar").unwrap(),
+        rsync_included.contains(&"bar".to_string())
+    );
+    assert_eq!(
+        matcher.is_included("baz").unwrap(),
+        rsync_included.contains(&"baz".to_string())
+    );
+}


### PR DESCRIPTION
## Summary
- Support reading null-delimited rules from stdin when filter path is "-"
- Add rsync parity test for null-separated filters streamed via stdin

## Testing
- `make verify-comments`
- `make lint` *(fails: clippy collapsible_if in daemon and engine)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: linker cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linker cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf5c69bb48323a29a139717413f93