### PR TITLE
Default build year to system year

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,8 @@ The Makefile offers shortcuts for common CI checks:
 The CI workflow runs with a consistent environment and enforces comment
 headers:
 
-- Environment variables: `CURRENT_YEAR` (set to the release year),
+- Environment variables: `CURRENT_YEAR` (defaults to the system year but
+  can be set for reproducible builds),
   `RUSTFLAGS="-Dwarnings"`, `LC_ALL=C`, `LANG=C`, `COLUMNS=80`, and `TZ=UTC`.
   - Repository access is read only (`permissions: { contents: read }`) and a
     concurrency group (`ci-${{ github.ref }}`) cancels in-progress runs for the same

--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 Run `scripts/preflight.sh` to verify these dependencies before building. Then
 install from crates.io or build from a local checkout:
 
+The build script embeds the current year into the binary for copyright
+messages. If the `CURRENT_YEAR` environment variable is not set, the build
+defaults to the system year. Set this variable when you need reproducible
+builds across years.
+
 If `libacl1-dev` isn't available, disable ACL support with the `no-acl`
 feature set:
 

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,8 @@
 
 use std::{env, fs, path::Path, path::PathBuf, process::Command};
 
+use time::OffsetDateTime;
+
 const UPSTREAM_VERSION: &str = "3.4.1";
 const SUPPORTED_PROTOCOLS: &[u32] = &[32, 31, 30];
 const BRANDING_VARS: &[&str] = &[
@@ -93,7 +95,8 @@ fn main() {
         println!("cargo:rerun-if-env-changed={key}");
     }
 
-    let year = env::var("CURRENT_YEAR").expect("CURRENT_YEAR must be set for reproducible builds");
+    let year =
+        env::var("CURRENT_YEAR").unwrap_or_else(|_| OffsetDateTime::now_utc().year().to_string());
     println!("cargo:rustc-env=CURRENT_YEAR={year}");
     println!("cargo:rerun-if-env-changed=CURRENT_YEAR");
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "oc-rsync-cli"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [dependencies]
 clap = { version = "4.5.47", features = ["derive", "env"] }
@@ -38,4 +39,7 @@ serial_test = "2"
 [features]
 default = []
 dump-help = []
+
+[build-dependencies]
+time = { version = "0.3", default-features = false, features = ["std"] }
 

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,0 +1,9 @@
+use std::env;
+use time::OffsetDateTime;
+
+fn main() {
+    let year =
+        env::var("CURRENT_YEAR").unwrap_or_else(|_| OffsetDateTime::now_utc().year().to_string());
+    println!("cargo:rustc-env=CURRENT_YEAR={year}");
+    println!("cargo:rerun-if-env-changed=CURRENT_YEAR");
+}

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 missing=()
 
 if [[ -z "${CURRENT_YEAR:-}" ]]; then
-  echo "Error: CURRENT_YEAR environment variable is required for reproducible builds." >&2
-  exit 1
+  echo "Warning: CURRENT_YEAR environment variable not set; build.rs will use the system year." >&2
 fi
 
 if ! command -v ld >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Default `CURRENT_YEAR` to the system year in build scripts, allowing override for reproducible builds
- Document automatic year handling in README and contribution docs
- Relax preflight checks and propagate year to CLI crate

## Testing
- `cargo build` (no `CURRENT_YEAR` set)
- `CURRENT_YEAR=1999 cargo build`
- `make verify-comments` *(fails: src/bin/oc-rsync/stdio.rs: additional comments)*
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: multiple tests including daemon::sequential_connections::handle_sequential_chrooted_connections)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(terminated after warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6bd81f188323b9e13c6ba2c69265