### PR TITLE
test: differentiate stdio pointers

### DIFF
--- a/src/bin/oc-rsync/stdio.rs
+++ b/src/bin/oc-rsync/stdio.rs
@@ -172,8 +172,10 @@ mod tests {
 
     #[test]
     fn stdout_failure() {
-        let out: *mut libc::FILE = std::ptr::dangling_mut();
-        let err: *mut libc::FILE = std::ptr::dangling_mut();
+        let mut out_stub = std::mem::MaybeUninit::<libc::FILE>::uninit();
+        let mut err_stub = std::mem::MaybeUninit::<libc::FILE>::uninit();
+        let out: *mut libc::FILE = out_stub.as_mut_ptr();
+        let err: *mut libc::FILE = err_stub.as_mut_ptr();
         let set_stream = |stream: *mut libc::FILE, _mode: libc::c_int| {
             if stream == out {
                 Err(io::Error::other("stdout failure"))
@@ -187,8 +189,10 @@ mod tests {
 
     #[test]
     fn stderr_failure() {
-        let out: *mut libc::FILE = std::ptr::dangling_mut();
-        let err: *mut libc::FILE = std::ptr::dangling_mut();
+        let mut out_stub = std::mem::MaybeUninit::<libc::FILE>::uninit();
+        let mut err_stub = std::mem::MaybeUninit::<libc::FILE>::uninit();
+        let out: *mut libc::FILE = out_stub.as_mut_ptr();
+        let err: *mut libc::FILE = err_stub.as_mut_ptr();
         let set_stream = |stream: *mut libc::FILE, _mode: libc::c_int| {
             if stream == err {
                 Err(io::Error::other("stderr failure"))


### PR DESCRIPTION
## Summary
- ensure stdout/stderr tests use distinct non-null pointers

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: value used here after move)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: value used here after move)*
- `make verify-comments` *(fails: crates/protocol/tests/charset_conv.rs: incorrect header)*
- `make lint`
- `cargo test --bin oc-rsync`


------
https://chatgpt.com/codex/tasks/task_e_68bcac08ede08323a0ab82d2349a6a3f