### PR TITLE
Deterministic ports for interop daemons

### DIFF
--- a/tests/interop/README.md
+++ b/tests/interop/README.md
@@ -12,7 +12,9 @@ filesystem trees for interoperability tests.
 - `run_matrix.sh` replays a matrix of rsync client/server combinations over both
   SSH and rsync:// transports using the pre-generated fixtures in `golden/`.
   Set `UPDATE=1` to regenerate tarball goldens from a locally built upstream
-  `rsync`.
+  `rsync`. Daemon ports are assigned deterministically starting from
+  `INTEROP_PORT_BASE` (default `43000`), incrementing for each daemon to ensure
+  unique, stable ports across runs.
 
 The committed goldens were recorded in a controlled environment using upstream
 `rsync 3.4.1` and the local `oc-rsync` build. To record fresh goldens, point

--- a/tests/interop/run_matrix.sh
+++ b/tests/interop/run_matrix.sh
@@ -16,6 +16,12 @@ SCENARIOS=(
 
 RSYNC_VERSIONS=(3.2.7 3.3.0 3.4.1)
 
+# Base port for rsync daemons. Override with INTEROP_PORT_BASE to avoid
+# collisions when running tests in parallel environments. Ports are
+# assigned sequentially for determinism across runs.
+PORT_BASE=${INTEROP_PORT_BASE:-43000}
+NEXT_PORT=$PORT_BASE
+
 if [[ "${LIST_SCENARIOS:-0}" == "1" ]]; then
   for entry in "${SCENARIOS[@]}"; do
     IFS=' ' read -r name _ <<< "$entry"
@@ -55,7 +61,8 @@ create_tree() {
 setup_daemon() {
   local server_bin="$1"
   local tmp="$(mktemp -d)"
-  local port=$(shuf -i 40000-49999 -n 1)
+  local port=$NEXT_PORT
+  NEXT_PORT=$((NEXT_PORT + 1))
   cat <<CFG > "$tmp/rsyncd.conf"
 uid = root
 gid = root


### PR DESCRIPTION
## Summary
- assign sequential rsync daemon ports starting from INTEROP_PORT_BASE
- document deterministic port allocation strategy

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linking with `cc` failed)*
- `make verify-comments`
- `make lint` *(fails: unsorted imports)*

------
https://chatgpt.com/codex/tasks/task_e_68bc02cb75608323a127894b77288bd1