### PR TITLE
Remove LZ4 build dependency

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -246,4 +246,4 @@ These features may be explored after achieving parity with upstream rsync.
 
 | Feature | Tracking issue |
 | --- | --- |
-| LZ4 codec | [#873](https://github.com/oferchen/oc-rsync/issues/873) |
+| LZ4 codec (no liblz4-dev prerequisite) | [#873](https://github.com/oferchen/oc-rsync/issues/873) |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -62,7 +62,7 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | --- | --- | --- | --- |
 | zstd and zlib codecs | Implemented | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/lib.rs](../crates/compress/src/lib.rs) |
 | `--skip-compress` suffix handling | Implemented | [tests/skip_compress.rs](../tests/skip_compress.rs) | [crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
-| LZ4 codec | Removed pending parity ([#1183](https://github.com/oferchen/oc-rsync/pull/1183)); planned post-parity ([#873](https://github.com/oferchen/oc-rsync/pull/873)) | — | — |
+| LZ4 codec | Planned post-parity ([#873](https://github.com/oferchen/oc-rsync/pull/873)); `liblz4-dev` no longer required for interop builds | — | — |
 
 ## Filters
 | Feature | Status | Tests | Source |

--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -23,7 +23,7 @@ ensure_build_deps() {
     apt-get install -y build-essential >/dev/null
   fi
   apt-get update >/dev/null
-  apt-get install -y libpopt-dev libzstd-dev zlib1g-dev libacl1-dev libxxhash-dev liblz4-dev >/dev/null
+  apt-get install -y libpopt-dev libzstd-dev zlib1g-dev libacl1-dev libxxhash-dev >/dev/null
 }
 
 # Build oc-rsync binary

--- a/tests/interop/build_upstream.sh
+++ b/tests/interop/build_upstream.sh
@@ -21,7 +21,7 @@ if ! command -v gcc >/dev/null; then
   apt-get install -y build-essential >/dev/null
 fi
 apt-get update
-apt-get install -y libpopt-dev libzstd-dev zlib1g-dev libacl1-dev libxxhash-dev liblz4-dev >/dev/null
+apt-get install -y libpopt-dev libzstd-dev zlib1g-dev libacl1-dev libxxhash-dev >/dev/null
 
 curl -L -O "https://download.samba.org/pub/rsync/src/rsync-$VER.tar.gz"
 tar xzf "rsync-$VER.tar.gz"

--- a/tests/interop/run_matrix.sh
+++ b/tests/interop/run_matrix.sh
@@ -38,7 +38,7 @@ ensure_build_deps() {
     apt-get install -y build-essential >/dev/null
   fi
   apt-get update >/dev/null
-  apt-get install -y libpopt-dev libzstd-dev zlib1g-dev libacl1-dev libxxhash-dev liblz4-dev >/dev/null
+  apt-get install -y libpopt-dev libzstd-dev zlib1g-dev libacl1-dev libxxhash-dev >/dev/null
 }
 
 if [[ ! -x "$OC_RSYNC" ]]; then


### PR DESCRIPTION
## Summary
- drop `liblz4-dev` from interop build scripts
- document that LZ4 is a post-parity feature and no longer a prerequisite

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: use of moved value `mode`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: use of undeclared type `Cursor`)*
- `make verify-comments`
- `make lint`
- `./scripts/interop.sh` *(fails: curl CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb9ed52c8832388037c53cb0f2968