### PR TITLE
Handle ancestor rules for files-from

### DIFF
--- a/crates/checksums/benches/rolling.rs
+++ b/crates/checksums/benches/rolling.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "nightly")]
 use checksums::rolling_checksum_avx512;
 use checksums::{rolling_checksum_avx2, rolling_checksum_scalar, rolling_checksum_sse42};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 
 fn bench_rolling(c: &mut Criterion) {
     let data = vec![0u8; 1024 * 1024];

--- a/crates/checksums/tests/golden.rs
+++ b/crates/checksums/tests/golden.rs
@@ -1,5 +1,5 @@
 // crates/checksums/tests/golden.rs
-use checksums::{rolling_checksum, ChecksumConfigBuilder, Rolling, StrongHash};
+use checksums::{ChecksumConfigBuilder, Rolling, StrongHash, rolling_checksum};
 
 #[test]
 fn rolling_golden_windows() {

--- a/crates/checksums/tests/rsync.rs
+++ b/crates/checksums/tests/rsync.rs
@@ -1,5 +1,5 @@
 // crates/checksums/tests/rsync.rs
-use checksums::{strong_digest, StrongHash};
+use checksums::{StrongHash, strong_digest};
 use std::{fs, path::Path};
 
 fn golden(alg: &str, endian: &str) -> String {

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -2,8 +2,7 @@
 use std::env;
 
 pub const DEFAULT_BRAND_VERSION: &str = env!("CARGO_PKG_VERSION");
-pub const DEFAULT_BRAND_CREDITS: &str =
-    "Automatic Rust re-implementation by Ofer Chen (2025). Not affiliated with Rsync team at Samba.";
+pub const DEFAULT_BRAND_CREDITS: &str = "Automatic Rust re-implementation by Ofer Chen (2025). Not affiliated with Rsync team at Samba.";
 pub const DEFAULT_BRAND_URL: &str = "https://github.com/oferchen/oc-rsync";
 
 pub const DEFAULT_TAGLINE: &str = "Pure-Rust reimplementation of rsync (protocol v32).";

--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -12,11 +12,11 @@ use std::time::{Duration, Instant};
 
 use crate::utils::{parse_bool, parse_dparam};
 use clap::{ArgMatches, Args};
-use daemon::{parse_config_file, parse_module, Module};
+use daemon::{Module, parse_config_file, parse_module};
 use engine::{EngineError, Result, SyncOptions};
 use logging::parse_escapes;
-use protocol::{negotiate_version, CharsetConv, ExitCode};
-use transport::{parse_sockopts, AddressFamily, SockOpt, TcpTransport, Transport};
+use protocol::{CharsetConv, ExitCode, negotiate_version};
+use transport::{AddressFamily, SockOpt, TcpTransport, Transport, parse_sockopts};
 
 #[derive(Args, Debug, Clone)]
 pub struct DaemonOpts {

--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -3,7 +3,7 @@ use clap::Command;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::env;
-use textwrap::{wrap, Options as WrapOptions};
+use textwrap::{Options as WrapOptions, wrap};
 
 use crate::branding;
 

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -6,8 +6,8 @@ use std::{ffi::OsString, path::PathBuf};
 pub use crate::daemon::DaemonOpts;
 use crate::formatter;
 use crate::utils::{
-    parse_duration, parse_minutes, parse_nonzero_duration, parse_rsh, parse_size, parse_stop_at,
-    RshCommand,
+    RshCommand, parse_duration, parse_minutes, parse_nonzero_duration, parse_rsh, parse_size,
+    parse_stop_at,
 };
 use clap::{Arg, ArgAction, Args, CommandFactory, Parser, ValueEnum};
 use logging::{DebugFlag, InfoFlag, StderrMode};

--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -8,15 +8,15 @@ use std::{ffi::OsStr, io, path::PathBuf};
 
 use clap::ArgMatches;
 use encoding_rs::Encoding;
-use filters::{parse_with_options, Rule};
+use filters::{Rule, parse_with_options};
 use logging::{DebugFlag, InfoFlag, StderrMode, SubscriberConfig};
-use meta::{parse_id_map, IdKind};
+use meta::{IdKind, parse_id_map};
 use protocol::CharsetConv;
 use shell_words::split as shell_split;
 
 use engine::{EngineError, IdMapper, Result};
 
-use time::{macros::format_description, PrimitiveDateTime};
+use time::{PrimitiveDateTime, macros::format_description};
 
 use crate::version;
 

--- a/crates/cli/tests/arg_order.rs
+++ b/crates/cli/tests/arg_order.rs
@@ -1,5 +1,5 @@
 // crates/cli/tests/arg_order.rs
-use oc_rsync_cli::{cli_command, ARG_ORDER};
+use oc_rsync_cli::{ARG_ORDER, cli_command};
 
 const SKIP_ARGS: &[&str] = &[
     "config",

--- a/crates/cli/tests/arg_order_help.rs
+++ b/crates/cli/tests/arg_order_help.rs
@@ -1,5 +1,5 @@
 // crates/cli/tests/arg_order_help.rs
-use oc_rsync_cli::{cli_command, ARG_ORDER};
+use oc_rsync_cli::{ARG_ORDER, cli_command};
 use std::collections::{HashMap, HashSet};
 
 const HELP_TEXT: &str = include_str!("../resources/rsync-help-80.txt");

--- a/crates/cli/tests/cli_parity.rs
+++ b/crates/cli/tests/cli_parity.rs
@@ -168,7 +168,9 @@ fn misuse_matches_upstream() {
     let our_lines: Vec<_> = ours_stderr.lines().collect();
     assert_eq!(ours.status.code(), Some(1));
     assert_eq!(our_lines.get(0), golden_lines.get(0));
-    assert!(our_lines
-        .get(1)
-        .map_or(false, |l| l.starts_with(golden_lines[1])));
+    assert!(
+        our_lines
+            .get(1)
+            .map_or(false, |l| l.starts_with(golden_lines[1]))
+    );
 }

--- a/crates/cli/tests/drive_letters.rs
+++ b/crates/cli/tests/drive_letters.rs
@@ -1,7 +1,7 @@
 // crates/cli/tests/drive_letters.rs
 #![cfg(windows)]
 
-use oc_rsync_cli::{parse_remote_spec, RemoteSpec};
+use oc_rsync_cli::{RemoteSpec, parse_remote_spec};
 use std::ffi::OsStr;
 
 #[test]

--- a/crates/cli/tests/logging_flags.rs
+++ b/crates/cli/tests/logging_flags.rs
@@ -2,8 +2,8 @@
 use clap::ValueEnum;
 use logging::SubscriberConfig;
 use oc_rsync_cli::{cli_command, parse_logging_flags};
-use tracing::subscriber::with_default;
 use tracing::Level;
+use tracing::subscriber::with_default;
 
 fn make_sub(
     format: logging::LogFormat,

--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -1,6 +1,6 @@
 // crates/compress/tests/codecs.rs
 use compress::{
-    available_codecs, decode_codecs, encode_codecs, negotiate_codec, should_compress, Codec,
+    Codec, available_codecs, decode_codecs, encode_codecs, negotiate_codec, should_compress,
 };
 
 #[cfg(any(feature = "zlib", feature = "zstd"))]

--- a/crates/daemon/src/lib.rs
+++ b/crates/daemon/src/lib.rs
@@ -6,19 +6,19 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
-use std::sync::{atomic::AtomicUsize, atomic::Ordering, Arc};
+use std::sync::{Arc, atomic::AtomicUsize, atomic::Ordering};
 use std::time::{Duration, Instant};
 
 #[cfg(unix)]
 use nix::sys::wait::waitpid;
 #[cfg(unix)]
-use nix::unistd::{fork, setsid, ForkResult};
+use nix::unistd::{ForkResult, fork, setsid};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 
 use ipnet::IpNet;
 use logging::{DebugFlag, InfoFlag, LogFormat, StderrMode, SubscriberConfig};
-use protocol::{negotiate_version, SUPPORTED_PROTOCOLS};
+use protocol::{SUPPORTED_PROTOCOLS, negotiate_version};
 #[cfg(unix)]
 use sd_notify::{self, NotifyState};
 use transport::{AddressFamily, RateLimitedTransport, TcpTransport, TimeoutTransport, Transport};
@@ -44,7 +44,7 @@ pub struct PrivilegeContext {
 #[cfg(unix)]
 impl Drop for PrivilegeContext {
     fn drop(&mut self) {
-        use nix::unistd::{chroot, fchdir, setegid, seteuid, Gid, Uid};
+        use nix::unistd::{Gid, Uid, chroot, fchdir, setegid, seteuid};
         let _ = setegid(Gid::from_raw(self.gid));
         let _ = seteuid(Uid::from_raw(self.uid));
         if self.use_chroot {
@@ -936,7 +936,7 @@ pub fn drop_privileges(uid: u32, gid: u32) -> io::Result<()> {
         target_os = "haiku",
     )))]
     use nix::unistd::setgroups;
-    use nix::unistd::{getegid, geteuid, setegid, seteuid, Gid, Uid};
+    use nix::unistd::{Gid, Uid, getegid, geteuid, setegid, seteuid};
     let cur_uid = geteuid().as_raw();
     let cur_gid = getegid().as_raw();
     if (uid != cur_uid || gid != cur_gid) && cur_uid != 0 {
@@ -1489,7 +1489,7 @@ mod tests {
     use transport::LocalPipeTransport;
 
     #[cfg(unix)]
-    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::os::unix::fs::{PermissionsExt, symlink};
 
     struct ChunkReader {
         data: Vec<u8>,

--- a/crates/daemon/tests/no_token.rs
+++ b/crates/daemon/tests/no_token.rs
@@ -1,5 +1,5 @@
 // crates/daemon/tests/no_token.rs
-use daemon::{handle_connection, Handler, Module};
+use daemon::{Handler, Module, handle_connection};
 use protocol::SUPPORTED_PROTOCOLS;
 use std::collections::HashMap;
 use std::io::Cursor;

--- a/crates/daemon/tests/sequential_connections.rs
+++ b/crates/daemon/tests/sequential_connections.rs
@@ -1,5 +1,5 @@
 // crates/daemon/tests/sequential_connections.rs
-use daemon::{handle_connection, Handler, Module};
+use daemon::{Handler, Module, handle_connection};
 #[cfg(unix)]
 use nix::unistd::geteuid;
 use protocol::SUPPORTED_PROTOCOLS;

--- a/crates/engine/benches/compress.rs
+++ b/crates/engine/benches/compress.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "zstd")]
 use compress::Zstd;
 use compress::{Compressor, Decompressor};
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 fn bench_compress(c: &mut Criterion) {
     let data = vec![0u8; 1024 * 1024];

--- a/crates/engine/benches/large_files.rs
+++ b/crates/engine/benches/large_files.rs
@@ -1,7 +1,7 @@
 // crates/engine/benches/large_files.rs
 use checksums::ChecksumConfigBuilder;
-use criterion::{criterion_group, criterion_main, Criterion};
-use engine::{compute_delta, SyncOptions};
+use criterion::{Criterion, criterion_group, criterion_main};
+use engine::{SyncOptions, compute_delta};
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
 fn bench_large_delta(c: &mut Criterion) {

--- a/crates/engine/benches/preallocate.rs
+++ b/crates/engine/benches/preallocate.rs
@@ -1,7 +1,7 @@
 // crates/engine/benches/preallocate.rs
 use compress::available_codecs;
-use criterion::{criterion_group, criterion_main, Criterion};
-use engine::{sync, SyncOptions};
+use criterion::{Criterion, criterion_group, criterion_main};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/engine/benches/rolling.rs
+++ b/crates/engine/benches/rolling.rs
@@ -1,6 +1,6 @@
 // crates/engine/benches/rolling.rs
 use checksums::rolling_checksum_seeded;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 fn bench_rolling(c: &mut Criterion) {
     let data = vec![0u8; 1024 * 1024];

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,8 +1,8 @@
 // crates/engine/src/lib.rs
 #![allow(clippy::collapsible_if)]
 #[cfg(unix)]
-use nix::unistd::{chown, Gid, Uid};
-use rand::{distributions::Alphanumeric, Rng};
+use nix::unistd::{Gid, Uid, chown};
+use rand::{Rng, distributions::Alphanumeric};
 use std::any::Any;
 use std::collections::{HashMap, VecDeque};
 use std::ffi::{OsStr, OsString};
@@ -19,13 +19,13 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 use tempfile::Builder;
-use transport::{pipe, Transport};
+use transport::{Transport, pipe};
 
 pub use checksums::StrongHash;
 use checksums::{ChecksumConfig, ChecksumConfigBuilder};
-use compress::{should_compress, Codec, Compressor, Decompressor, Zlib, ZlibX, Zstd};
+use compress::{Codec, Compressor, Decompressor, Zlib, ZlibX, Zstd, should_compress};
 use filters::Matcher;
-use logging::{escape_path, progress_formatter, rate_formatter, InfoFlag};
+use logging::{InfoFlag, escape_path, progress_formatter, rate_formatter};
 use md4::{Digest, Md4};
 use md5::Md5;
 use protocol::ExitCode;
@@ -174,7 +174,7 @@ fn check_time_limit(start: Instant, opts: &SyncOptions) -> Result<()> {
 pub fn preallocate(file: &File, len: u64) -> std::io::Result<()> {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     {
-        use nix::fcntl::{fallocate, FallocateFlags};
+        use nix::fcntl::{FallocateFlags, fallocate};
         fallocate(file, FallocateFlags::empty(), 0, len as i64).map_err(std::io::Error::from)
     }
 
@@ -431,11 +431,7 @@ fn remove_file_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
         Ok(_) => Ok(()),
         Err(e) => {
             let e = io_context(path, e);
-            if opts.ignore_errors {
-                Ok(())
-            } else {
-                Err(e)
-            }
+            if opts.ignore_errors { Ok(()) } else { Err(e) }
         }
     }
 }
@@ -467,11 +463,7 @@ fn remove_dir_opts(path: &Path, opts: &SyncOptions) -> Result<()> {
         Ok(_) => Ok(()),
         Err(e) => {
             let e = io_context(path, e);
-            if opts.ignore_errors {
-                Ok(())
-            } else {
-                Err(e)
-            }
+            if opts.ignore_errors { Ok(()) } else { Err(e) }
         }
     }
 }
@@ -775,7 +767,7 @@ fn write_sparse(file: &mut File, data: &[u8]) -> Result<()> {
             let len = i - start;
             #[cfg(all(unix, any(target_os = "linux", target_os = "android")))]
             {
-                use nix::fcntl::{fallocate, FallocateFlags};
+                use nix::fcntl::{FallocateFlags, fallocate};
 
                 let offset = file.stream_position()?;
                 let _ = fallocate(
@@ -1241,11 +1233,7 @@ impl Sender {
         let existing_partial = if partial_path.exists() {
             Some(partial_path.clone())
         } else if let Some(bp) = basename_partial.as_ref() {
-            if bp.exists() {
-                Some(bp.clone())
-            } else {
-                None
-            }
+            if bp.exists() { Some(bp.clone()) } else { None }
         } else {
             None
         };
@@ -1484,11 +1472,7 @@ impl Receiver {
         let existing_partial = if partial.exists() {
             Some(partial.clone())
         } else if let Some(bp) = basename_partial.as_ref() {
-            if bp.exists() {
-                Some(bp.clone())
-            } else {
-                None
-            }
+            if bp.exists() { Some(bp.clone()) } else { None }
         } else {
             None
         };
@@ -2529,11 +2513,7 @@ fn delete_extraneous(
         }
     }
     if let Some(e) = first_err {
-        if opts.ignore_errors {
-            Ok(())
-        } else {
-            Err(e)
-        }
+        if opts.ignore_errors { Ok(()) } else { Err(e) }
     } else {
         Ok(())
     }
@@ -3186,7 +3166,7 @@ mod tests {
     use filters::Matcher;
     use std::fs;
     use std::io::Write;
-    use tempfile::{tempdir, NamedTempFile};
+    use tempfile::{NamedTempFile, tempdir};
 
     #[test]
     fn delta_roundtrip() {

--- a/crates/engine/tests/append.rs
+++ b/crates/engine/tests/append.rs
@@ -1,6 +1,6 @@
 // crates/engine/tests/append.rs
 use compress::available_codecs;
-use engine::{sync, EngineError, SyncOptions};
+use engine::{EngineError, SyncOptions, sync};
 use filters::Matcher;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -8,14 +8,14 @@ use std::io::{Seek, SeekFrom, Write};
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 
 use compress::available_codecs;
-use engine::{sync, IdMapper, SyncOptions};
-use filetime::{set_file_atime, set_file_mtime, set_file_times, set_symlink_file_times, FileTime};
+use engine::{IdMapper, SyncOptions, sync};
+use filetime::{FileTime, set_file_atime, set_file_mtime, set_file_times, set_symlink_file_times};
 use filters::Matcher;
-use meta::{parse_chmod, parse_chown, parse_id_map, IdKind};
-use nix::sys::stat::{mknod, Mode, SFlag};
-use nix::unistd::{chown, mkfifo, Gid, Uid};
+use meta::{IdKind, parse_chmod, parse_chown, parse_id_map};
+use nix::sys::stat::{Mode, SFlag, mknod};
+use nix::unistd::{Gid, Uid, chown, mkfifo};
 #[cfg(feature = "acl")]
-use posix_acl::{PosixACL, Qualifier, ACL_READ, ACL_WRITE};
+use posix_acl::{ACL_READ, ACL_WRITE, PosixACL, Qualifier};
 use tempfile::tempdir;
 #[cfg(feature = "xattr")]
 use xattr;
@@ -503,7 +503,7 @@ fn symlink_xattrs_roundtrip() {
 #[cfg(feature = "acl")]
 #[test]
 fn acls_roundtrip() {
-    use posix_acl::{PosixACL, Qualifier, ACL_READ};
+    use posix_acl::{ACL_READ, PosixACL, Qualifier};
 
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
@@ -587,7 +587,7 @@ fn acls_roundtrip() {
 #[cfg(feature = "acl")]
 #[test]
 fn acls_imply_perms() {
-    use posix_acl::{PosixACL, Qualifier, ACL_READ};
+    use posix_acl::{ACL_READ, PosixACL, Qualifier};
     use std::os::unix::fs::PermissionsExt;
 
     let tmp = tempdir().unwrap();

--- a/crates/engine/tests/auto_tmp.rs
+++ b/crates/engine/tests/auto_tmp.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::time::Duration;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/backup.rs
+++ b/crates/engine/tests/backup.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, DeleteMode, SyncOptions};
+use engine::{DeleteMode, SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/batch_encoding.rs
+++ b/crates/engine/tests/batch_encoding.rs
@@ -1,5 +1,5 @@
 // crates/engine/tests/batch_encoding.rs
-use engine::{decode_batch, encode_batch, Batch};
+use engine::{Batch, decode_batch, encode_batch};
 
 #[test]
 fn golden_batch_roundtrip() {

--- a/crates/engine/tests/batch_replay.rs
+++ b/crates/engine/tests/batch_replay.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/checksum.rs
+++ b/crates/engine/tests/checksum.rs
@@ -2,8 +2,8 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
-use filetime::{set_file_mtime, FileTime};
+use engine::{SyncOptions, sync};
+use filetime::{FileTime, set_file_mtime};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/cleanup.rs
+++ b/crates/engine/tests/cleanup.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/compress.rs
+++ b/crates/engine/tests/compress.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::Codec;
-use engine::{select_codec, sync, SyncOptions};
+use engine::{SyncOptions, select_codec, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/create_dst.rs
+++ b/crates/engine/tests/create_dst.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/delete.rs
+++ b/crates/engine/tests/delete.rs
@@ -1,7 +1,7 @@
 // crates/engine/tests/delete.rs
 use compress::available_codecs;
-use engine::{sync, DeleteMode, SyncOptions};
-use filters::{parse, Matcher};
+use engine::{DeleteMode, SyncOptions, sync};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/engine/tests/delete_errors.rs
+++ b/crates/engine/tests/delete_errors.rs
@@ -7,9 +7,9 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use compress::available_codecs;
-use engine::{sync, DeleteMode, SyncOptions};
+use engine::{DeleteMode, SyncOptions, sync};
 use filters::Matcher;
-use nix::unistd::{chown, Gid, Uid};
+use nix::unistd::{Gid, Uid, chown};
 use tempfile::tempdir;
 
 #[test]

--- a/crates/engine/tests/filter.rs
+++ b/crates/engine/tests/filter.rs
@@ -1,7 +1,7 @@
 // crates/engine/tests/filter.rs
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
-use filters::{parse, Matcher};
+use engine::{SyncOptions, sync};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/engine/tests/fuzzy.rs
+++ b/crates/engine/tests/fuzzy.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{fuzzy_match, sync, SyncOptions};
+use engine::{SyncOptions, fuzzy_match, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/links.rs
+++ b/crates/engine/tests/links.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::os::unix::fs::MetadataExt;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/max_delete.rs
+++ b/crates/engine/tests/max_delete.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, DeleteMode, SyncOptions};
+use engine::{DeleteMode, SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/missing_args.rs
+++ b/crates/engine/tests/missing_args.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/open_noatime.rs
+++ b/crates/engine/tests/open_noatime.rs
@@ -5,8 +5,8 @@ use std::fs;
 use std::time::SystemTime;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
-use filetime::{set_file_times, FileTime};
+use engine::{SyncOptions, sync};
+use filetime::{FileTime, set_file_times};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/remove_source.rs
+++ b/crates/engine/tests/remove_source.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/resume.rs
+++ b/crates/engine/tests/resume.rs
@@ -1,7 +1,7 @@
 // crates/engine/tests/resume.rs
 use checksums::ChecksumConfigBuilder;
 use compress::available_codecs;
-use engine::{compute_delta, sync, Op, SyncOptions};
+use engine::{Op, SyncOptions, compute_delta, sync};
 use filters::Matcher;
 use std::fs::{self, File};
 use tempfile::tempdir;

--- a/crates/engine/tests/streaming.rs
+++ b/crates/engine/tests/streaming.rs
@@ -1,6 +1,6 @@
 // crates/engine/tests/streaming.rs
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/engine/tests/update.rs
+++ b/crates/engine/tests/update.rs
@@ -1,7 +1,7 @@
 // crates/engine/tests/update.rs
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
-use filetime::{set_file_mtime, FileTime};
+use engine::{SyncOptions, sync};
+use filetime::{FileTime, set_file_mtime};
 use filters::Matcher;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/engine/tests/upstream_batch.rs
+++ b/crates/engine/tests/upstream_batch.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/write_batch.rs
+++ b/crates/engine/tests/write_batch.rs
@@ -2,7 +2,7 @@
 use std::fs;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
 use tempfile::tempdir;
 

--- a/crates/engine/tests/write_devices.rs
+++ b/crates/engine/tests/write_devices.rs
@@ -5,9 +5,9 @@ use std::fs;
 use std::os::unix::fs::FileTypeExt;
 
 use compress::available_codecs;
-use engine::{sync, SyncOptions};
+use engine::{SyncOptions, sync};
 use filters::Matcher;
-use nix::sys::stat::{mknod, Mode, SFlag};
+use nix::sys::stat::{Mode, SFlag, mknod};
 use tempfile::tempdir;
 
 #[test]

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -993,11 +993,7 @@ fn decode_line(raw: &str) -> Option<String> {
         last_non_space = out.len();
     }
     out.truncate(last_non_space);
-    if out.is_empty() {
-        None
-    } else {
-        Some(out)
-    }
+    if out.is_empty() { None } else { Some(out) }
 }
 
 pub fn parse_with_options(
@@ -1412,7 +1408,7 @@ pub fn parse_with_options(
                     let sub = match parse_file(&path, from0, visited, depth + 1) {
                         Ok(r) => r,
                         Err(ParseError::Io(_)) => {
-                            return Err(ParseError::InvalidRule(raw_line.to_string()))
+                            return Err(ParseError::InvalidRule(raw_line.to_string()));
                         }
                         Err(e) => return Err(e),
                     };
@@ -1780,7 +1776,7 @@ mod tests {
     #[cfg(unix)]
     use std::os::unix::io::IntoRawFd;
     use std::path::Path;
-    use tempfile::{tempfile, NamedTempFile};
+    use tempfile::{NamedTempFile, tempfile};
 
     #[test]
     fn reads_from_file() {

--- a/crates/filters/tests/anchored_dir_merge.rs
+++ b/crates/filters/tests/anchored_dir_merge.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/anchored_dir_merge.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/anchored_wildcards.rs
+++ b/crates/filters/tests/anchored_wildcards.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/anchored_wildcards.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 
 fn p(input: &str) -> Vec<filters::Rule> {

--- a/crates/filters/tests/basic.rs
+++ b/crates/filters/tests/basic.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/basic.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 
 fn m(input: &str) -> Matcher {

--- a/crates/filters/tests/comments.rs
+++ b/crates/filters/tests/comments.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/comments.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 
 fn p(input: &str) -> Vec<filters::Rule> {

--- a/crates/filters/tests/cvs_rules.rs
+++ b/crates/filters/tests/cvs_rules.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/cvs_rules.rs
-use filters::{default_cvs_rules, parse, Matcher};
+use filters::{Matcher, default_cvs_rules, parse};
 use std::collections::HashSet;
 use std::env;
 use std::fs;

--- a/crates/filters/tests/escaped_patterns.rs
+++ b/crates/filters/tests/escaped_patterns.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/escaped_patterns.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 
 fn p(s: &str) -> Matcher {

--- a/crates/filters/tests/existing_prune.rs
+++ b/crates/filters/tests/existing_prune.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/existing_prune.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/files_from.rs
+++ b/crates/filters/tests/files_from.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/files_from.rs
-use filters::{parse, parse_with_options, Matcher};
+use filters::{Matcher, parse, parse_with_options};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/from0_merges.rs
+++ b/crates/filters/tests/from0_merges.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/from0_merges.rs
-use filters::{parse, parse_list, parse_with_options, Matcher};
+use filters::{Matcher, parse, parse_list, parse_with_options};
 use proptest::prelude::*;
 use std::collections::HashSet;
 use std::fs;

--- a/crates/filters/tests/include_exclude.rs
+++ b/crates/filters/tests/include_exclude.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/include_exclude.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use proptest::prelude::*;
 use std::collections::HashSet;
 

--- a/crates/filters/tests/include_from.rs
+++ b/crates/filters/tests/include_from.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/include_from.rs
-use filters::{parse_rule_list_from_bytes, Matcher};
+use filters::{Matcher, parse_rule_list_from_bytes};
 use proptest::prelude::*;
 use std::collections::HashSet;
 

--- a/crates/filters/tests/include_merge.rs
+++ b/crates/filters/tests/include_merge.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/include_merge.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/info_filter.rs
+++ b/crates/filters/tests/info_filter.rs
@@ -2,16 +2,16 @@
 use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 
-use filters::{parse_file, Matcher};
+use filters::{Matcher, parse_file};
 use logging::InfoFlag;
 use std::collections::HashSet;
 use tempfile::NamedTempFile;
 use tracing::level_filters::LevelFilter;
 use tracing::subscriber::with_default;
 use tracing_subscriber::{
+    EnvFilter,
     fmt::{self, writer::MakeWriter},
     layer::SubscriberExt,
-    EnvFilter,
 };
 
 #[derive(Clone, Default)]

--- a/crates/filters/tests/list_files.rs
+++ b/crates/filters/tests/list_files.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/list_files.rs
-use filters::{parse_with_options, Matcher};
+use filters::{Matcher, parse_with_options};
 use std::collections::HashSet;
 use std::fs;
 

--- a/crates/filters/tests/malformed.rs
+++ b/crates/filters/tests/malformed.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/malformed.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/merge.rs
+++ b/crates/filters/tests/merge.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/merge.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use proptest::prelude::*;
 use std::collections::HashSet;
 

--- a/crates/filters/tests/merge_order.rs
+++ b/crates/filters/tests/merge_order.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/merge_order.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/merge_same_index.rs
+++ b/crates/filters/tests/merge_same_index.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/merge_same_index.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/nested_filter_cache.rs
+++ b/crates/filters/tests/nested_filter_cache.rs
@@ -1,6 +1,6 @@
 // crates/filters/tests/nested_filter_cache.rs
 
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use std::thread::sleep;

--- a/crates/filters/tests/nested_merge.rs
+++ b/crates/filters/tests/nested_merge.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/nested_merge.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use proptest::prelude::*;
 use std::collections::HashSet;
 use std::fs;

--- a/crates/filters/tests/recursive_filters.rs
+++ b/crates/filters/tests/recursive_filters.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/recursive_filters.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/rsync_filter_files.rs
+++ b/crates/filters/tests/rsync_filter_files.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/rsync_filter_files.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use proptest::prelude::*;
 use std::collections::HashSet;
 use std::fs;

--- a/crates/filters/tests/rsync_parity.rs
+++ b/crates/filters/tests/rsync_parity.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/rsync_parity.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/rsync_property.rs
+++ b/crates/filters/tests/rsync_property.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/rsync_property.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use proptest::prelude::*;
 use std::collections::HashSet;
 use std::fs;

--- a/crates/filters/tests/rule_modifiers.rs
+++ b/crates/filters/tests/rule_modifiers.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/rule_modifiers.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/crates/filters/tests/rule_prefixes.rs
+++ b/crates/filters/tests/rule_prefixes.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/rule_prefixes.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use proptest::prelude::*;
 use std::collections::HashSet;
 use std::fs;

--- a/crates/filters/tests/rule_stats.rs
+++ b/crates/filters/tests/rule_stats.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/rule_stats.rs
-use filters::{parse_file, Matcher};
+use filters::{Matcher, parse_file};
 use std::collections::HashSet;
 use tempfile::NamedTempFile;
 

--- a/crates/filters/tests/stdin_from0.rs
+++ b/crates/filters/tests/stdin_from0.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/stdin_from0.rs
-use filters::{parse_file, Matcher};
+use filters::{Matcher, parse_file};
 use std::collections::HashSet;
 use std::fs;
 use std::io::{Seek, SeekFrom, Write};

--- a/crates/logging/src/formatter.rs
+++ b/crates/logging/src/formatter.rs
@@ -2,10 +2,10 @@
 use crate::parse_escapes;
 use std::collections::HashMap;
 use std::fmt;
-use time::{macros::format_description, OffsetDateTime};
+use time::{OffsetDateTime, macros::format_description};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Subscriber};
-use tracing_subscriber::fmt::{format::Writer, FmtContext, FormatEvent, FormatFields};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, format::Writer};
 use tracing_subscriber::registry::LookupSpan;
 
 pub struct RsyncFormatter {

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -9,16 +9,15 @@ use std::os::unix::ffi::OsStrExt;
 #[cfg(all(unix, any(feature = "syslog", feature = "journald")))]
 use std::os::unix::net::UnixDatagram;
 use std::path::{Path, PathBuf};
-use time::{macros::format_description, OffsetDateTime};
+use time::{OffsetDateTime, macros::format_description};
 use tracing::field::{Field, Visit};
 use tracing::level_filters::LevelFilter;
 use tracing::{Event, Level, Subscriber};
 use tracing_subscriber::{
-    fmt as tracing_fmt,
+    EnvFilter, fmt as tracing_fmt,
     fmt::MakeWriter,
     layer::{Context, Layer, SubscriberExt},
     util::SubscriberInitExt,
-    EnvFilter,
 };
 
 mod formatter;

--- a/crates/logging/tests/info_flags.rs
+++ b/crates/logging/tests/info_flags.rs
@@ -7,9 +7,9 @@ use logging::InfoFlag;
 use tracing::level_filters::LevelFilter;
 use tracing::subscriber::with_default;
 use tracing_subscriber::{
+    EnvFilter,
     fmt::{self, writer::MakeWriter},
     layer::SubscriberExt,
-    EnvFilter,
 };
 
 #[derive(Clone, Default)]

--- a/crates/logging/tests/journald.rs
+++ b/crates/logging/tests/journald.rs
@@ -1,7 +1,7 @@
 // crates/logging/tests/journald.rs
 #![cfg(all(unix, feature = "journald"))]
 
-use logging::{init, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
+use logging::{DebugFlag, InfoFlag, LogFormat, SubscriberConfig, init};
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::info;

--- a/crates/logging/tests/levels.rs
+++ b/crates/logging/tests/levels.rs
@@ -1,7 +1,7 @@
 // crates/logging/tests/levels.rs
-use logging::{subscriber, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
-use tracing::subscriber::with_default;
+use logging::{DebugFlag, InfoFlag, LogFormat, SubscriberConfig, subscriber};
 use tracing::Level;
+use tracing::subscriber::with_default;
 
 #[test]
 fn info_not_emitted_by_default() {

--- a/crates/logging/tests/log_file_error.rs
+++ b/crates/logging/tests/log_file_error.rs
@@ -1,6 +1,6 @@
 // crates/logging/tests/log_file_error.rs
 
-use logging::{subscriber, SubscriberConfig};
+use logging::{SubscriberConfig, subscriber};
 use tempfile::tempdir;
 
 #[test]

--- a/crates/logging/tests/syslog.rs
+++ b/crates/logging/tests/syslog.rs
@@ -1,7 +1,7 @@
 // crates/logging/tests/syslog.rs
 #![cfg(all(unix, feature = "syslog"))]
 
-use logging::{init, DebugFlag, InfoFlag, LogFormat, SubscriberConfig};
+use logging::{DebugFlag, InfoFlag, LogFormat, SubscriberConfig, init};
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::info;

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -25,7 +25,7 @@ mod stub;
 pub use stub::*;
 
 mod parse;
-pub use parse::{parse_chmod, parse_chmod_spec, parse_chown, parse_id_map, IdKind};
+pub use parse::{IdKind, parse_chmod, parse_chmod_spec, parse_chown, parse_id_map};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MetaOpts {
@@ -84,7 +84,7 @@ impl Options {
 
 #[cfg(unix)]
 use filetime::set_symlink_file_times;
-use filetime::{set_file_times, FileTime};
+use filetime::{FileTime, set_file_times};
 use std::collections::HashMap;
 #[cfg(unix)]
 use std::collections::HashSet;
@@ -313,4 +313,4 @@ impl UidTable {
 }
 
 #[cfg(unix)]
-pub use posix_acl::{ACLEntry, PosixACL, Qualifier, ACL_EXECUTE, ACL_READ, ACL_RWX, ACL_WRITE};
+pub use posix_acl::{ACL_EXECUTE, ACL_READ, ACL_RWX, ACL_WRITE, ACLEntry, PosixACL, Qualifier};

--- a/crates/meta/src/parse.rs
+++ b/crates/meta/src/parse.rs
@@ -1,5 +1,5 @@
 // crates/meta/src/parse.rs
-use crate::{normalize_mode, Chmod, ChmodOp, ChmodTarget};
+use crate::{Chmod, ChmodOp, ChmodTarget, normalize_mode};
 use std::result::Result as StdResult;
 use std::sync::Arc;
 

--- a/crates/meta/src/unix.rs
+++ b/crates/meta/src/unix.rs
@@ -8,7 +8,7 @@ use crate::normalize_mode;
 use caps::{CapSet, Capability};
 use filetime::{self, FileTime};
 use nix::errno::Errno;
-use nix::fcntl::{AtFlags, AT_FDCWD};
+use nix::fcntl::{AT_FDCWD, AtFlags};
 use nix::sys::stat::{self, FchmodatFlags, Mode, SFlag};
 use nix::unistd::{self, Gid, Uid};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -70,7 +70,7 @@ pub fn xattrs_supported() -> bool {
 
 #[cfg(feature = "acl")]
 pub fn acls_supported() -> bool {
-    use posix_acl::{PosixACL, Qualifier, ACL_READ};
+    use posix_acl::{ACL_READ, PosixACL, Qualifier};
     *ACLS_SUPPORTED.get_or_init(|| {
         let path = std::env::temp_dir().join("oc_rsync_acl_check");
         if fs::write(&path, b"1").is_err() {
@@ -924,7 +924,7 @@ fn store_fake_super_acl(
 
 #[cfg(target_os = "linux")]
 fn get_file_crtime(path: &Path) -> io::Result<Option<FileTime>> {
-    use libc::{statx, AT_FDCWD, AT_STATX_SYNC_AS_STAT, STATX_BTIME};
+    use libc::{AT_FDCWD, AT_STATX_SYNC_AS_STAT, STATX_BTIME, statx};
     use std::ffi::CString;
     use std::mem::MaybeUninit;
     use std::os::unix::ffi::OsStrExt;
@@ -981,7 +981,7 @@ fn get_file_crtime(_path: &Path) -> io::Result<Option<FileTime>> {
 
 #[cfg(target_os = "macos")]
 fn set_file_crtime(path: &Path, crtime: FileTime) -> io::Result<()> {
-    use libc::{attrlist, setattrlist, timespec, ATTR_BIT_MAP_COUNT, ATTR_CMN_CRTIME};
+    use libc::{ATTR_BIT_MAP_COUNT, ATTR_CMN_CRTIME, attrlist, setattrlist, timespec};
     use std::ffi::CString;
     use std::mem;
 
@@ -1069,10 +1069,11 @@ mod tests {
                 ..Default::default()
             },
         )?;
-        assert!(meta
-            .xattrs
-            .iter()
-            .all(|(name, _)| name != "user.disappearing"));
+        assert!(
+            meta.xattrs
+                .iter()
+                .all(|(name, _)| name != "user.disappearing")
+        );
         Ok(())
     }
 }

--- a/crates/meta/src/windows.rs
+++ b/crates/meta/src/windows.rs
@@ -1,5 +1,5 @@
 // crates/meta/src/windows.rs
-use filetime::{set_file_times, FileTime};
+use filetime::{FileTime, set_file_times};
 #[cfg(feature = "acl")]
 use posix_acl::ACLEntry;
 #[cfg(feature = "xattr")]

--- a/crates/meta/tests/acl_codec.rs
+++ b/crates/meta/tests/acl_codec.rs
@@ -1,8 +1,8 @@
 // crates/meta/tests/acl_codec.rs
 #![cfg(feature = "acl")]
 
-use meta::{decode_acl, encode_acl, Metadata, Options};
-use posix_acl::{PosixACL, Qualifier, ACL_READ};
+use meta::{Metadata, Options, decode_acl, encode_acl};
+use posix_acl::{ACL_READ, PosixACL, Qualifier};
 use std::fs;
 use tempfile::tempdir;
 

--- a/crates/meta/tests/acl_gid.rs
+++ b/crates/meta/tests/acl_gid.rs
@@ -1,8 +1,8 @@
 // crates/meta/tests/acl_gid.rs
 #![cfg(feature = "acl")]
 use meta::{Metadata, Options};
-use nix::unistd::{chown, Gid};
-use posix_acl::{PosixACL, Qualifier, ACL_READ};
+use nix::unistd::{Gid, chown};
+use posix_acl::{ACL_READ, PosixACL, Qualifier};
 use std::fs;
 use tempfile::tempdir;
 

--- a/crates/meta/tests/acl_prune.rs
+++ b/crates/meta/tests/acl_prune.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "acl")]
 
 use meta::{encode_acl, read_acl, write_acl};
-use posix_acl::{PosixACL, Qualifier, ACL_READ};
+use posix_acl::{ACL_READ, PosixACL, Qualifier};
 use std::fs;
 use tempfile::tempdir;
 

--- a/crates/meta/tests/acl_roundtrip.rs
+++ b/crates/meta/tests/acl_roundtrip.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "acl")]
 
 use meta::{read_acl, write_acl};
-use posix_acl::{PosixACL, Qualifier, ACL_READ};
+use posix_acl::{ACL_READ, PosixACL, Qualifier};
 use std::fs;
 use tempfile::tempdir;
 

--- a/crates/meta/tests/chmod.rs
+++ b/crates/meta/tests/chmod.rs
@@ -2,9 +2,9 @@
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 
-use meta::{normalize_mode, parse_chmod, Metadata, Options};
+use meta::{Metadata, Options, normalize_mode, parse_chmod};
 use nix::fcntl::AT_FDCWD;
-use nix::sys::stat::{fchmodat, FchmodatFlags, Mode};
+use nix::sys::stat::{FchmodatFlags, Mode, fchmodat};
 use tempfile::tempdir;
 
 #[test]

--- a/crates/meta/tests/chown_nonroot.rs
+++ b/crates/meta/tests/chown_nonroot.rs
@@ -3,7 +3,7 @@ use std::fs::{self, Permissions};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 use meta::{Metadata, Options};
-use nix::unistd::{setgid, setuid, Gid, Uid};
+use nix::unistd::{Gid, Uid, setgid, setuid};
 use tempfile::tempdir;
 use users::get_user_by_name;
 

--- a/crates/meta/tests/gid_table.rs
+++ b/crates/meta/tests/gid_table.rs
@@ -1,5 +1,5 @@
 // crates/meta/tests/gid_table.rs
-use meta::{parse_chown, parse_id_map, GidTable, IdKind};
+use meta::{GidTable, IdKind, parse_chown, parse_id_map};
 
 #[test]
 fn gid_table_deduplicates_and_indexes() {

--- a/crates/meta/tests/id_map.rs
+++ b/crates/meta/tests/id_map.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::sync::Arc;
 
 use meta::{Metadata, Options};
-use nix::unistd::{chown, Gid, Uid};
+use nix::unistd::{Gid, Uid, chown};
 use tempfile::tempdir;
 
 #[test]

--- a/crates/meta/tests/numeric_ids_nonroot.rs
+++ b/crates/meta/tests/numeric_ids_nonroot.rs
@@ -4,7 +4,7 @@ use std::fs::{self, Permissions};
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 use meta::{Metadata, Options};
-use nix::unistd::{setgid, setuid, Gid, Uid};
+use nix::unistd::{Gid, Uid, setgid, setuid};
 use tempfile::tempdir;
 use users::get_user_by_name;
 

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -6,7 +6,7 @@ use std::os::unix::fs::PermissionsExt;
 use filetime::FileTime;
 use meta::{Metadata, Options};
 use nix::fcntl::AT_FDCWD;
-use nix::unistd::{chown, geteuid, Gid, Uid};
+use nix::unistd::{Gid, Uid, chown, geteuid};
 use std::time::SystemTime;
 use tempfile::tempdir;
 

--- a/crates/meta/tests/uid_table.rs
+++ b/crates/meta/tests/uid_table.rs
@@ -1,5 +1,5 @@
 // crates/meta/tests/uid_table.rs
-use meta::{parse_chown, parse_id_map, IdKind, UidTable};
+use meta::{IdKind, UidTable, parse_chown, parse_id_map};
 
 #[test]
 fn uid_table_deduplicates_and_indexes() {

--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -2,14 +2,14 @@
 use std::io::{self, Read, Write};
 use std::time::Duration;
 
-use checksums::{strong_digest, StrongHash};
+use checksums::{StrongHash, strong_digest};
 use subtle::ConstantTimeEq;
 
 use crate::{
-    negotiate_caps, negotiate_version, Demux, ExitCode, Frame, Message, Mux, UnknownExit,
-    CAP_CODECS, CAP_ZSTD, V30,
+    CAP_CODECS, CAP_ZSTD, Demux, ExitCode, Frame, Message, Mux, UnknownExit, V30, negotiate_caps,
+    negotiate_version,
 };
-use compress::{decode_codecs, encode_codecs, negotiate_codec, Codec};
+use compress::{Codec, decode_codecs, encode_codecs, negotiate_codec};
 
 pub struct Server<R: Read, W: Write> {
     reader: R,

--- a/crates/protocol/tests/auth.rs
+++ b/crates/protocol/tests/auth.rs
@@ -1,7 +1,7 @@
 // crates/protocol/tests/auth.rs
-use checksums::{strong_digest, StrongHash};
+use checksums::{StrongHash, strong_digest};
 use compress::{available_codecs, encode_codecs};
-use protocol::{Message, Server, SUPPORTED_CAPS, SUPPORTED_PROTOCOLS};
+use protocol::{Message, SUPPORTED_CAPS, SUPPORTED_PROTOCOLS, Server};
 use std::io::Cursor;
 use std::time::Duration;
 

--- a/crates/protocol/tests/mux_demux.rs
+++ b/crates/protocol/tests/mux_demux.rs
@@ -2,7 +2,7 @@
 use std::thread::sleep;
 use std::time::Duration;
 
-use protocol::{demux::Demux, mux::Mux, Message};
+use protocol::{Message, demux::Demux, mux::Mux};
 
 #[test]
 fn multiplex_multiple_channels() {

--- a/crates/protocol/tests/mux_register.rs
+++ b/crates/protocol/tests/mux_register.rs
@@ -1,7 +1,7 @@
 // crates/protocol/tests/mux_register.rs
 use std::time::Duration;
 
-use protocol::{mux::ChannelError, Message, Mux};
+use protocol::{Message, Mux, mux::ChannelError};
 
 #[test]
 fn duplicate_channel_id_errors() {

--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -2,8 +2,8 @@
 use encoding_rs::Encoding;
 use filelist::{Decoder as FDecoder, Encoder as FEncoder, Entry as FEntry};
 use protocol::{
-    negotiate_caps, negotiate_version, CharsetConv, Frame, Message, Msg, Tag, CAP_ACLS, CAP_CODECS,
-    CAP_XATTRS, CAP_ZSTD, MIN_VERSION, SUPPORTED_PROTOCOLS,
+    CAP_ACLS, CAP_CODECS, CAP_XATTRS, CAP_ZSTD, CharsetConv, Frame, MIN_VERSION, Message, Msg,
+    SUPPORTED_PROTOCOLS, Tag, negotiate_caps, negotiate_version,
 };
 
 #[test]

--- a/crates/protocol/tests/server.rs
+++ b/crates/protocol/tests/server.rs
@@ -1,8 +1,8 @@
 // crates/protocol/tests/server.rs
-use compress::{available_codecs, encode_codecs, Codec};
+use compress::{Codec, available_codecs, encode_codecs};
 use protocol::{
-    ExitCode, Server, CAP_ACLS, CAP_CODECS, CAP_XATTRS, CAP_ZSTD, SUPPORTED_CAPS,
-    SUPPORTED_PROTOCOLS, V30,
+    CAP_ACLS, CAP_CODECS, CAP_XATTRS, CAP_ZSTD, ExitCode, SUPPORTED_CAPS, SUPPORTED_PROTOCOLS,
+    Server, V30,
 };
 use std::io::Cursor;
 use std::time::Duration;

--- a/crates/transport/src/ssh.rs
+++ b/crates/transport/src/ssh.rs
@@ -1,7 +1,7 @@
 // crates/transport/src/ssh.rs
 
-use nix::fcntl::{fcntl, FcntlArg, OFlag};
-use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
+use nix::fcntl::{FcntlArg, OFlag, fcntl};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 use std::ffi::OsStr;
 use std::io::{self, BufReader, Read, Write};
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
@@ -11,9 +11,9 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
-use checksums::{strong_digest, StrongHash};
-use compress::{available_codecs, Codec};
-use protocol::{negotiate_version, Frame, FrameHeader, Message, Msg, Tag, CAP_CODECS};
+use checksums::{StrongHash, strong_digest};
+use compress::{Codec, available_codecs};
+use protocol::{CAP_CODECS, Frame, FrameHeader, Message, Msg, Tag, negotiate_version};
 
 use crate::{AddressFamily, LocalPipeTransport, SshTransport, Transport};
 

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -6,7 +6,7 @@ use std::net::{
 use std::os::fd::{AsRawFd, BorrowedFd, RawFd};
 use std::time::Duration;
 
-use nix::poll::{poll, PollFd, PollFlags, PollTimeout};
+use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 
 use ipnet::IpNet;
 use socket2::SockRef;

--- a/crates/transport/tests/blocking_io.rs
+++ b/crates/transport/tests/blocking_io.rs
@@ -1,10 +1,10 @@
 // crates/transport/tests/blocking_io.rs
 #[cfg(unix)]
-use nix::fcntl::{fcntl, FcntlArg, OFlag};
+use nix::fcntl::{FcntlArg, OFlag, fcntl};
 use std::net::TcpListener;
 #[cfg(unix)]
 use std::thread;
-use transport::{ssh::SshStdioTransport, tcp::TcpTransport, Transport};
+use transport::{Transport, ssh::SshStdioTransport, tcp::TcpTransport};
 
 #[cfg(unix)]
 #[test]

--- a/crates/transport/tests/pipe.rs
+++ b/crates/transport/tests/pipe.rs
@@ -6,7 +6,7 @@ use std::thread;
 use std::time::Duration;
 use tempfile::tempdir;
 use transport::{
-    pipe, LocalPipeTransport, SshStdioTransport, TcpTransport, TimeoutTransport, Transport,
+    LocalPipeTransport, SshStdioTransport, TcpTransport, TimeoutTransport, Transport, pipe,
 };
 
 fn wait_for<F: Fn() -> bool>(cond: F) {

--- a/crates/transport/tests/reject.rs
+++ b/crates/transport/tests/reject.rs
@@ -3,7 +3,7 @@ use std::net::{Ipv4Addr, Ipv6Addr, TcpStream};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use transport::{tcp::TcpTransport, AddressFamily};
+use transport::{AddressFamily, tcp::TcpTransport};
 
 #[test]
 fn rejects_sleep_prevents_spin() {

--- a/crates/transport/tests/sockopts.rs
+++ b/crates/transport/tests/sockopts.rs
@@ -4,7 +4,7 @@ use std::thread;
 use std::time::Duration;
 
 use socket2::SockRef;
-use transport::{parse_sockopts, tcp::TcpTransport, SockOpt};
+use transport::{SockOpt, parse_sockopts, tcp::TcpTransport};
 
 #[test]
 fn parse_ip_ttl() {
@@ -248,7 +248,9 @@ fn apply_sockopt_bind_device_unsupported() {
     let stream = TcpStream::connect(addr).unwrap();
     let transport = TcpTransport::from_stream(stream);
 
-    assert!(transport
-        .apply_sockopts(&[SockOpt::BindToDevice("eth0".into())])
-        .is_err());
+    assert!(
+        transport
+            .apply_sockopts(&[SockOpt::BindToDevice("eth0".into())])
+            .is_err()
+    );
 }

--- a/crates/transport/tests/ssh_capabilities.rs
+++ b/crates/transport/tests/ssh_capabilities.rs
@@ -2,7 +2,7 @@
 
 use compress::Codec;
 use protocol::{CAP_CODECS, LATEST_VERSION};
-use transport::{ssh::SshStdioTransport, Transport};
+use transport::{Transport, ssh::SshStdioTransport};
 
 const SERVER_HANDSHAKE_SUCCESS: &[u8] = &[
     0x00, 0x00, 0x00, 0x1f, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x02,

--- a/crates/transport/tests/ssh_max_frame.rs
+++ b/crates/transport/tests/ssh_max_frame.rs
@@ -1,9 +1,9 @@
 // crates/transport/tests/ssh_max_frame.rs
-use protocol::{Msg, Tag, CAP_CODECS, LATEST_VERSION};
+use protocol::{CAP_CODECS, LATEST_VERSION, Msg, Tag};
 use std::io;
 use transport::{
-    ssh::{SshStdioTransport, MAX_FRAME_LEN},
     Transport,
+    ssh::{MAX_FRAME_LEN, SshStdioTransport},
 };
 
 struct ChunkedTransport {

--- a/crates/transport/tests/ssh_process_cleanup.rs
+++ b/crates/transport/tests/ssh_process_cleanup.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::thread::sleep;
 use std::time::Duration;
 
-use transport::{ssh::SshStdioTransport, Transport};
+use transport::{Transport, ssh::SshStdioTransport};
 
 #[test]
 fn no_zombie_after_drop() {

--- a/crates/transport/tests/ssh_stdio.rs
+++ b/crates/transport/tests/ssh_stdio.rs
@@ -1,5 +1,5 @@
 // crates/transport/tests/ssh_stdio.rs
-use transport::{ssh::SshStdioTransport, Transport};
+use transport::{Transport, ssh::SshStdioTransport};
 
 #[test]
 fn send_receive_via_ssh_stdio() {

--- a/crates/transport/tests/tcp.rs
+++ b/crates/transport/tests/tcp.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::thread;
 
-use transport::{tcp::TcpTransport, Transport};
+use transport::{Transport, tcp::TcpTransport};
 
 #[test]
 fn send_receive_over_tcp() {

--- a/crates/walk/tests/walk.rs
+++ b/crates/walk/tests/walk.rs
@@ -31,18 +31,26 @@ fn walk_includes_files_dirs_and_symlinks() {
         }
     }
     assert!(entries.iter().any(|(p, t)| p == root && t.is_dir()));
-    assert!(entries
-        .iter()
-        .any(|(p, t)| p.as_path() == root.join("dir").as_path() && t.is_dir()));
-    assert!(entries
-        .iter()
-        .any(|(p, t)| p.as_path() == root.join("dir/large.txt").as_path() && t.is_file()));
-    assert!(entries
-        .iter()
-        .any(|(p, t)| p == link_path.as_path() && t.is_symlink()));
-    assert!(entries
-        .iter()
-        .any(|(p, t)| p.as_path() == root.join("small.txt").as_path() && t.is_file()));
+    assert!(
+        entries
+            .iter()
+            .any(|(p, t)| p.as_path() == root.join("dir").as_path() && t.is_dir())
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(p, t)| p.as_path() == root.join("dir/large.txt").as_path() && t.is_file())
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(p, t)| p == link_path.as_path() && t.is_symlink())
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(p, t)| p.as_path() == root.join("small.txt").as_path() && t.is_file())
+    );
 }
 
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,12 +1,12 @@
 // tests/cli.rs
 
 use assert_cmd::prelude::*;
-use assert_cmd::{cargo::cargo_bin, Command};
+use assert_cmd::{Command, cargo::cargo_bin};
 use engine::SyncOptions;
-use filetime::{set_file_mtime, FileTime};
+use filetime::{FileTime, set_file_mtime};
 use logging::progress_formatter;
 #[cfg(unix)]
-use nix::unistd::{chown, mkfifo, Gid, Uid};
+use nix::unistd::{Gid, Uid, chown, mkfifo};
 use oc_rsync_cli::{parse_iconv, spawn_daemon_session};
 use predicates::prelude::PredicateBooleanExt;
 use protocol::SUPPORTED_PROTOCOLS;
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 use std::process::Command as StdCommand;
 use std::thread;
 use std::time::Duration;
-use tempfile::{tempdir, tempdir_in, TempDir};
+use tempfile::{TempDir, tempdir, tempdir_in};
 #[cfg(unix)]
 use users::{get_current_gid, get_current_uid, get_group_by_gid, get_user_by_uid};
 #[cfg(all(unix, feature = "xattr"))]
@@ -1561,7 +1561,7 @@ fn owner_group_and_mode_preserved() {
 #[cfg(all(unix, feature = "acl"))]
 #[test]
 fn owner_group_perms_acls_preserved() {
-    use posix_acl::{PosixACL, Qualifier, ACL_READ};
+    use posix_acl::{ACL_READ, PosixACL, Qualifier};
     use std::os::unix::fs::PermissionsExt;
     if !Uid::effective().is_root() {
         eprintln!("skipping owner_group_perms_acls_preserved: requires root or CAP_CHOWN");
@@ -1924,7 +1924,7 @@ fn group_names_are_mapped() {
 #[cfg(unix)]
 #[test]
 fn parse_usermap_accepts_numeric_and_name() {
-    use meta::{parse_id_map, IdKind};
+    use meta::{IdKind, parse_id_map};
     use users::get_user_by_uid;
 
     let numeric = parse_id_map("0:1", IdKind::User).unwrap();
@@ -1943,7 +1943,7 @@ fn parse_usermap_accepts_numeric_and_name() {
 #[cfg(unix)]
 #[test]
 fn parse_groupmap_accepts_numeric_and_name() {
-    use meta::{parse_id_map, IdKind};
+    use meta::{IdKind, parse_id_map};
     use users::get_group_by_gid;
 
     let numeric = parse_id_map("0:1", IdKind::Group).unwrap();
@@ -2007,11 +2007,7 @@ fn user_name_to_numeric_id_is_mapped() {
             parts.next();
             let uid_str = parts.next()?;
             let uid_val: u32 = uid_str.parse().ok()?;
-            if uid_val != uid {
-                Some(uid_val)
-            } else {
-                None
-            }
+            if uid_val != uid { Some(uid_val) } else { None }
         })
         .expect("no alternate user id found");
 
@@ -2362,7 +2358,7 @@ fn force_removes_multiple_non_empty_dirs() {
 #[test]
 #[serial]
 fn perms_flag_preserves_permissions() {
-    use nix::sys::stat::{umask, Mode};
+    use nix::sys::stat::{Mode, umask};
     use std::fs;
     let dir = tempdir().unwrap();
     let src_dir = dir.path().join("src");
@@ -2398,7 +2394,7 @@ fn perms_flag_preserves_permissions() {
 #[test]
 #[serial]
 fn default_umask_masks_permissions() {
-    use nix::sys::stat::{umask, Mode};
+    use nix::sys::stat::{Mode, umask};
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     let dir = tempdir().unwrap();
@@ -2655,6 +2651,39 @@ fn files_from_list_transfers_only_listed_files() {
     assert!(dst.join("keep.txt").exists());
     assert!(dst.join("other file.txt").exists());
     assert!(!dst.join("skip.txt").exists());
+}
+
+#[test]
+fn files_from_list_transfers_nested_paths() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::create_dir_all(src.join("a/b")).unwrap();
+    fs::create_dir_all(src.join("a/d/sub")).unwrap();
+    fs::write(src.join("a/b/file.txt"), b"f").unwrap();
+    fs::write(src.join("a/b/other.txt"), b"o").unwrap();
+    fs::write(src.join("a/d/sub/nested.txt"), b"n").unwrap();
+    fs::write(src.join("unlisted.txt"), b"u").unwrap();
+    let list = dir.path().join("files.txt");
+    fs::write(&list, "a/b/file.txt\na/d/\n").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--recursive",
+            "--files-from",
+            list.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(dst.join("a/b/file.txt").exists());
+    assert!(dst.join("a/d/sub/nested.txt").exists());
+    assert!(!dst.join("a/b/other.txt").exists());
+    assert!(!dst.join("unlisted.txt").exists());
 }
 
 #[test]

--- a/xtask/src/bin/comment_lint.rs
+++ b/xtask/src/bin/comment_lint.rs
@@ -1,5 +1,5 @@
 // xtask/src/bin/comment_lint.rs
-use rustc_lexer::{tokenize, TokenKind};
+use rustc_lexer::{TokenKind, tokenize};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary
- generate include rules for each ancestor path in files-from
- add test to verify nested files-from paths transfer

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: test result FAILED)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: command produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0295dd888323b53b52b1f008970f