### PR TITLE
engine: gate AsRawFd import

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -4,8 +4,15 @@
 use nix::unistd::{Gid, Uid, chown};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, Write};
-#[cfg(unix)]
-#[allow(unused_imports)]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "illumos",
+    target_os = "solaris",
+))]
 use std::os::fd::AsRawFd;
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt};


### PR DESCRIPTION
## Summary
- gate AsRawFd to only compile on platforms that use it

## Testing
- `cargo fmt --all`
- `cargo nextest run --workspace --no-fail-fast` (fails: cannot find -lacl)
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` (fails: cannot find -lacl)
- `make verify-comments` (fails: crates/protocol/tests/charset_conv.rs incorrect header)
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68bca627a1c0832387cc096cba081cd1