### PR TITLE
Add no-ACL test path for missing ACL library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,8 @@ xattr = ["engine/xattr"]
 acl = ["engine/acl", "meta/acl", "posix-acl"]
 zlib = ["compress/zlib"]
 zstd = ["compress/zstd"]
+# Convenience feature set that mirrors the defaults but without ACL support.
+no-acl = ["xattr", "zlib", "zstd"]
 # Enables CLI-only tools
 cli = []
 # Enables AVX-512 implementations requiring a nightly toolchain

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ test:
 	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast
 	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly"
 
+# Run the test suite without ACL support for environments lacking libacl.
+test-noacl:
+	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --no-default-features --features "no-acl"
+	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --no-default-features --features "cli nightly no-acl"
+
 coverage:
 	cargo llvm-cov nextest --workspace --features "cli nightly" --doctests \
 	--fail-under-lines 95 --fail-under-functions 95 -- --no-fail-fast

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 Run `scripts/preflight.sh` to verify these dependencies before building. Then
 install from crates.io or build from a local checkout:
 
-If `libacl1-dev` isn't available, disable ACL support with
+If `libacl1-dev` isn't available, disable ACL support with the `no-acl`
+feature set:
 
 ```bash
-cargo build --no-default-features --features xattr
+cargo build --no-default-features --features no-acl
 ```
 
 ```bash
@@ -88,6 +89,9 @@ An overview of crate boundaries, data flow, and algorithms is in [docs/architect
 ## Testing & CI
 
 `make test` runs the full test suite with `cargo nextest run --workspace --no-fail-fast` followed by `cargo nextest run --workspace --no-fail-fast --features "cli nightly"`. CI workflows live under [.github/workflows](.github/workflows). Fuzzing and interoperability grids are described in [docs/fuzzing.md](docs/fuzzing.md) and [docs/interop-grid.md](docs/interop-grid.md).
+
+Systems without `libacl` can execute the suite via `make test-noacl`,
+which runs the tests with the `no-acl` feature set.
 
 ## Security
 


### PR DESCRIPTION
## Summary
- add no-acl feature for environments without libacl
- expose test-noacl Makefile target and document usage

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: hides_temp_files, replay_is_deterministic, cleans_up_temp_dir_on_rename_failure, removes_partial_dir_after_sync, resume_from_partial_file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2f3378148323bde7002e060fe891