### PR TITLE
Fix root path matching with star exclude

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1477,7 +1477,8 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
     if !opts.files_from.is_empty() {
         add_rules(
             usize::MAX,
-            parse_filters("- *", opts.from0).map_err(|e| EngineError::Other(format!("{:?}", e)))?,
+            parse_filters("- /**", opts.from0)
+                .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
         );
     }
     if opts.cvs_exclude {
@@ -1538,7 +1539,7 @@ mod tests {
     use super::*;
     use crate::utils::{parse_bool, parse_remote_spec, RemoteSpec};
     use clap::Parser;
-    use ::daemon::authenticate;
+    use daemon::authenticate;
     use engine::SyncOptions;
     use std::ffi::OsStr;
     use std::path::PathBuf;

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -246,6 +246,10 @@ impl Matcher {
             }
         }
 
+        if path.as_os_str().is_empty() {
+            return Ok((true, false));
+        }
+
         let mut seq = 0usize;
         let mut active: Vec<(usize, usize, usize, Rule)> = Vec::new();
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2686,6 +2686,34 @@ fn include_pattern_allows_file() {
 }
 
 #[test]
+fn include_nested_path_allows_file() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::create_dir_all(src.join("sub")).unwrap();
+    fs::write(src.join("sub/keep.txt"), b"k").unwrap();
+    fs::write(src.join("sub/skip.txt"), b"s").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--recursive",
+            "--include",
+            "sub/keep.txt",
+            "--exclude",
+            "*",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(dst.join("sub/keep.txt").exists());
+    assert!(!dst.join("sub/skip.txt").exists());
+}
+
+#[test]
 fn include_complex_glob_pattern_allows_file() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");


### PR DESCRIPTION
## Summary
- avoid excluding root when synthesizing `- *` for `--files-from`
- ensure `Matcher::check` treats empty root path as unmatched
- test explicit include with global `--exclude '*'

## Testing
- `cargo fmt --all` *(failed: reformatted unrelated files, reverted)*
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(failed: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(failed: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bc02aeb3508323b7fca122e6b85a6d