### PR TITLE
Align CVS ignore handling with upstream semantics

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -655,14 +655,12 @@ impl Matcher {
         let adjusted = if cvs {
             let rel_str = rel.map(|p| p.to_string_lossy().to_string());
             let mut buf = String::new();
-            let iter: Box<dyn Iterator<Item = &str>> = if self.from0 {
-                Box::new(content.split('\0'))
-            } else {
-                Box::new(content.split_whitespace())
-            };
-            for token in iter {
+            for token in content.split_whitespace() {
                 if token.is_empty() || token.starts_with('#') {
                     continue;
+                }
+                if token.starts_with('!') {
+                    return Err(ParseError::InvalidRule(token.to_string()));
                 }
                 let pat = if let Some(rel_str) = &rel_str {
                     if token.starts_with('/') {


### PR DESCRIPTION
## Summary
- handle `.cvsignore` entries like upstream: always whitespace-split and reject `!` tokens
- add regression test covering nested `.cvsignore` override with `--include`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: call to unsafe function `set_var` requires unsafe block)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: call to unsafe function `set_var` requires unsafe block)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc307fa87c8323abb9262f3f6c2080