### PR TITLE
docs: update interop script links

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -10,10 +10,10 @@ when available. Do not exceed functionality of upstream at <https://rsync.samba.
 ## Interop matrix scenarios
 
 The interoperability matrix builds upstream `rsync 3.4.1` via
-[tests/interop/build_upstream.sh](../tests/interop/build_upstream.sh) and
+[scripts/interop.sh](../scripts/interop.sh) and
 exercises real transfers. The following scenarios are currently captured:
 
-  - `base`: baseline transfer using [run_matrix.sh](../tests/interop/run_matrix.sh)
+  - `base`: baseline transfer using [interop.sh](../scripts/interop.sh)
   - `delete`: `--delete` removes extraneous files
   - `compression`: zlib/zstd negotiation using [codec_negotiation.rs](../tests/interop/codec_negotiation.rs)
   - `filters`: include/exclude and `.rsync-filter` rules via [filter_complex.rs](../tests/interop/filter_complex.rs)


### PR DESCRIPTION
## Summary
- point interop matrix docs to new scripts/interop.sh
- refresh base scenario link to new script location

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: value used here after move)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments` *(fails: incorrect header)*
- `make lint`
- `scripts/check-run-matrix-docs.sh` *(fails: docs/gaps.md scenarios do not match tests/interop/run_matrix.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9ec6c78c8323831647e10a9e9c0a