### PR TITLE
Ensure glob filters respect directory boundaries

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1079,13 +1079,13 @@ impl Matcher {
         let mut rules = Vec::new();
         let mut merges = Vec::new();
 
-        fn is_excluded(rules: &[(usize, Rule)], path: &Path) -> bool {
+        fn is_excluded(rules: &[(usize, Rule)], path: &Path, is_dir: bool) -> bool {
             let mut state: Option<bool> = None;
             for (_, r) in rules {
                 match r {
                     Rule::Clear => state = None,
                     Rule::Include(d) | Rule::Protect(d) => {
-                        if d.dir_only && !path.is_dir() {
+                        if d.dir_only && !is_dir {
                             continue;
                         }
                         let matched = d.matcher.is_match(path);
@@ -1094,7 +1094,7 @@ impl Matcher {
                         }
                     }
                     Rule::Exclude(d) => {
-                        if d.dir_only && !path.is_dir() {
+                        if d.dir_only && !is_dir {
                             continue;
                         }
                         let matched = d.matcher.is_match(path);
@@ -1133,7 +1133,7 @@ impl Matcher {
                         dir.join(&pd.file)
                     };
                     let dir_for_rule = nested.parent().unwrap_or(&nested).to_path_buf();
-                    if is_excluded(&rules, &dir_for_rule) {
+                    if is_excluded(&rules, &dir_for_rule, true) {
                         continue;
                     }
                     merges.push((index, pd.clone()));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -4370,12 +4370,14 @@ fn double_star_glob_matches() {
     let dst = tmp.path().join("dst");
     fs::create_dir_all(src.join("a/inner")).unwrap();
     fs::create_dir_all(src.join("b/deeper/more")).unwrap();
+    fs::create_dir_all(src.join("c/other")).unwrap();
     fs::write(src.join("a/keep1.txt"), "1").unwrap();
     fs::write(src.join("a/inner/keep2.txt"), "2").unwrap();
     fs::write(src.join("b/deeper/more/keep3.txt"), "3").unwrap();
     fs::write(src.join("a/omit.log"), "x").unwrap();
     fs::write(src.join("a/inner/omit.log"), "x").unwrap();
     fs::write(src.join("b/deeper/more/omit.log"), "x").unwrap();
+    fs::write(src.join("c/other/omit.log"), "x").unwrap();
     let src_arg = format!("{}/", src.display());
     Command::cargo_bin("oc-rsync")
         .unwrap()
@@ -4399,6 +4401,8 @@ fn double_star_glob_matches() {
     assert!(!dst.join("a/omit.log").exists());
     assert!(!dst.join("a/inner/omit.log").exists());
     assert!(!dst.join("b/deeper/more/omit.log").exists());
+    assert!(!dst.join("c/other/omit.log").exists());
+    assert!(!dst.join("c").exists());
 }
 
 #[test]
@@ -4424,7 +4428,9 @@ fn single_star_does_not_cross_directories() {
         .assert()
         .success();
     assert!(dst.join("a/file.txt").exists());
+    assert!(dst.join("a").is_dir());
     assert!(!dst.join("a/b/file.txt").exists());
+    assert!(!dst.join("a/b").exists());
 }
 
 #[test]
@@ -4450,5 +4456,7 @@ fn char_class_respects_directory_boundaries() {
         .assert()
         .success();
     assert!(dst.join("1/keep.txt").exists());
+    assert!(dst.join("1").is_dir());
     assert!(!dst.join("1/2/keep.txt").exists());
+    assert!(!dst.join("1/2").exists());
 }


### PR DESCRIPTION
## Summary
- honor directory context in filter exclusion checks so includes don't implicitly pull in descendants
- tighten glob behavior by testing single- and double-star plus character class patterns

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: unresolved import `engine::fuzzy_match`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: mismatched types in `checksums`)*
- `make verify-comments`
- `make lint` *(fails: mismatched types in `checksums`)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc02bd0cc832385394a3cc952fd16