### PR TITLE
Ensure root path inclusion in filters

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -246,6 +246,10 @@ impl Matcher {
             }
         }
 
+        if path.as_os_str().is_empty() {
+            return Ok((true, false));
+        }
+
         let mut seq = 0usize;
         let mut active: Vec<(usize, usize, usize, Rule)> = Vec::new();
 

--- a/crates/filters/tests/root_inclusion.rs
+++ b/crates/filters/tests/root_inclusion.rs
@@ -1,0 +1,15 @@
+// crates/filters/tests/root_inclusion.rs
+use filters::{parse, Matcher};
+use std::collections::HashSet;
+
+fn m(input: &str) -> Matcher {
+    let mut v = HashSet::new();
+    Matcher::new(parse(input, &mut v, 0).unwrap())
+}
+
+#[test]
+fn source_root_is_included_despite_global_exclude() {
+    let matcher = m("- *\n");
+    assert!(matcher.is_included("").unwrap());
+    assert!(!matcher.is_included("something").unwrap());
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2683,6 +2683,7 @@ fn include_pattern_allows_file() {
 
     assert!(dst.join("keep.txt").exists());
     assert!(!dst.join("skip.txt").exists());
+    assert_eq!(fs::read_dir(&dst).unwrap().count(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- prevent filter rules from excluding the source root
- test root inclusion despite `- *`
- verify CLI includes files when using `--include keep.txt --exclude '*'`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(command interrupted: build warnings)*
- `make verify-comments`
- `make lint` *(fails: formatting differences)*

------
https://chatgpt.com/codex/tasks/task_e_68bc02976b588323884154b7e748a4ad