### PR TITLE
docs: drop lz4 from feature matrix

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -210,8 +210,7 @@ Classic `rsync` protocol versions 30–32 are supported.
 
 | Feature | Status | Tests | Source | Notes |
 | --- | --- | --- | --- | --- |
-| zstd and zlib codecs | Implemented | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/lib.rs](../crates/compress/src/lib.rs) | |
-| LZ4 codec | Missing | — | — | [#873](https://github.com/oferchen/oc-rsync/issues/873) |
+| zlib and zstd codecs | Implemented | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/lib.rs](../crates/compress/src/lib.rs) | |
 
 ## Daemon
 
@@ -240,3 +239,11 @@ Classic `rsync` protocol versions 30–32 are supported.
 | --- | --- | --- | --- | --- |
 | Workspace coverage via `cargo llvm-cov` | Implemented | [reports/metrics.md](../reports/metrics.md) | [Makefile](../Makefile) | |
 | Windows CI coverage gating | Missing | — | [codecov.yml](../codecov.yml) | [#989](https://github.com/oferchen/oc-rsync/issues/989) |
+
+## Post-parity roadmap
+
+These features may be explored after achieving parity with upstream rsync.
+
+| Feature | Tracking issue |
+| --- | --- |
+| LZ4 codec | [#873](https://github.com/oferchen/oc-rsync/issues/873) |


### PR DESCRIPTION
## Summary
- drop LZ4 from compression feature matrix
- add post-parity roadmap section referencing LZ4

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linking with `cc` failed)*
- `make verify-comments`
- `make lint` *(fails: see log)*

------
https://chatgpt.com/codex/tasks/task_e_68bc02c6b79c8323b01f739aa077faaf