### PR TITLE
Isolate non-interop tests from system rsync

### DIFF
--- a/crates/filters/tests/stdin_from0.rs
+++ b/crates/filters/tests/stdin_from0.rs
@@ -1,18 +1,16 @@
 // crates/filters/tests/stdin_from0.rs
 use filters::{Matcher, parse_file};
 use std::collections::HashSet;
-use std::fs;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
-use std::process::{Command, Stdio};
-use tempfile::{tempdir, tempfile};
+use tempfile::tempfile;
 
 #[cfg(unix)]
 use std::os::unix::io::IntoRawFd;
 
 #[cfg(unix)]
 #[test]
-fn null_separated_filters_from_stdin_match_rsync() {
+fn null_separated_filters_from_stdin() {
     let mut tmpfile = tempfile().unwrap();
     tmpfile.write_all(b"+ foo\0+ bar\0- *\0").unwrap();
     tmpfile.seek(SeekFrom::Start(0)).unwrap();
@@ -26,63 +24,10 @@ fn null_separated_filters_from_stdin_match_rsync() {
     let rules = parse_file(Path::new("-"), false, &mut visited, 0).unwrap();
     let matcher = Matcher::new(rules);
 
-    assert!(matcher.is_included("foo").unwrap());
-    assert!(matcher.is_included("bar").unwrap());
-    assert!(!matcher.is_included("baz").unwrap());
-
     assert!(unsafe { libc::dup2(stdin_fd, 0) } >= 0);
     unsafe { libc::close(stdin_fd) };
 
-    let tmp = tempdir().unwrap();
-    let src = tmp.path().join("src");
-    fs::create_dir_all(&src).unwrap();
-    fs::write(src.join("foo"), "").unwrap();
-    fs::write(src.join("bar"), "").unwrap();
-    fs::write(src.join("baz"), "").unwrap();
-    let dest = tmp.path().join("dest");
-    fs::create_dir_all(&dest).unwrap();
-
-    let mut child = Command::new("rsync")
-        .arg("-r")
-        .arg("-n")
-        .arg("-i")
-        .arg("--from0")
-        .arg("--filter=merge,-")
-        .arg(format!("{}/", src.display()))
-        .arg(dest.to_str().unwrap())
-        .stdin(Stdio::piped())
-        .spawn()
-        .unwrap();
-    {
-        let stdin = child.stdin.as_mut().unwrap();
-        stdin.write_all(b"+ foo\0+ bar\0- *\0").unwrap();
-    }
-    let output = child.wait_with_output().unwrap();
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut rsync_included = Vec::new();
-    for line in stdout.lines() {
-        if line.starts_with("sending ") || line.starts_with("sent ") || line.starts_with("total ") {
-            continue;
-        }
-        if let Some(name) = line.split_whitespace().last() {
-            rsync_included.push(name.to_string());
-        }
-    }
-    assert_eq!(
-        matcher.is_included("foo").unwrap(),
-        rsync_included.contains(&"foo".to_string())
-    );
-    assert_eq!(
-        matcher.is_included("bar").unwrap(),
-        rsync_included.contains(&"bar".to_string())
-    );
-    assert_eq!(
-        matcher.is_included("baz").unwrap(),
-        rsync_included.contains(&"baz".to_string())
-    );
+    assert!(matcher.is_included("foo").unwrap());
+    assert!(matcher.is_included("bar").unwrap());
+    assert!(!matcher.is_included("baz").unwrap());
 }


### PR DESCRIPTION
## Summary
- remove upstream `rsync` invocations from default CLI tests
- rewrite stdin filter test to avoid calling external `rsync`

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: many tests did not pass)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: warnings, run did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68bc15c6cad48323995f424ba3e89e50