### PR TITLE
docs: update filter status

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -196,6 +196,7 @@ Classic `rsync` protocol versions 30–32 are supported.
 | Feature | Status | Tests | Source | Notes |
 | --- | --- | --- | --- | --- |
 | `.rsync-filter` merge semantics | Implemented | [crates/filters/tests/merge.rs](../crates/filters/tests/merge.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) | |
+| CVS ignore semantics (`--cvs-exclude`) | Partial | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) | parity with upstream rules incomplete |
 | Additional rule modifiers | Partial | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) | [#268](https://github.com/oferchen/oc-rsync/issues/268) |
 
 ## Metadata

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -71,6 +71,8 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | `.rsync-filter` merge semantics | Implemented | [crates/filters/tests/merge.rs](../crates/filters/tests/merge.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Null-delimited filter lists and merges (`--from0`) | Implemented | [crates/filters/tests/include_from.rs](../crates/filters/tests/include_from.rs)<br>[crates/filters/tests/from0_merges.rs](../crates/filters/tests/from0_merges.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Rule logging and statistics | Implemented | [crates/filters/tests/rule_stats.rs](../crates/filters/tests/rule_stats.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| Additional rule modifiers | Partial | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs)<br>[#268](https://github.com/oferchen/oc-rsync/issues/268) |
+| CVS ignore semantics (`--cvs-exclude`) | Partial | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 
 ## File Selection
 | Feature | Status | Tests | Source |


### PR DESCRIPTION
## Summary
- document outstanding filter gaps

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: collapsible-if)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: multiple test failures, run interrupted)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(linker missing libacl; rerun aborted)*
- `make verify-comments`
- `make lint` *(fails: collapsible-if)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf5ca76b48323996e281ae2552edb