### PR TITLE
Reorder imports in root inclusion test

### DIFF
--- a/crates/filters/tests/root_inclusion.rs
+++ b/crates/filters/tests/root_inclusion.rs
@@ -1,5 +1,5 @@
 // crates/filters/tests/root_inclusion.rs
-use filters::{parse, Matcher};
+use filters::{Matcher, parse};
 use std::collections::HashSet;
 
 fn m(input: &str) -> Matcher {


### PR DESCRIPTION
## Summary
- reorder filter imports in root inclusion test to `use filters::{Matcher, parse};`

## Testing
- `cargo fmt -- crates/filters/tests/root_inclusion.rs`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc2d728a5883239e53985d9bac236c