### PR TITLE
Use expect for partial paths and test receiver

### DIFF
--- a/crates/engine/tests/delete.rs
+++ b/crates/engine/tests/delete.rs
@@ -26,7 +26,7 @@ fn run_delete_filter(mode: DeleteMode) {
         &matcher,
         &available_codecs(),
         &SyncOptions {
-            delete: Some(mode),
+            delete: Some(mode.clone()),
             ..Default::default()
         },
     )


### PR DESCRIPTION
## Summary
- use `expect` instead of `unwrap` when using existing partial paths
- add tests to cover receiver behavior with and without partial files
- fix delete integration test to clone `DeleteMode`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: use of undeclared type `Cursor` in crates/engine/src/lib.rs)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: unresolved import `engine::fuzzy_match`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcba11d5088323a368483dbac1d74d