### PR TITLE
feat: add streaming compression API

### DIFF
--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -22,8 +22,14 @@ const DATA: &[u8] = b"The quick brown fox jumps over the lazy dog";
 #[test]
 fn zlib_roundtrip() {
     let codec = Zlib::default();
-    let compressed = codec.compress(DATA).expect("compress");
-    let decompressed = codec.decompress(&compressed).expect("decompress");
+    let mut compressed = Vec::new();
+    let mut src = DATA;
+    codec.compress(&mut src, &mut compressed).expect("compress");
+    let mut decompressed = Vec::new();
+    let mut c_slice = compressed.as_slice();
+    codec
+        .decompress(&mut c_slice, &mut decompressed)
+        .expect("decompress");
     assert_eq!(DATA, decompressed.as_slice());
 }
 
@@ -31,8 +37,14 @@ fn zlib_roundtrip() {
 #[test]
 fn zlibx_roundtrip() {
     let codec = ZlibX::default();
-    let compressed = codec.compress(DATA).expect("compress");
-    let decompressed = codec.decompress(&compressed).expect("decompress");
+    let mut compressed = Vec::new();
+    let mut src = DATA;
+    codec.compress(&mut src, &mut compressed).expect("compress");
+    let mut decompressed = Vec::new();
+    let mut c_slice = compressed.as_slice();
+    codec
+        .decompress(&mut c_slice, &mut decompressed)
+        .expect("decompress");
     assert_eq!(DATA, decompressed.as_slice());
 }
 
@@ -40,8 +52,14 @@ fn zlibx_roundtrip() {
 #[test]
 fn zstd_roundtrip() {
     let codec = Zstd::default();
-    let compressed = codec.compress(DATA).expect("compress");
-    let decompressed = codec.decompress(&compressed).expect("decompress");
+    let mut compressed = Vec::new();
+    let mut src = DATA;
+    codec.compress(&mut src, &mut compressed).expect("compress");
+    let mut decompressed = Vec::new();
+    let mut c_slice = compressed.as_slice();
+    codec
+        .decompress(&mut c_slice, &mut decompressed)
+        .expect("decompress");
     assert_eq!(DATA, decompressed.as_slice());
 }
 

--- a/crates/compress/tests/large.rs
+++ b/crates/compress/tests/large.rs
@@ -1,0 +1,45 @@
+// crates/compress/tests/large.rs
+#[cfg(any(feature = "zlib", feature = "zstd"))]
+use compress::{Compressor, Decompressor};
+
+#[cfg(feature = "zlib")]
+use compress::Zlib;
+
+#[cfg(feature = "zstd")]
+use compress::Zstd;
+
+const LARGE_SIZE: usize = 10 * 1024 * 1024; // 10MB
+
+#[cfg(feature = "zlib")]
+#[test]
+fn zlib_large_roundtrip() {
+    let data = vec![0u8; LARGE_SIZE];
+    let codec = Zlib::default();
+    let mut compressed = Vec::new();
+    let mut src = data.as_slice();
+    codec.compress(&mut src, &mut compressed).expect("compress");
+    let mut decompressed = Vec::new();
+    let mut comp_slice = compressed.as_slice();
+    codec
+        .decompress(&mut comp_slice, &mut decompressed)
+        .expect("decompress");
+    assert_eq!(decompressed.len(), data.len());
+    assert_eq!(data, decompressed);
+}
+
+#[cfg(feature = "zstd")]
+#[test]
+fn zstd_large_roundtrip() {
+    let data = vec![0u8; LARGE_SIZE];
+    let codec = Zstd::default();
+    let mut compressed = Vec::new();
+    let mut src = data.as_slice();
+    codec.compress(&mut src, &mut compressed).expect("compress");
+    let mut decompressed = Vec::new();
+    let mut comp_slice = compressed.as_slice();
+    codec
+        .decompress(&mut comp_slice, &mut decompressed)
+        .expect("decompress");
+    assert_eq!(decompressed.len(), data.len());
+    assert_eq!(data, decompressed);
+}

--- a/crates/engine/benches/compress.rs
+++ b/crates/engine/benches/compress.rs
@@ -9,15 +9,21 @@ fn bench_compress(c: &mut Criterion) {
     #[cfg(feature = "zstd")]
     {
         let zstd = Zstd::default();
-        let compressed = zstd.compress(&data).unwrap();
+        let mut compressed = Vec::new();
+        let mut src = data.as_slice();
+        zstd.compress(&mut src, &mut compressed).unwrap();
         c.bench_function("zstd_compress_1mb", |b| {
             b.iter(|| {
-                zstd.compress(&data).unwrap();
+                let mut out = Vec::new();
+                let mut cursor = data.as_slice();
+                zstd.compress(&mut cursor, &mut out).unwrap();
             });
         });
         c.bench_function("zstd_decompress_1mb", |b| {
             b.iter(|| {
-                zstd.decompress(&compressed).unwrap();
+                let mut out = Vec::new();
+                let mut cursor = compressed.as_slice();
+                zstd.decompress(&mut cursor, &mut out).unwrap();
             });
         });
     }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1383,11 +1383,21 @@ impl Sender {
                     *d = match codec {
                         Codec::Zlib | Codec::Zlibx => {
                             let lvl = self.opts.compress_level.unwrap_or(6);
-                            Zlib::new(lvl).compress(d).map_err(EngineError::from)?
+                            let mut out = Vec::new();
+                            let mut cursor = d.as_slice();
+                            Zlib::new(lvl)
+                                .compress(&mut cursor, &mut out)
+                                .map_err(EngineError::from)?;
+                            out
                         }
                         Codec::Zstd => {
                             let lvl = self.opts.compress_level.unwrap_or(0);
-                            Zstd::new(lvl).compress(d).map_err(EngineError::from)?
+                            let mut out = Vec::new();
+                            let mut cursor = d.as_slice();
+                            Zstd::new(lvl)
+                                .compress(&mut cursor, &mut out)
+                                .map_err(EngineError::from)?;
+                            out
                         }
                     };
                 }
@@ -1682,9 +1692,21 @@ impl Receiver {
                 if let Op::Data(ref mut d) = op {
                     *d = match codec {
                         Codec::Zlib | Codec::Zlibx => {
-                            ZlibX::default().decompress(d).map_err(EngineError::from)?
+                            let mut out = Vec::new();
+                            let mut cursor = d.as_slice();
+                            ZlibX::default()
+                                .decompress(&mut cursor, &mut out)
+                                .map_err(EngineError::from)?;
+                            out
                         }
-                        Codec::Zstd => Zstd::default().decompress(d).map_err(EngineError::from)?,
+                        Codec::Zstd => {
+                            let mut out = Vec::new();
+                            let mut cursor = d.as_slice();
+                            Zstd::default()
+                                .decompress(&mut cursor, &mut out)
+                                .map_err(EngineError::from)?;
+                            out
+                        }
                     };
                 }
             }


### PR DESCRIPTION
## Summary
- redesign compression traits to operate on Read/Write streams
- update engine to stream compress and decompress
- cover large roundtrip cases for zlib and zstd

## Testing
- `make lint` *(fails: diff generated by cargo fmt --all --check)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68bc02eb51c08323aff0584ebd93f737