### PR TITLE
Handle hash-prefixed CVS ignore patterns

### DIFF
--- a/crates/filters/tests/cvs_rules.rs
+++ b/crates/filters/tests/cvs_rules.rs
@@ -69,3 +69,23 @@ fn git_directory_is_ignored_by_default_rules() {
     let matcher = Matcher::new(rules).with_root(root);
     assert!(!matcher.is_included(".git").unwrap());
 }
+
+#[test]
+fn default_rules_ignore_hash_prefixed_files() {
+    let rules = p("-C\n");
+    let matcher = Matcher::new(rules);
+    assert!(!matcher.is_included("#temp").unwrap());
+}
+
+#[test]
+fn env_hash_patterns_are_respected() {
+    unsafe {
+        env::set_var("CVSIGNORE", "#envpat");
+    }
+    let rules = p("-C\n");
+    let matcher = Matcher::new(rules);
+    assert!(!matcher.is_included("#envpat").unwrap());
+    unsafe {
+        env::remove_var("CVSIGNORE");
+    }
+}


### PR DESCRIPTION
## Summary
- generate default CVS rules using `parse_rule_list_from_bytes`
- allow `#` inside filter patterns unless it begins the line
- test `--cvs-exclude` with patterns beginning with `#`

## Testing
- `make verify-comments`
- `make lint` *(fails: could not compile `checksums` crate: expected `*const __m512i`, found `*const i32`)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: mismatched types in `checksums` crate)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc028a17083239545cc945472534c