### PR TITLE
Remove redundant comments in stdio buffering

### DIFF
--- a/src/bin/oc-rsync/stdio.rs
+++ b/src/bin/oc-rsync/stdio.rs
@@ -122,8 +122,6 @@ pub fn set_std_buffering(mode: OutBuf) -> Result<(), StdBufferError> {
         OutBuf::B => libc::_IOFBF,
     };
     let out = stdout_stream().map_err(StdBufferError::Stdout)?.as_ptr();
-    // Capture err stream after successfully setting stdout to allow restore on failure
-    // Errors from stdout will also be reported.
     let err = stderr_stream().map_err(StdBufferError::Stderr)?.as_ptr();
     set_std_buffering_raw(mode, out, err)
 }


### PR DESCRIPTION
## Summary
- drop outdated comments around stderr capture in `set_std_buffering`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: hides_temp_files, replay_is_deterministic, cleans_up_temp_dir_on_rename_failure, removes_partial_dir_after_sync, resume_from_partial_file, etc.)*
- `make verify-comments` *(fails: crates/cli/build.rs incorrect header)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc71f793c8832395a64223db27b12a