### PR TITLE
ci: fail interop job on mismatches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
   interop:
     needs: test-linux
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- fail CI when interop tests report mismatches

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: `let` expressions in this position are unstable)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: use of unstable library feature `stdarch_x86_avx512`)*
- `make verify-comments`
- `make lint` *(fails: diff in xtask/src/bin/comment_lint.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf54079fc83239b45a36ed0c1fc5c