### PR TITLE
filters: anchor slash patterns to root

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1491,7 +1491,7 @@ pub fn parse_with_options(
         if has_anchor && !pattern.starts_with('/') {
             pattern = format!("/{}", pattern);
         }
-        let anchored = pattern.starts_with('/');
+        let anchored = pattern.starts_with('/') || pattern.contains('/');
         let dir_all = pattern.ends_with("/***");
         let dir_only = !dir_all && pattern.ends_with('/');
         let mut base = pattern.trim_start_matches('/').to_string();
@@ -1500,11 +1500,12 @@ pub fn parse_with_options(
         } else if dir_only {
             base = base.trim_end_matches('/').to_string();
         }
-        let bases: Vec<String> = if !anchored && !base.starts_with("**/") && base != "**" {
-            vec![base.clone(), format!("**/{}", base)]
-        } else {
-            vec![base]
-        };
+        let bases: Vec<String> =
+            if !anchored && !base.starts_with("**/") && base != "**" && !base.contains('/') {
+                vec![base.clone(), format!("**/{}", base)]
+            } else {
+                vec![base]
+            };
         let mut pats: Vec<(String, bool)> = Vec::new();
         for b in bases {
             if dir_all {
@@ -1592,7 +1593,8 @@ pub fn default_cvs_rules() -> Result<Vec<Rule>, ParseError> {
         } else if pat.ends_with('/') {
             base = base.trim_end_matches('/').to_string();
         }
-        let bases: Vec<String> = if !base.starts_with("**/") && base != "**" {
+        let bases: Vec<String> = if !base.starts_with("**/") && base != "**" && !base.contains('/')
+        {
             vec![base.clone(), format!("**/{}", base)]
         } else {
             vec![base]

--- a/crates/filters/tests/directory_boundaries.rs
+++ b/crates/filters/tests/directory_boundaries.rs
@@ -1,0 +1,44 @@
+// crates/filters/tests/directory_boundaries.rs
+use filters::{Matcher, parse};
+use std::collections::HashSet;
+
+fn p(input: &str) -> Vec<filters::Rule> {
+    let mut v = HashSet::new();
+    parse(input, &mut v, 0).unwrap()
+}
+
+#[test]
+fn star_slash_file() {
+    let rules = p("+ */file.txt\n- *\n");
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("dir/file.txt").unwrap());
+    assert!(!matcher.is_included("dir/sub/file.txt").unwrap());
+}
+
+#[test]
+fn class_slash_star() {
+    let rules = p("+ [0-9]/*\n- *\n");
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("1/file.txt").unwrap());
+    assert!(!matcher.is_included("1/dir/file.txt").unwrap());
+}
+
+#[test]
+fn dir_prefix_double_star() {
+    let rules = p("+ dir*/**/keep[0-9].txt\n- *\n");
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("dir/keep1.txt").unwrap());
+    assert!(matcher.is_included("dir/sub/keep2.txt").unwrap());
+    assert!(!matcher.is_included("adir/keep3.txt").unwrap());
+    assert!(!matcher.is_included("dir/keep10.txt").unwrap());
+}
+
+#[test]
+fn leading_double_star() {
+    let rules = p("+ **/keep?.txt\n- *\n");
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("keep1.txt").unwrap());
+    assert!(matcher.is_included("dir/keep2.txt").unwrap());
+    assert!(!matcher.is_included("keep10.txt").unwrap());
+    assert!(!matcher.is_included("dir/sub/keep12.txt").unwrap());
+}


### PR DESCRIPTION
## Summary
- treat patterns containing '/' as root-anchored
- limit automatic `**/` prefixing to patterns without '/'
- add regression tests covering directory-boundary cases

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc22d79e648323952b9ec10cef2acf