### PR TITLE
test: cover md4 and default md5 checksum seed behavior

### DIFF
--- a/tests/checksum_seed.rs
+++ b/tests/checksum_seed.rs
@@ -22,28 +22,28 @@ fn checksum_seed_changes_strong_checksum() {
     let strong1 = cfg1.checksum(data).strong;
     let hex0 = hex::encode(&strong0);
     let hex1 = hex::encode(&strong1);
-    assert_eq!(hex0, "7ced6b52c8203ba97580659d7dc33548");
-    assert_eq!(hex1, "681d333539cc115fe7b2f40bb5aa8b89");
+    assert_eq!(hex0, "be4b47980f89d075f8f7e7a9fab84e29");
+    assert_eq!(hex1, "157438ee5881306a9af554cc9b3e5974");
     assert_ne!(hex0, hex1);
 }
 
 #[test]
-fn checksum_seed_changes_strong_checksum_md5() {
+fn checksum_seed_changes_strong_checksum_md4() {
     let data = b"hello world";
     let cfg0 = ChecksumConfigBuilder::new()
         .seed(0)
-        .strong(StrongHash::Md5)
+        .strong(StrongHash::Md4)
         .build();
     let cfg1 = ChecksumConfigBuilder::new()
         .seed(1)
-        .strong(StrongHash::Md5)
+        .strong(StrongHash::Md4)
         .build();
     let strong0 = cfg0.checksum(data).strong;
     let strong1 = cfg1.checksum(data).strong;
     let hex0 = hex::encode(&strong0);
     let hex1 = hex::encode(&strong1);
-    assert_eq!(hex0, "be4b47980f89d075f8f7e7a9fab84e29");
-    assert_eq!(hex1, "157438ee5881306a9af554cc9b3e5974");
+    assert_eq!(hex0, "7ced6b52c8203ba97580659d7dc33548");
+    assert_eq!(hex1, "681d333539cc115fe7b2f40bb5aa8b89");
     assert_ne!(hex0, hex1);
 }
 


### PR DESCRIPTION
## Summary
- clarify MD4 strong checksum test with explicit StrongHash::Md4
- add test for default MD5 strong checksum behavior

## Testing
- `make verify-comments` *(fails: crates/protocol/tests/charset_conv.rs: incorrect header)*
- `make lint`
- `cargo test` *(fails: linking with `cc` failed: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linking with `cc` failed: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb03842d08323811cbc919227a257