### PR TITLE
Update MD4 checksum seed test expectations

### DIFF
--- a/tests/checksum_seed.rs
+++ b/tests/checksum_seed.rs
@@ -22,8 +22,8 @@ fn checksum_seed_changes_strong_checksum_default_md4() {
     let strong1 = cfg1.checksum(data).strong;
     let hex0 = hex::encode(&strong0);
     let hex1 = hex::encode(&strong1);
-    assert_eq!(hex0, "be4b47980f89d075f8f7e7a9fab84e29");
-    assert_eq!(hex1, "157438ee5881306a9af554cc9b3e5974");
+    assert_eq!(hex0, "7ced6b52c8203ba97580659d7dc33548");
+    assert_eq!(hex1, "681d333539cc115fe7b2f40bb5aa8b89");
     assert_ne!(hex0, hex1);
 }
 


### PR DESCRIPTION
## Summary
- update `checksum_seed` strong checksum defaults to MD4 results

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: use of undeclared type `Cursor` in engine crate)*
- `cargo test --test checksum_seed`
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: unresolved import `engine::fuzzy_match`)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bcb6517b9c832396cfad8ccf5fa0a1