### PR TITLE
docs: clarify multiple source paths in usage

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,8 +15,10 @@ resource and adjust `ARG_ORDER` so the test continues to pass.
 ## Usage
 
 ```sh
-oc-rsync [OPTIONS] "<SRC>" "<DEST>"
+oc-rsync [OPTIONS] "<SRC>..." "<DEST>"
 ```
+
+Multiple source paths may be specified; the last path is treated as the destination.
 
 ### Examples
 
@@ -24,6 +26,12 @@ oc-rsync [OPTIONS] "<SRC>" "<DEST>"
 
   ```sh
   oc-rsync "./src" "./backup"
+  ```
+
+- Multiple sources into one destination:
+
+  ```sh
+  oc-rsync "./src1" "./src2" "./backup"
   ```
 
 - Remote sync over SSH:


### PR DESCRIPTION
## Summary
- document support for multiple source paths in `oc-rsync`

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint` *(fails: rustfmt reordered use statements)*

------
https://chatgpt.com/codex/tasks/task_e_68bc02f825208323ab37284daaa05360