### PR TITLE
Include ancestor directories for nested include patterns

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1500,11 +1500,43 @@ pub fn parse_with_options(
         } else if dir_only {
             base = base.trim_end_matches('/').to_string();
         }
+        let base_for_ancestors = base.clone();
         let bases: Vec<String> = if !anchored && !base.starts_with("**/") && base != "**" {
             vec![base.clone(), format!("**/{}", base)]
         } else {
-            vec![base]
+            vec![base.clone()]
         };
+
+        if matches!(kind, RuleKind::Include) {
+            if base_for_ancestors.contains('/')
+                && !base_for_ancestors.contains('*')
+                && !base_for_ancestors.contains('?')
+                && !base_for_ancestors.contains('[')
+                && !base_for_ancestors.contains('{')
+            {
+                let parts: Vec<&str> = base_for_ancestors.split('/').collect();
+                for i in 1..parts.len() {
+                    let ancestor = parts[..i].join("/");
+                    let ancestor_bases: Vec<String> = if !anchored && ancestor != "**" {
+                        vec![ancestor.clone(), format!("**/{}", ancestor)]
+                    } else {
+                        vec![ancestor]
+                    };
+                    for pat in ancestor_bases {
+                        let matcher = compile_glob(&pat)?;
+                        let data = RuleData {
+                            matcher,
+                            invert: mods.contains('!'),
+                            flags: flags.clone(),
+                            source: source.clone(),
+                            dir_only: true,
+                        };
+                        rules.push(Rule::Include(data));
+                    }
+                }
+            }
+        }
+
         let mut pats: Vec<(String, bool)> = Vec::new();
         for b in bases {
             if dir_all {

--- a/tests/rsync_filter_dir_ancestors.rs
+++ b/tests/rsync_filter_dir_ancestors.rs
@@ -1,0 +1,29 @@
+// tests/rsync_filter_dir_ancestors.rs
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn include_pattern_traverses_ancestors() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(src.join("a/b")).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+
+    fs::write(src.join("a/b/keep.txt"), "hi").unwrap();
+    fs::write(src.join("a/b/omit.txt"), "no").unwrap();
+    fs::write(src.join(".rsync-filter"), b"+ /a/b/keep.txt\n- omit.txt\n").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
+    cmd.arg("--recursive")
+        .args(["-F", "-F"])
+        .arg(&src_arg)
+        .arg(&dst);
+    let out = cmd.output().unwrap();
+    assert!(out.status.success(), "oc-rsync failed: {:?}", out);
+
+    assert!(dst.join("a/b/keep.txt").exists());
+    assert!(!dst.join("a/b/omit.txt").exists());
+}


### PR DESCRIPTION
## Summary
- ensure include rules for nested paths also include their ancestor directories as dir-only
- add test covering traversal with nested include and sibling exclude

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: test result: FAILED. 0 passed; 1 failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc22d9359083238350f93d03af88ba