### PR TITLE
Default strong checksum to MD4

### DIFF
--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -26,7 +26,7 @@ pub struct ChecksumConfigBuilder {
 impl Default for ChecksumConfigBuilder {
     fn default() -> Self {
         Self {
-            strong: StrongHash::Md5,
+            strong: StrongHash::Md4,
             seed: 0,
         }
     }
@@ -169,8 +169,8 @@ pub fn strong_digest(data: &[u8], alg: StrongHash, seed: u32) -> Vec<u8> {
 pub fn available_strong_hashes() -> Vec<StrongHash> {
     vec![
         StrongHash::XxHash,
-        StrongHash::Md5,
         StrongHash::Md4,
+        StrongHash::Md5,
         StrongHash::Sha1,
     ]
 }

--- a/crates/checksums/tests/golden.rs
+++ b/crates/checksums/tests/golden.rs
@@ -32,8 +32,8 @@ fn rolling_golden_windows() {
 
 #[test]
 fn builder_strong_digests() {
-    let cfg_md5 = ChecksumConfigBuilder::new().build();
-    let cfg_md4 = ChecksumConfigBuilder::new().strong(StrongHash::Md4).build();
+    let cfg_default = ChecksumConfigBuilder::new().build();
+    let cfg_md5 = ChecksumConfigBuilder::new().strong(StrongHash::Md5).build();
     let cfg_sha1 = ChecksumConfigBuilder::new()
         .strong(StrongHash::Sha1)
         .build();
@@ -42,18 +42,18 @@ fn builder_strong_digests() {
         .build();
     let data = b"hello world";
 
+    let cs_default = cfg_default.checksum(data);
+    assert_eq!(cs_default.weak, rolling_checksum(data));
+    assert_eq!(
+        hex::encode(cs_default.strong),
+        "7ced6b52c8203ba97580659d7dc33548"
+    );
+
     let cs_md5 = cfg_md5.checksum(data);
     assert_eq!(cs_md5.weak, rolling_checksum(data));
     assert_eq!(
         hex::encode(cs_md5.strong),
         "be4b47980f89d075f8f7e7a9fab84e29"
-    );
-
-    let cs_md4 = cfg_md4.checksum(data);
-    assert_eq!(cs_md4.weak, rolling_checksum(data));
-    assert_eq!(
-        hex::encode(cs_md4.strong),
-        "7ced6b52c8203ba97580659d7dc33548"
     );
 
     let cs_sha1 = cfg_sha1.checksum(data);
@@ -78,10 +78,10 @@ fn negotiation_picks_common_algorithm() {
 }
 
 #[test]
-fn negotiation_defaults_to_md5_when_no_common() {
+fn negotiation_defaults_to_md4_when_no_common() {
     let remote: Vec<StrongHash> = Vec::new();
     let cfg = ChecksumConfigBuilder::new().negotiate(&remote).build();
     let ours = cfg.checksum(b"test");
-    let expected = strong_digest(b"test", StrongHash::Md5, 0);
+    let expected = strong_digest(b"test", StrongHash::Md4, 0);
     assert_eq!(ours.strong, expected);
 }

--- a/crates/protocol/src/server.rs
+++ b/crates/protocol/src/server.rs
@@ -6,7 +6,7 @@ use checksums::{StrongHash, strong_digest};
 use subtle::ConstantTimeEq;
 
 use crate::{
-    CAP_CODECS, CAP_ZSTD, Demux, ExitCode, Frame, Message, Mux, UnknownExit, V30, negotiate_caps,
+    CAP_CODECS, CAP_ZSTD, Demux, ExitCode, Frame, Message, Mux, UnknownExit, negotiate_caps,
     negotiate_version,
 };
 use compress::{Codec, decode_codecs, encode_codecs, negotiate_codec};
@@ -214,11 +214,7 @@ impl<R: Read, W: Write> Server<R, W> {
 
         let strong =
             if let Some((_, list)) = self.env.iter().find(|(k, _)| k == "RSYNC_CHECKSUM_LIST") {
-                let mut chosen = if self.version < V30 {
-                    StrongHash::Md4
-                } else {
-                    StrongHash::Md5
-                };
+                let mut chosen = StrongHash::Md4;
                 for name in list.split(',') {
                     match name {
                         "sha1" => {
@@ -237,10 +233,8 @@ impl<R: Read, W: Write> Server<R, W> {
                     }
                 }
                 chosen
-            } else if self.version < V30 {
-                StrongHash::Md4
             } else {
-                StrongHash::Md5
+                StrongHash::Md4
             };
         self.mux.strong_hash = strong;
         self.demux.strong_hash = strong;

--- a/crates/protocol/tests/charset_conv.rs
+++ b/crates/protocol/tests/charset_conv.rs
@@ -1,3 +1,4 @@
+// crates/protocol/tests/charset_conv.rs
 use encoding_rs::Encoding;
 use protocol::CharsetConv;
 use std::borrow::Cow;

--- a/tests/checksum_seed.rs
+++ b/tests/checksum_seed.rs
@@ -14,7 +14,7 @@ fn checksum_seed_changes_weak_checksum() {
 }
 
 #[test]
-fn checksum_seed_changes_strong_checksum() {
+fn checksum_seed_changes_strong_checksum_default_md4() {
     let data = b"hello world";
     let cfg0 = ChecksumConfigBuilder::new().seed(0).build();
     let cfg1 = ChecksumConfigBuilder::new().seed(1).build();


### PR DESCRIPTION
## Summary
- default to MD4 for strong checksum hashing and adjust available algorithm ordering
- update CLI and server negotiation logic to prefer MD4
- fix tests and add missing charset conversion test header

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` (fails: unresolved import `engine::fuzzy_match`)
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` (fails: use of undeclared type `Cursor`)
- `cargo test -p checksums`


------
https://chatgpt.com/codex/tasks/task_e_68bcb02187388323ab8afea348943c81