### PR TITLE
docs: note filter limitations

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -75,7 +75,6 @@ Classic `rsync` protocol versions 30–32 are supported.
 | `--fake-super` | ✅ | N | N | N | [tests/fake_super.rs](../tests/fake_super.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | requires `xattr` feature |
 | `--files-from` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--filter` | ✅ | Y | Y | Y | [tests/golden/cli_parity/selection.sh](../tests/golden/cli_parity/selection.sh) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
-| `--filter-file` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | read rules from file |
 | `-F` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) | filter merge shorthand |
 | `--force` | ✅ | Y | Y | Y | [tests/delete_policy.rs](../tests/delete_policy.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |
 | `--from0` | ✅ | Y | Y | Y | [tests/cli.rs](../tests/cli.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |  |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -73,6 +73,8 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | Rule logging and statistics | Implemented | [crates/filters/tests/rule_stats.rs](../crates/filters/tests/rule_stats.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Additional rule modifiers | Partial | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs)<br>[#268](https://github.com/oferchen/oc-rsync/issues/268) |
 | CVS ignore semantics (`--cvs-exclude`) | Partial | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| Complex glob patterns | Missing | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| `--files-from` directory entries | Missing | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 
 ## File Selection
 | Feature | Status | Tests | Source |


### PR DESCRIPTION
## Summary
- remove non-upstream `--filter-file` option from feature matrix
- track missing complex glob and `--files-from` directory support in gaps documentation

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: 153 failed, 8 skipped due to interrupt)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted during build)*
- `make verify-comments`
- `make lint` *(fails: rustfmt differences)*

------
https://chatgpt.com/codex/tasks/task_e_68bc15c9cc9883238e1c8470cf753da2