### PR TITLE
Handle wildcard include directory parents

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1264,15 +1264,18 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
         let mut finished = true;
         let trimmed = rooted.trim_end_matches('/');
         for part in trimmed.trim_start_matches('/').split('/') {
-            if part.contains(['*', '?', '[', ']']) {
-                finished = false;
-                break;
-            }
             if !base.is_empty() {
                 base.push('/');
             }
             base.push_str(part);
-            dirs.push(format!("/{}", base));
+            let has_glob = part.contains(['*', '?', '[', ']']);
+            if has_glob {
+                dirs.push(format!("/{base}/"));
+                dirs.push(format!("/{base}/**"));
+                finished = false;
+                break;
+            }
+            dirs.push(format!("/{base}/"));
         }
         if finished {
             dirs.pop();
@@ -1335,9 +1338,9 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
             );
             for dir in parents {
                 let rule = if opts.from0 {
-                    format!("+{}/", dir)
+                    format!("+{}", dir)
                 } else {
-                    format!("+ {}/", dir)
+                    format!("+ {}", dir)
                 };
                 add_rules(
                     idx + 1,
@@ -1381,9 +1384,9 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
                         );
                         for dir in parents {
                             let rule = if opts.from0 {
-                                format!("+{}/", dir)
+                                format!("+{}", dir)
                             } else {
-                                format!("+ {}/", dir)
+                                format!("+ {}", dir)
                             };
                             add_rules(
                                 idx + 1,
@@ -1407,9 +1410,9 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
                     );
                     for dir in parents {
                         let rule = if opts.from0 {
-                            format!("+{}/", dir)
+                            format!("+{}", dir)
                         } else {
-                            format!("+ {}/", dir)
+                            format!("+ {}", dir)
                         };
                         add_rules(
                             idx + 1,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4432,7 +4432,49 @@ fn complex_glob_matches() {
     assert!(dst.join("dirA/keep1.txt").is_file());
     assert!(dst.join("dirB/sub/keep2.txt").is_file());
     assert!(dst.join("dirC/deep/deeper/keep3.txt").is_file());
+    assert!(dst.join("dirA").is_dir());
+    assert!(dst.join("dirB/sub").is_dir());
+    assert!(dst.join("dirC/deep/deeper").is_dir());
     assert!(!dst.join("dirA/skip.log").exists());
     assert!(!dst.join("dirB/sub/other.txt").exists());
     assert!(!dst.join("otherdir/keep4.txt").exists());
+    assert!(!dst.join("otherdir").exists());
+}
+
+#[test]
+fn double_star_glob_matches() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(src.join("a/inner")).unwrap();
+    fs::create_dir_all(src.join("b/deeper/more")).unwrap();
+    fs::write(src.join("a/keep1.txt"), "1").unwrap();
+    fs::write(src.join("a/inner/keep2.txt"), "2").unwrap();
+    fs::write(src.join("b/deeper/more/keep3.txt"), "3").unwrap();
+    fs::write(src.join("a/omit.log"), "x").unwrap();
+    fs::write(src.join("a/inner/omit.log"), "x").unwrap();
+    fs::write(src.join("b/deeper/more/omit.log"), "x").unwrap();
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "-r",
+            "--include",
+            "**/keep?.txt",
+            "--exclude",
+            "*",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(dst.join("a/keep1.txt").is_file());
+    assert!(dst.join("a/inner/keep2.txt").is_file());
+    assert!(dst.join("b/deeper/more/keep3.txt").is_file());
+    assert!(dst.join("a").is_dir());
+    assert!(dst.join("a/inner").is_dir());
+    assert!(dst.join("b/deeper/more").is_dir());
+    assert!(!dst.join("a/omit.log").exists());
+    assert!(!dst.join("a/inner/omit.log").exists());
+    assert!(!dst.join("b/deeper/more/omit.log").exists());
 }


### PR DESCRIPTION
## Summary
- generate parent patterns for include globs with wildcards
- use wildcard parent patterns to create implied directories
- test wildcard includes for implied directories

## Testing
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc15aa82608323a4491e06924e9c5d