### PR TITLE
Use Cow for charset conversions

### DIFF
--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -118,7 +118,7 @@ pub fn spawn_daemon_session(
                 break;
             }
             let s = if let Some(cv) = iconv {
-                cv.decode_remote(&line)
+                cv.decode_remote(&line).into_owned()
             } else {
                 String::from_utf8_lossy(&line).into_owned()
             };
@@ -150,11 +150,11 @@ pub fn spawn_daemon_session(
     t.set_write_timeout(timeout).map_err(EngineError::from)?;
 
     if let Some(cv) = iconv {
-        let mut line = cv.encode_remote(module);
+        let mut line = cv.encode_remote(module).into_owned();
         line.push(b'\n');
         t.send(&line).map_err(EngineError::from)?;
         for opt in &opts.remote_options {
-            let mut o = cv.encode_remote(opt);
+            let mut o = cv.encode_remote(opt).into_owned();
             o.push(b'\n');
             t.send(&o).map_err(EngineError::from)?;
         }

--- a/crates/cli/src/exec.rs
+++ b/crates/cli/src/exec.rs
@@ -194,7 +194,7 @@ pub(crate) fn execute_transfer(
                 let (err, _) = session.stderr();
                 if !err.is_empty() {
                     let msg = if let Some(cv) = iconv {
-                        cv.decode_remote(&err)
+                        cv.decode_remote(&err).into_owned()
                     } else {
                         String::from_utf8_lossy(&err).into_owned()
                     };
@@ -274,7 +274,7 @@ pub(crate) fn execute_transfer(
                 let (err, _) = session.stderr();
                 if !err.is_empty() {
                     let msg = if let Some(cv) = iconv {
-                        cv.decode_remote(&err)
+                        cv.decode_remote(&err).into_owned()
                     } else {
                         String::from_utf8_lossy(&err).into_owned()
                     };

--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -11,7 +11,7 @@ pub(crate) fn check_session_errors(
     let (err, _) = session.stderr();
     if !err.is_empty() {
         let msg = if let Some(cv) = iconv {
-            cv.decode_remote(&err)
+            cv.decode_remote(&err).into_owned()
         } else {
             String::from_utf8_lossy(&err).into_owned()
         };

--- a/crates/cli/tests/iconv.rs
+++ b/crates/cli/tests/iconv.rs
@@ -36,7 +36,7 @@ fn invalid_iconv_spec_errors() {
 #[test]
 fn iconv_converts_encodings() {
     let cv = parse_iconv("utf-8,iso8859-1").unwrap();
-    assert_eq!(cv.encode_remote("é"), vec![0xe9]);
-    let local = cv.to_local(&[0xe9]);
+    assert_eq!(cv.encode_remote("é").into_owned(), vec![0xe9]);
+    let local = cv.to_local(&[0xe9]).into_owned();
     assert_eq!(String::from_utf8(local).unwrap(), "é");
 }

--- a/crates/engine/src/flist.rs
+++ b/crates/engine/src/flist.rs
@@ -10,7 +10,7 @@ pub fn encode(entries: &[Entry], iconv: Option<&CharsetConv>) -> Vec<Vec<u8>> {
         .map(|e| {
             let mut e = e.clone();
             if let Some(cv) = iconv {
-                e.path = cv.to_remote(&e.path);
+                e.path = cv.to_remote(&e.path).into_owned();
             }
             enc.encode_entry(&e)
         })
@@ -27,7 +27,7 @@ pub fn decode(
         .map(|c| {
             let mut e = dec.decode_entry(c)?;
             if let Some(cv) = iconv {
-                e.path = cv.to_local(&e.path);
+                e.path = cv.to_local(&e.path).into_owned();
             }
             Ok(e)
         })

--- a/crates/protocol/tests/charset_conv.rs
+++ b/crates/protocol/tests/charset_conv.rs
@@ -1,0 +1,38 @@
+use encoding_rs::Encoding;
+use protocol::CharsetConv;
+use std::borrow::Cow;
+
+#[test]
+fn round_trip_between_encodings() {
+    let cv = CharsetConv::new(
+        Encoding::for_label(b"iso-8859-1").unwrap(),
+        Encoding::for_label(b"utf-8").unwrap(),
+    );
+    let text = "Grüße";
+    let encoded = cv.encode_remote(text);
+    assert_eq!(encoded.as_ref(), &[0x47, 0x72, 0xFC, 0xDF, 0x65]);
+    let decoded = cv.decode_remote(encoded.as_ref());
+    assert_eq!(decoded, "Grüße");
+
+    let remote = cv.to_remote(text.as_bytes());
+    assert_eq!(remote.as_ref(), encoded.as_ref());
+    let local = cv.to_local(remote.as_ref());
+    assert_eq!(local.as_ref(), text.as_bytes());
+}
+
+#[test]
+fn identity_conversions_borrow() {
+    let cv = CharsetConv::new(
+        Encoding::for_label(b"utf-8").unwrap(),
+        Encoding::for_label(b"utf-8").unwrap(),
+    );
+    let s = "hello";
+    let enc = cv.encode_remote(s);
+    assert!(matches!(enc, Cow::Borrowed(_)));
+    let dec = cv.decode_remote(s.as_bytes());
+    assert!(matches!(dec, Cow::Borrowed(_)));
+    let to_remote = cv.to_remote(s.as_bytes());
+    assert!(matches!(to_remote, Cow::Borrowed(_)));
+    let to_local = cv.to_local(s.as_bytes());
+    assert!(matches!(to_local, Cow::Borrowed(_)));
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -577,9 +577,9 @@ fn iconv_transcodes_filenames() {
     let spec = "utf8,latin1";
     let cv = parse_iconv(spec).unwrap();
     let remote = b"f\xF8o";
-    let local = cv.to_local(remote);
+    let local = cv.to_local(remote).into_owned();
     assert_eq!(local, b"f\xC3\xB8o");
-    let roundtrip = cv.to_remote(&local);
+    let roundtrip = cv.to_remote(&local).into_owned();
     assert_eq!(roundtrip, remote);
 }
 


### PR DESCRIPTION
## Summary
- refactor `CharsetConv` to return `Cow` to avoid allocations on identity conversions
- adjust callers to accept `Cow` results
- add tests for cross-encoding round-trips and borrowed conversions

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` exited with status 1)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linking with `cc` exited with status 1)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc9a45f57c8323bde816d313c3622e