### PR TITLE
Handle directories in files-from lists

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1483,16 +1483,25 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
                     parse_filters(&rule, opts.from0)
                         .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
                 );
-                let rule = if opts.from0 {
-                    format!("+{}/***", last)
+                let src_base = PathBuf::from(&opts.paths[0]);
+                let fs_path = if Path::new(&pat).is_absolute() {
+                    PathBuf::from(pat.trim_end_matches('/'))
                 } else {
-                    format!("+ {}/***", last)
+                    src_base.join(pat.trim_end_matches('/'))
                 };
-                add_rules(
-                    idx + 1,
-                    parse_filters(&rule, opts.from0)
-                        .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
-                );
+                let is_dir = pat.ends_with('/') || fs_path.is_dir();
+                if is_dir {
+                    let rule = if opts.from0 {
+                        format!("+{}/***", last)
+                    } else {
+                        format!("+ {}/***", last)
+                    };
+                    add_rules(
+                        idx + 1,
+                        parse_filters(&rule, opts.from0)
+                            .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
+                    );
+                }
             }
         }
     }

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -9,6 +9,10 @@ additional rule actions:
 - `hide PATTERN` – alias for `exclude`; hides matches from the transfer.
 - `show PATTERN` – alias for `include`; reveals matches hidden by earlier rules.
 
+Directory paths listed via `--files-from` are detected even without a trailing
+slash, ensuring their contents are visited and any nested `.rsync-filter` rules
+are merged during traversal.
+
 Per-directory merge files are evaluated in the same order as upstream rsync.
 Rules from deeper directories take precedence over ancestor directories and
 their relative order is preserved with global rules.

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -74,7 +74,7 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | Additional rule modifiers | Partial | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs)<br>[#268](https://github.com/oferchen/oc-rsync/issues/268) |
 | CVS ignore semantics (`--cvs-exclude`) | Partial | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Complex glob patterns | Missing | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
-| `--files-from` directory entries | Missing | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| `--files-from` directory entries | Implemented | [crates/filters/tests/files_from.rs](../crates/filters/tests/files_from.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 
 ## File Selection
 | Feature | Status | Tests | Source |


### PR DESCRIPTION
## Summary
- detect directory entries when expanding `--files-from` patterns
- traverse listed directories and merge their `.rsync-filter` rules
- document completed files-from directory support

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(failed: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3cf891688323b8a5867d20387138