### PR TITLE
Gate AVX-512 checksum on nightly Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "hex",
  "md-5",
  "md4",
+ "rustversion",
  "sha1",
  "tempfile",
  "xxhash-rust",
@@ -1346,6 +1347,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,12 @@ verify-comments:
 
 lint:
 	cargo fmt --all --check
-	cargo clippy --all-targets --all-features -- -D warnings
+	if rustc --version | grep -q nightly; then \
+	cargo clippy --all-targets --all-features -- -D warnings; \
+	else \
+	cargo clippy --all-targets -- -D warnings; \
+	echo "note: AVX-512 linting requires a nightly toolchain"; \
+	fi
 
 fmt:
 	cargo fmt --all

--- a/crates/checksums/Cargo.toml
+++ b/crates/checksums/Cargo.toml
@@ -8,6 +8,7 @@ md4 = "0.10"
 md-5 = "0.10"
 sha1 = "0.10"
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
+rustversion = "1"
 
 [features]
 default = []
@@ -18,6 +19,9 @@ nightly = []
 hex = "0.4"
 criterion = { version = "0.5", default-features = false }
 tempfile = "3"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(rustversion, values("nightly"))'] }
 
 [[bench]]
 name = "rolling"

--- a/crates/checksums/src/lib.rs
+++ b/crates/checksums/src/lib.rs
@@ -186,7 +186,7 @@ pub fn rolling_checksum(data: &[u8]) -> u32 {
 pub fn rolling_checksum_seeded(data: &[u8], seed: u32) -> u32 {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        #[cfg(feature = "nightly")]
+        #[cfg(all(feature = "nightly", rustversion = "nightly"))]
         if std::arch::is_x86_feature_detected!("avx512f") {
             return unsafe { rolling_checksum_avx512(data, seed) };
         }
@@ -342,7 +342,11 @@ pub unsafe fn rolling_checksum_avx2(data: &[u8], seed: u32) -> u32 {
     (s1 & 0xffff) | (s2 << 16)
 }
 
-#[cfg(all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(
+    feature = "nightly",
+    rustversion = "nightly",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[target_feature(enable = "avx512f,avx512bw")]
 #[doc(hidden)]
 #[allow(unused_unsafe)]
@@ -494,7 +498,7 @@ mod tests {
         unsafe {
             assert_eq!(rolling_checksum_sse42(data, 0), scalar);
             assert_eq!(rolling_checksum_avx2(data, 0), scalar);
-            #[cfg(feature = "nightly")]
+            #[cfg(all(feature = "nightly", rustversion = "nightly"))]
             assert_eq!(rolling_checksum_avx512(data, 0), scalar);
         }
     }
@@ -511,7 +515,7 @@ mod tests {
             unsafe {
                 assert_eq!(rolling_checksum_sse42(slice, 1), scalar);
                 assert_eq!(rolling_checksum_avx2(slice, 1), scalar);
-                #[cfg(feature = "nightly")]
+                #[cfg(all(feature = "nightly", rustversion = "nightly"))]
                 assert_eq!(rolling_checksum_avx512(slice, 1), scalar);
             }
         }


### PR DESCRIPTION
## Summary
- use rustversion to gate AVX-512 rolling checksum functions and tests to nightly toolchains
- add rustversion dependency and allow its cfg in checksums crate
- make `make lint` skip nightly features on stable toolchains

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bcbc6696f48323bebab8b24f5aec2e