### PR TITLE
Rename Zlibx codec variant to ZlibX

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -517,7 +517,7 @@ fn run_single(
             for name in s.split(',') {
                 let codec = match name {
                     "zlib" => Codec::Zlib,
-                    "zlibx" => Codec::Zlibx,
+                    "zlibx" => Codec::ZlibX,
                     "zstd" => Codec::Zstd,
                     other => {
                         return Err(EngineError::Other(format!("unknown codec {other}")));

--- a/crates/compress/src/lib.rs
+++ b/crates/compress/src/lib.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Codec {
     Zlib,
-    Zlibx,
+    ZlibX,
     Zstd,
 }
 
@@ -14,7 +14,7 @@ impl Codec {
     pub fn to_byte(self) -> u8 {
         match self {
             Codec::Zlib => 1,
-            Codec::Zlibx => 2,
+            Codec::ZlibX => 2,
             Codec::Zstd => 4,
         }
     }
@@ -22,7 +22,7 @@ impl Codec {
     pub fn from_byte(b: u8) -> io::Result<Self> {
         match b {
             1 => Ok(Codec::Zlib),
-            2 => Ok(Codec::Zlibx),
+            2 => Ok(Codec::ZlibX),
             4 => Ok(Codec::Zstd),
             other => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -37,7 +37,7 @@ pub fn available_codecs() -> Vec<Codec> {
         #[cfg(feature = "zstd")]
         Codec::Zstd,
         #[cfg(feature = "zlib")]
-        Codec::Zlibx,
+        Codec::ZlibX,
         #[cfg(feature = "zlib")]
         Codec::Zlib,
     ];
@@ -477,7 +477,7 @@ mod tests {
     fn available_codecs_returns_all_codecs() {
         assert_eq!(
             available_codecs(),
-            vec![Codec::Zstd, Codec::Zlibx, Codec::Zlib]
+            vec![Codec::Zstd, Codec::ZlibX, Codec::Zlib]
         );
     }
 
@@ -490,7 +490,7 @@ mod tests {
     #[cfg(all(feature = "zlib", not(feature = "zstd")))]
     #[test]
     fn available_codecs_returns_only_zlib() {
-        assert_eq!(available_codecs(), vec![Codec::Zlibx, Codec::Zlib]);
+        assert_eq!(available_codecs(), vec![Codec::ZlibX, Codec::Zlib]);
     }
 
     #[cfg(all(not(feature = "zlib"), not(feature = "zstd")))]

--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -86,7 +86,7 @@ fn encode_decode_roundtrip_and_error() {
     {
         codecs.push(Codec::Zlib);
         bytes.push(1);
-        codecs.push(Codec::Zlibx);
+        codecs.push(Codec::ZlibX);
         bytes.push(2);
     }
     #[cfg(feature = "zstd")]
@@ -132,7 +132,7 @@ fn available_codecs_matches_features() {
     expected.push(Codec::Zstd);
     #[cfg(feature = "zlib")]
     {
-        expected.push(Codec::Zlibx);
+        expected.push(Codec::ZlibX);
         expected.push(Codec::Zlib);
     }
     assert_eq!(available_codecs(), expected);

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1368,7 +1368,7 @@ impl Sender {
             if let Some(codec) = file_codec {
                 if let Op::Data(ref mut d) = op {
                     *d = match codec {
-                        Codec::Zlib | Codec::Zlibx => {
+                        Codec::Zlib | Codec::ZlibX => {
                             let lvl = self.opts.compress_level.unwrap_or(6);
                             let mut out = Vec::new();
                             let mut cursor = d.as_slice();
@@ -1674,7 +1674,7 @@ impl Receiver {
             if let Some(codec) = file_codec {
                 if let Op::Data(ref mut d) = op {
                     *d = match codec {
-                        Codec::Zlib | Codec::Zlibx => {
+                        Codec::Zlib | Codec::ZlibX => {
                             let mut out = Vec::new();
                             let mut cursor = d.as_slice();
                             ZlibX::default()
@@ -2265,7 +2265,7 @@ pub fn select_codec(remote: &[Codec], opts: &SyncOptions) -> Option<Codec> {
     }
     let choices: Vec<Codec> = opts.compress_choice.clone().unwrap_or_else(|| {
         let mut v = vec![Codec::Zstd];
-        v.push(Codec::Zlibx);
+        v.push(Codec::ZlibX);
         v.push(Codec::Zlib);
         v
     });

--- a/crates/engine/tests/compress.rs
+++ b/crates/engine/tests/compress.rs
@@ -38,7 +38,7 @@ fn zlibx_roundtrip() {
         &src,
         &dst,
         &Matcher::default(),
-        &[Codec::Zlibx],
+        &[Codec::ZlibX],
         &SyncOptions {
             compress: true,
             ..Default::default()
@@ -76,19 +76,19 @@ fn codec_selection_respects_options() {
         ..Default::default()
     };
     assert_eq!(
-        select_codec(&[Codec::Zlib, Codec::Zlibx, Codec::Zstd], &opts,),
+        select_codec(&[Codec::Zlib, Codec::ZlibX, Codec::Zstd], &opts,),
         Some(Codec::Zstd)
     );
-    assert_eq!(select_codec(&[Codec::Zlibx], &opts), Some(Codec::Zlibx));
+    assert_eq!(select_codec(&[Codec::ZlibX], &opts), Some(Codec::ZlibX));
 
     let opts = SyncOptions {
         compress: true,
-        compress_choice: Some(vec![Codec::Zlibx, Codec::Zlib]),
+        compress_choice: Some(vec![Codec::ZlibX, Codec::Zlib]),
         ..Default::default()
     };
     assert_eq!(
-        select_codec(&[Codec::Zlibx, Codec::Zstd], &opts),
-        Some(Codec::Zlibx)
+        select_codec(&[Codec::ZlibX, Codec::Zstd], &opts),
+        Some(Codec::ZlibX)
     );
 
     let opts = SyncOptions {


### PR DESCRIPTION
## Summary
- rename compression codec variant `Zlibx` to `ZlibX`
- update engine, CLI, and tests to use the new variant
- keep CLI parsing accepting the `zlibx` string

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast` *(fails: 783 passed, 175 failed, 1 leaky)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly" --status-level fail --hide-progress-bar --failure-output never --success-output never` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc86f890448323875f9977b0930b7b