### PR TITLE
chore: require build year env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  CURRENT_YEAR: "2025" # ensure reproducible build metadata
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
   LC_ALL: C

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,8 @@ The Makefile offers shortcuts for common CI checks:
 The CI workflow runs with a consistent environment and enforces comment
 headers:
 
-- Environment variables: `RUSTFLAGS="-Dwarnings"`, `LC_ALL=C`, `LANG=C`,
-  `COLUMNS=80`, and `TZ=UTC`.
+- Environment variables: `CURRENT_YEAR` (set to the release year),
+  `RUSTFLAGS="-Dwarnings"`, `LC_ALL=C`, `LANG=C`, `COLUMNS=80`, and `TZ=UTC`.
   - Repository access is read only (`permissions: { contents: read }`) and a
     concurrency group (`ci-${{ github.ref }}`) cancels in-progress runs for the same
     ref.
@@ -57,10 +57,11 @@ headers:
 
 ## Standardized Test Environment
 
-For deterministic CLI help and usage output, run tests with a consistent
-environment:
+For deterministic CLI help and usage output, and to guarantee reproducible
+build metadata, run tests with a consistent environment:
 
 ```bash
+export CURRENT_YEAR=$(date +%Y)
 LC_ALL=C LANG=C COLUMNS=80 TZ=UTC make test
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,6 @@
 
 use std::{env, fs, path::Path, path::PathBuf, process::Command};
 
-use time::OffsetDateTime;
-
 const UPSTREAM_VERSION: &str = "3.4.1";
 const SUPPORTED_PROTOCOLS: &[u32] = &[32, 31, 30];
 const BRANDING_VARS: &[&str] = &[
@@ -95,8 +93,7 @@ fn main() {
         println!("cargo:rerun-if-env-changed={key}");
     }
 
-    let year =
-        env::var("CURRENT_YEAR").unwrap_or_else(|_| OffsetDateTime::now_utc().year().to_string());
+    let year = env::var("CURRENT_YEAR").expect("CURRENT_YEAR must be set for reproducible builds");
     println!("cargo:rustc-env=CURRENT_YEAR={year}");
     println!("cargo:rerun-if-env-changed=CURRENT_YEAR");
 

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -93,7 +93,7 @@ pub fn brand_credits() -> String {
 }
 
 fn default_copyright() -> String {
-    let year = option_env!("CURRENT_YEAR").unwrap_or("2025");
+    let year = env!("CURRENT_YEAR");
     format!("Copyright (C) 2024-{year} oc-rsync contributors.")
 }
 

--- a/crates/cli/tests/version.rs
+++ b/crates/cli/tests/version.rs
@@ -28,7 +28,7 @@ fn banner_is_static() {
             option_env!("OFFICIAL_BUILD").unwrap_or("unofficial"),
         ),
     ];
-    let year = option_env!("CURRENT_YEAR").unwrap_or("2025");
+    let year = env!("CURRENT_YEAR");
     expected.push(format!("Copyright (C) 2024-{year} oc-rsync contributors."));
     let tail = include_str!("fixtures/oc-rsync-version-tail.txt");
     expected.extend(tail.lines().map(|l| l.to_string()));

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 missing=()
 
+if [[ -z "${CURRENT_YEAR:-}" ]]; then
+  echo "Error: CURRENT_YEAR environment variable is required for reproducible builds." >&2
+  exit 1
+fi
+
 if ! command -v ld >/dev/null 2>&1; then
   missing+=("ld (linker from binutils)")
 fi


### PR DESCRIPTION
## Summary
- require CURRENT_YEAR environment variable for reproducible builds
- document and validate CURRENT_YEAR in CI and docs
- add preflight check for missing CURRENT_YEAR

## Testing
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` (fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing, hides_temp_files, replay_is_deterministic, cleans_up_temp_dir_on_rename_failure, removes_partial_dir_after_sync, resume_from_partial_file)
- `cargo build --release` twice with same CURRENT_YEAR and compared hashes


------
https://chatgpt.com/codex/tasks/task_e_68bc43637b648323bafb1a2ecf21074b