### PR TITLE
ci: generate coverage lcov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,14 @@ jobs:
         run: cargo nextest run --workspace --no-fail-fast --features "cli nightly"
       - name: Test with coverage (95% lines & functions)
         if: steps.install_nextest.outcome == 'success' && steps.install_llvm_cov.outcome == 'success'
-        run: cargo llvm-cov nextest --workspace --features "cli nightly" --fail-under-lines 95 --fail-under-functions 95 --html -- --no-fail-fast
+        run: |
+          cargo llvm-cov nextest --workspace --features "cli nightly" \
+            --fail-under-lines 95 --fail-under-functions 95 \
+            --lcov --output-path coverage.lcov -- --no-fail-fast
+
+      - name: Verify coverage file exists
+        if: steps.install_nextest.outcome == 'success' && steps.install_llvm_cov.outcome == 'success'
+        run: ls -l coverage.lcov
 
       - name: Upload coverage report
         if: steps.install_nextest.outcome == 'success' && steps.install_llvm_cov.outcome == 'success'


### PR DESCRIPTION
## Summary
- produce lcov coverage report and verify file before uploading to Codecov

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: 161 failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*
- `make verify-comments`
- `make lint` *(fails: formatting issues in xtask/src/bin/comment_lint.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf538ebf88323a1da809824314a47