### PR TITLE
Skip filter-file test on rsync versions without support

### DIFF
--- a/crates/compress/tests/large.rs
+++ b/crates/compress/tests/large.rs
@@ -1,4 +1,5 @@
 // crates/compress/tests/large.rs
+
 #[cfg(any(feature = "zlib", feature = "zstd"))]
 use compress::{Compressor, Decompressor};
 
@@ -8,7 +9,7 @@ use compress::Zlib;
 #[cfg(feature = "zstd")]
 use compress::Zstd;
 
-const LARGE_SIZE: usize = 10 * 1024 * 1024; // 10MB
+const LARGE_SIZE: usize = 10 * 1024 * 1024;
 
 #[cfg(feature = "zlib")]
 #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -71,6 +71,34 @@ impl Tmpfs {
     }
 }
 
+fn rsync_supports_filter_file() -> bool {
+    StdCommand::new("rsync")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|out| {
+            if !out.status.success() {
+                return None;
+            }
+            std::str::from_utf8(&out.stdout).ok().and_then(|s| {
+                s.lines().next().and_then(|line| {
+                    let mut parts = line.split_whitespace();
+                    while let Some(part) = parts.next() {
+                        if part == "version" {
+                            let ver = parts.next()?;
+                            let mut nums = ver.split('.').filter_map(|n| n.parse::<u32>().ok());
+                            let major = nums.next().unwrap_or(0);
+                            let minor = nums.next().unwrap_or(0);
+                            return Some(major > 3 || (major == 3 && minor >= 4));
+                        }
+                    }
+                    None
+                })
+            })
+        })
+        .unwrap_or(false)
+}
+
 #[test]
 fn files_from_from0_matches_rsync() {
     use std::process::Command as StdCommand;
@@ -399,6 +427,11 @@ fn filter_merge_from0_matches_filter_file() {
 #[test]
 fn filter_file_from0_stdin_matches_rsync() {
     use std::process::Command as StdCommand;
+
+    if !rsync_supports_filter_file() {
+        eprintln!("skipping filter_file_from0_stdin_matches_rsync: rsync lacks --filter-file",);
+        return;
+    }
 
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");


### PR DESCRIPTION
## Summary
- detect installed `rsync` version and skip filter-file-from-stdin test when `--filter-file` isn't supported
- adjust comment formatting in compress test to satisfy comment lint

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: unresolved import `daemon::authenticate`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: unresolved import `daemon::authenticate`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0d9317ac832396bed5de579030ed