### PR TITLE
Handle stdout restoration when stderr buffering fails

### DIFF
--- a/tests/bin_stdio.rs
+++ b/tests/bin_stdio.rs
@@ -3,8 +3,47 @@
 mod stdio;
 
 use oc_rsync_cli::options::OutBuf;
+use std::mem;
 use std::ptr;
-use stdio::{set_std_buffering, set_stream_buffer};
+use stdio::{StdBufferError, set_std_buffering, set_std_buffering_for_test, set_stream_buffer};
+
+#[cfg(not(target_os = "windows"))]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn stdout_ptr() -> *mut libc::FILE {
+    unsafe extern "C" {
+        #[cfg_attr(target_os = "macos", link_name = "__stdoutp")]
+        static mut stdout: *mut libc::FILE;
+    }
+    unsafe { stdout }
+}
+
+#[cfg(not(target_os = "windows"))]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn stderr_ptr() -> *mut libc::FILE {
+    unsafe extern "C" {
+        #[cfg_attr(target_os = "macos", link_name = "__stderrp")]
+        static mut stderr: *mut libc::FILE;
+    }
+    unsafe { stderr }
+}
+
+#[cfg(target_os = "windows")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn stdout_ptr() -> *mut libc::FILE {
+    unsafe extern "C" {
+        fn __acrt_iob_func(idx: libc::c_uint) -> *mut libc::FILE;
+    }
+    unsafe { __acrt_iob_func(1) }
+}
+
+#[cfg(target_os = "windows")]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn stderr_ptr() -> *mut libc::FILE {
+    unsafe extern "C" {
+        fn __acrt_iob_func(idx: libc::c_uint) -> *mut libc::FILE;
+    }
+    unsafe { __acrt_iob_func(2) }
+}
 
 #[test]
 fn mode_changes_ok() {
@@ -26,6 +65,38 @@ fn invalid_setvbuf_returns_error() {
 #[test]
 fn null_stream_returns_error() {
     assert!(set_stream_buffer(ptr::null_mut(), libc::_IONBF).is_err());
+}
+
+#[test]
+fn stderr_failure_restores_stdout() {
+    unsafe {
+        let out = stdout_ptr();
+        let size = mem::size_of::<libc::FILE>();
+        let mut before = vec![0u8; size];
+        ptr::copy_nonoverlapping(out as *const u8, before.as_mut_ptr(), size);
+        let res = set_std_buffering_for_test(libc::_IONBF, out, ptr::null_mut());
+        assert!(matches!(res, Err(StdBufferError::Stderr(_))));
+        let mut after = vec![0u8; size];
+        ptr::copy_nonoverlapping(out as *const u8, after.as_mut_ptr(), size);
+        assert_eq!(before, after);
+    }
+}
+
+#[test]
+fn stdout_failure_reports_error() {
+    unsafe {
+        let err = stderr_ptr();
+        let res = set_std_buffering_for_test(libc::_IONBF, ptr::null_mut(), err);
+        assert!(matches!(res, Err(StdBufferError::Stdout(_))));
+    }
+}
+
+#[test]
+fn both_fail_reports_both() {
+    unsafe {
+        let res = set_std_buffering_for_test(libc::_IONBF, ptr::null_mut(), ptr::null_mut());
+        assert!(matches!(res, Err(StdBufferError::Both { .. })));
+    }
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
## Summary
- ensure both stdio streams share consistent buffering when stderr setup fails
- surface which stream(s) failed during buffering configuration
- add tests that mock stdout/stderr failures and restoration behavior

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace` *(fails: `/usr/bin/ld: cannot find -lacl`)*
- `make verify-comments` *(fails: `src/bin/oc-rsync/stdio.rs: additional comments`)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bc69265df48323b25e294fdaea1a32