### PR TITLE
Remove dead code allowances and gate test helpers

### DIFF
--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -174,16 +174,14 @@ impl Zstd {
     }
 }
 
-#[cfg(feature = "zstd")]
+#[cfg(all(feature = "zstd", test))]
 #[inline]
-#[allow(dead_code)]
 fn zstd_compress_scalar(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     zstd::bulk::compress(data, level).map_err(io::Error::other)
 }
 
-#[cfg(feature = "zstd")]
+#[cfg(all(feature = "zstd", test))]
 #[inline]
-#[allow(dead_code)]
 fn zstd_decompress_scalar(data: &[u8]) -> io::Result<Vec<u8>> {
     let mut decoder = zstd::stream::Decoder::new(data)?;
     let mut out = Vec::new();
@@ -191,9 +189,11 @@ fn zstd_decompress_scalar(data: &[u8]) -> io::Result<Vec<u8>> {
     Ok(out)
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[target_feature(enable = "sse4.2")]
 /// Compress data using zstd with SSE4.2 optimizations.
 ///
@@ -211,9 +211,11 @@ unsafe fn zstd_compress_sse42(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     Ok(out)
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 fn zstd_compress_sse42_safe(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     if std::arch::is_x86_feature_detected!("sse4.2") {
         unsafe { zstd_compress_sse42(data, level) }
@@ -225,9 +227,11 @@ fn zstd_compress_sse42_safe(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     }
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[target_feature(enable = "avx2")]
 /// Compress data using zstd with AVX2 optimizations.
 ///
@@ -245,9 +249,11 @@ unsafe fn zstd_compress_avx2(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     Ok(out)
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 fn zstd_compress_avx2_safe(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     if std::arch::is_x86_feature_detected!("avx2") {
         unsafe { zstd_compress_avx2(data, level) }
@@ -259,9 +265,12 @@ fn zstd_compress_avx2_safe(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     }
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    feature = "nightly",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[target_feature(enable = "avx512f")]
 /// Compress data using zstd with AVX512 optimizations.
 ///
@@ -279,9 +288,12 @@ unsafe fn zstd_compress_avx512(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     Ok(out)
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    feature = "nightly",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 fn zstd_compress_avx512_safe(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     if std::arch::is_x86_feature_detected!("avx512f") {
         unsafe { zstd_compress_avx512(data, level) }
@@ -293,9 +305,11 @@ fn zstd_compress_avx512_safe(data: &[u8], level: i32) -> io::Result<Vec<u8>> {
     }
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[target_feature(enable = "sse4.2")]
 /// Decompress data using zstd with SSE4.2 optimizations.
 ///
@@ -315,9 +329,11 @@ unsafe fn zstd_decompress_sse42(data: &[u8]) -> io::Result<Vec<u8>> {
     Ok(out)
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 fn zstd_decompress_sse42_safe(data: &[u8]) -> io::Result<Vec<u8>> {
     if std::arch::is_x86_feature_detected!("sse4.2") {
         unsafe { zstd_decompress_sse42(data) }
@@ -329,9 +345,11 @@ fn zstd_decompress_sse42_safe(data: &[u8]) -> io::Result<Vec<u8>> {
     }
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[target_feature(enable = "avx2")]
 /// Decompress data using zstd with AVX2 optimizations.
 ///
@@ -351,9 +369,11 @@ unsafe fn zstd_decompress_avx2(data: &[u8]) -> io::Result<Vec<u8>> {
     Ok(out)
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 fn zstd_decompress_avx2_safe(data: &[u8]) -> io::Result<Vec<u8>> {
     if std::arch::is_x86_feature_detected!("avx2") {
         unsafe { zstd_decompress_avx2(data) }
@@ -365,9 +385,12 @@ fn zstd_decompress_avx2_safe(data: &[u8]) -> io::Result<Vec<u8>> {
     }
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    feature = "nightly",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[target_feature(enable = "avx512f")]
 /// Decompress data using zstd with AVX512 optimizations.
 ///
@@ -387,9 +410,12 @@ unsafe fn zstd_decompress_avx512(data: &[u8]) -> io::Result<Vec<u8>> {
     Ok(out)
 }
 
-#[cfg(feature = "zstd")]
-#[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
-#[allow(dead_code)]
+#[cfg(all(
+    feature = "zstd",
+    feature = "nightly",
+    test,
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 fn zstd_decompress_avx512_safe(data: &[u8]) -> io::Result<Vec<u8>> {
     if std::arch::is_x86_feature_detected!("avx512f") {
         unsafe { zstd_decompress_avx512(data) }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -388,19 +388,6 @@ fn remove_basename_partial(dest: &Path) {
     }
 }
 
-#[allow(dead_code)]
-fn temp_file_path(parent: &Path, base: &OsStr) -> Result<PathBuf> {
-    #[allow(deprecated)]
-    let tmp = Builder::new()
-        .prefix(&format!(".{}.", base.to_string_lossy()))
-        .rand_bytes(6)
-        .tempfile_in(parent)
-        .map_err(|e| io_context(parent, e))?;
-    let path = tmp.path().to_path_buf();
-    tmp.close().map_err(|e| io_context(&path, e))?;
-    Ok(path)
-}
-
 struct TempFileGuard {
     path: PathBuf,
 }

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -21,23 +21,12 @@ pub struct RuleFlags {
     xattr: bool,
 }
 
-#[allow(dead_code)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum RuleModifier {
-    Sender,
-    Receiver,
-    Perishable,
-    Xattr,
-}
-
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum MergeModifier {
     IncludeOnly,
     ExcludeOnly,
     NoInherit,
     WordSplit,
-    ExcludeSelf,
     CvsMode,
 }
 
@@ -49,7 +38,6 @@ impl MergeModifier {
             MergeModifier::NoInherit => pd.inherit = false,
             MergeModifier::WordSplit => pd.word_split = true,
             MergeModifier::CvsMode => pd.cvs = true,
-            MergeModifier::ExcludeSelf => {}
         }
     }
 }

--- a/src/bin/oc-rsync/stdio.rs
+++ b/src/bin/oc-rsync/stdio.rs
@@ -134,7 +134,6 @@ pub fn set_std_buffering(mode: OutBuf) -> Result<(), StdBufferError> {
 }
 
 #[cfg(test)]
-#[allow(dead_code)]
 pub(crate) unsafe fn set_std_buffering_for_test(
     mode: libc::c_int,
     orig_mode: libc::c_int,
@@ -142,4 +141,21 @@ pub(crate) unsafe fn set_std_buffering_for_test(
     err: *mut libc::FILE,
 ) -> Result<(), StdBufferError> {
     set_std_buffering_raw(mode, orig_mode, out, err)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke() {
+        unsafe {
+            let _ = set_std_buffering_for_test(
+                libc::_IONBF,
+                libc::_IOLBF,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Gate SIMD zstd helpers behind `cfg(test)` and drop dead code allows
- Trim unused rule modifier types in filters
- Remove leftover temp file helper in engine
- Add test hook and usage to `stdio` without dead code allowances

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(failed: linking with `cc` failed: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(failed: linking with `cc` failed: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc833f018883239382ea68828ab85b