### PR TITLE
Verify upstream rsync downloads

### DIFF
--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -9,6 +9,12 @@ FILELIST_DIR="$INTEROP_DIR/filelists"
 VERSIONS=("3.0.9" "3.1.3" "3.4.1")
 FLAGS=(--recursive --times --perms)
 
+declare -A RSYNC_SHA256=(
+  ["3.0.9"]="30f10f8dd5490d28240d4271bb652b1da7a60b22ed2b9ae28090668de9247c05"
+  ["3.1.3"]="55cc554efec5fdaad70de921cd5a5eeb6c29a95524c715f3bbf849235b0800c0"
+  ["3.4.1"]="2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52"
+)
+
 mkdir -p "$WIRE_DIR" "$FILELIST_DIR"
 
 ensure_build_deps() {
@@ -63,6 +69,12 @@ download_rsync() {
     pushd "$ROOT/target/upstream" >/dev/null
     tarball="rsync-$ver.tar.gz"
     curl -L "https://download.samba.org/pub/rsync/src/$tarball" -o "$tarball"
+    sha="${RSYNC_SHA256[$ver]}"
+    if [[ -z "$sha" ]]; then
+      echo "missing checksum for rsync $ver" >&2
+      exit 1
+    fi
+    echo "$sha  $tarball" | sha256sum -c -
     tar xzf "$tarball"
     pushd "rsync-$ver" >/dev/null
     ./configure --prefix="$prefix" >/dev/null


### PR DESCRIPTION
## Summary
- verify downloaded upstream rsync tarballs in `scripts/interop.sh`
- store known SHA256 checksums for supported rsync versions

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command: `nextest`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: no such command: `nextest`)*
- `make verify-comments` *(interrupted)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bca8a11f7c8323a0e7c6ef8f2c707e