### PR TITLE
feat(filters): support advanced glob patterns

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -109,6 +109,7 @@ impl FilterStats {
 fn compile_glob(pat: &str) -> Result<GlobMatcher, ParseError> {
     Ok(GlobBuilder::new(pat)
         .literal_separator(true)
+        .backslash_escape(true)
         .build()?
         .compile_matcher())
 }

--- a/crates/filters/tests/advanced_globs.rs
+++ b/crates/filters/tests/advanced_globs.rs
@@ -1,0 +1,31 @@
+// crates/filters/tests/advanced_globs.rs
+use filters::{Matcher, parse};
+use std::collections::HashSet;
+
+fn p(s: &str) -> Matcher {
+    let mut v = HashSet::new();
+    Matcher::new(parse(s, &mut v, 0).unwrap())
+}
+
+#[test]
+fn bracket_set_matching() {
+    let m = p("+ file[ab].txt\n- *\n");
+    assert!(m.is_included("filea.txt").unwrap());
+    assert!(m.is_included("fileb.txt").unwrap());
+    assert!(!m.is_included("filec.txt").unwrap());
+}
+
+#[test]
+fn bracket_negation_matching() {
+    let m = p("+ file[!ab].txt\n- *\n");
+    assert!(m.is_included("filec.txt").unwrap());
+    assert!(!m.is_included("filea.txt").unwrap());
+}
+
+#[test]
+fn double_star_precedence() {
+    let m = p("- dir/**\n+ dir/**/keep.txt\n- *\n");
+    assert!(!m.is_included("dir/sub/keep.txt").unwrap());
+    let m2 = p("+ dir/**/keep.txt\n- dir/**\n- *\n");
+    assert!(m2.is_included("dir/sub/keep.txt").unwrap());
+}


### PR DESCRIPTION
## Summary
- support bracket expressions and other advanced glob syntax via globset
- add tests covering bracket sets, negations and double-star precedence

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linking with `cc`)*
- `make verify-comments`
- `make lint`
- `cargo test -p filters --test advanced_globs`


------
https://chatgpt.com/codex/tasks/task_e_68bc30843e048323a9dc7b17d20169cf