### PR TITLE
feat(filters): add upstream rule modifiers

### DIFF
--- a/crates/filters/tests/rule_prefixes.rs
+++ b/crates/filters/tests/rule_prefixes.rs
@@ -50,3 +50,11 @@ fn clear_resets_parent_rules() {
     assert!(!matcher.is_included("secret").unwrap());
     assert!(matcher.is_included("sub/secret").unwrap());
 }
+
+#[test]
+fn clear_alias_c() {
+    let mut v = HashSet::new();
+    let rules = parse("- secret\nc\n+ secret\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("secret").unwrap());
+}

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -71,7 +71,7 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | `.rsync-filter` merge semantics | Implemented | [crates/filters/tests/merge.rs](../crates/filters/tests/merge.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Null-delimited filter lists and merges (`--from0`) | Implemented | [crates/filters/tests/include_from.rs](../crates/filters/tests/include_from.rs)<br>[crates/filters/tests/from0_merges.rs](../crates/filters/tests/from0_merges.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Rule logging and statistics | Implemented | [crates/filters/tests/rule_stats.rs](../crates/filters/tests/rule_stats.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
-| Additional rule modifiers | Partial | — | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs)<br>[#268](https://github.com/oferchen/oc-rsync/issues/268) |
+| Additional rule modifiers | Implemented | [crates/filters/tests/rule_modifiers.rs](../crates/filters/tests/rule_modifiers.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | CVS ignore semantics (`--cvs-exclude`) | Partial | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Complex glob patterns | Implemented | [crates/filters/tests/advanced_globs.rs](../crates/filters/tests/advanced_globs.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | `--files-from` directory entries | Implemented | [crates/filters/tests/files_from.rs](../crates/filters/tests/files_from.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |


### PR DESCRIPTION
## Summary
- enumerate upstream filter rule modifiers and centralize mapping
- parse short rule prefixes for hide, dir-merge, and clear
- test dir-merge modifiers and lowercase hide semantics

## Testing
- `make lint`
- `make verify-comments` *(fails: crates/filters/src/lib.rs: additional comments)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_68bc577e052c8323be3f60ec1ff5c65f