### PR TITLE
Validate compression level range for CLI and zlib

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,3 +1,4 @@
+// crates/cli/build.rs
 use std::env;
 use time::OffsetDateTime;
 

--- a/crates/cli/src/options.rs
+++ b/crates/cli/src/options.rs
@@ -466,7 +466,8 @@ pub(crate) struct ClientOpts {
         long = "compress-level",
         value_name = "NUM",
         help_heading = "Compression",
-        visible_alias = "zl"
+        visible_alias = "zl",
+        value_parser = clap::value_parser!(i32).range(0..=9)
     )]
     pub compress_level: Option<i32>,
     #[arg(

--- a/crates/cli/tests/compress_level.rs
+++ b/crates/cli/tests/compress_level.rs
@@ -1,0 +1,31 @@
+// crates/cli/tests/compress_level.rs
+use clap::error::ErrorKind;
+use oc_rsync_cli::cli_command;
+
+#[test]
+fn compress_level_accepts_range() {
+    let mut cmd = cli_command();
+    let matches = cmd
+        .try_get_matches_from(["prog", "--compress-level", "0", "src", "dst"])
+        .expect("valid level 0");
+    assert_eq!(matches.get_one::<i32>("compress_level"), Some(&0));
+    let mut cmd = cli_command();
+    let matches = cmd
+        .try_get_matches_from(["prog", "--compress-level", "9", "src", "dst"])
+        .expect("valid level 9");
+    assert_eq!(matches.get_one::<i32>("compress_level"), Some(&9));
+}
+
+#[test]
+fn compress_level_rejects_out_of_range() {
+    let mut cmd = cli_command();
+    let err = cmd
+        .try_get_matches_from(["prog", "--compress-level", "10", "src", "dst"])
+        .unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::ValueValidation);
+    let mut cmd = cli_command();
+    let err = cmd
+        .try_get_matches_from(["prog", "--compress-level=-1", "src", "dst"])
+        .unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::ValueValidation);
+}

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -96,6 +96,7 @@ pub struct Zlib {
 #[cfg(feature = "zlib")]
 impl Zlib {
     pub fn new(level: i32) -> Self {
+        let level = level.clamp(0, 9);
         Self { level }
     }
 }

--- a/crates/compress/tests/zlib.rs
+++ b/crates/compress/tests/zlib.rs
@@ -1,0 +1,20 @@
+// crates/compress/tests/zlib.rs
+#[cfg(feature = "zlib")]
+use compress::{Compressor, Zlib};
+
+#[cfg(feature = "zlib")]
+#[test]
+fn zlib_new_clamps_level() {
+    let data = b"clamp test data";
+    let compress_with = |lvl: i32| {
+        let codec = Zlib::new(lvl);
+        let mut compressed = Vec::new();
+        codec
+            .compress(&mut &data[..], &mut compressed)
+            .expect("compress");
+        compressed
+    };
+
+    assert_eq!(compress_with(10), compress_with(9));
+    assert_eq!(compress_with(-5), compress_with(0));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2649,6 +2649,15 @@ fn invalid_compress_level_fails() {
 }
 
 #[test]
+fn out_of_range_compress_level_fails() {
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["--compress-level", "10"])
+        .assert()
+        .failure();
+}
+
+#[test]
 fn help_flag_prints_usage() {
     Command::cargo_bin("oc-rsync")
         .unwrap()


### PR DESCRIPTION
## Summary
- enforce --compress-level to accept only values 0-9 via clap
- clamp zlib compression level to rsync's valid range
- add tests for valid and invalid compression levels

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `/usr/bin/ld: cannot find -lacl`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: `/usr/bin/ld: cannot find -lacl`)*

------
https://chatgpt.com/codex/tasks/task_e_68bc75ad52d88323801cf134b51917d2