### PR TITLE
test: assert unknown codec error

### DIFF
--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -76,6 +76,7 @@ fn negotiation_helper_picks_common_codec() {
 fn codec_from_byte_rejects_unknown() {
     let err = Codec::from_byte(99).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    assert_eq!(err.to_string(), "unknown codec 99");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- assert the exact error string for unknown codec in `codec_from_byte_rejects_unknown`

## Testing
- `cargo fmt --all`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `delta::Op` missing Debug)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: unresolved import `engine::fuzzy_match`)*
- `cargo nextest run -p compress`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcba420a388323bede6f8fa1a83e9e