### PR TITLE
Anchor include-from rules to root and test nested includes

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -2084,18 +2084,33 @@ pub fn parse_rule_list_from_bytes(
     let pats = parse_list(input, from0);
     let mut rules = Vec::new();
     for pat in pats {
-        let line = if from0 {
-            format!("{sign}{pat}\n")
+        let is_dir = pat.ends_with('/');
+        let anchored = if pat.starts_with('/') {
+            pat.clone()
         } else {
-            format!("{sign} {pat}\n")
+            format!("/{}", pat)
         };
-        rules.extend(parse_with_options(
-            &line,
-            from0,
-            visited,
-            depth,
-            source.clone(),
-        )?);
+        let line = if from0 {
+            format!("{sign}{anchored}\n")
+        } else {
+            format!("{sign} {anchored}\n")
+        };
+        let mut sub = parse_with_options(&line, from0, visited, depth, source.clone())?;
+        if is_dir {
+            let trimmed = anchored.trim_start_matches('/').trim_end_matches('/');
+            if !trimmed.is_empty() {
+                let anc_count = trimmed.split('/').count().saturating_sub(1);
+                if let Some(rule) = sub.get_mut(anc_count) {
+                    match rule {
+                        Rule::Include(d) | Rule::Exclude(d) | Rule::Protect(d) => {
+                            d.dir_only = true;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        rules.extend(sub);
     }
     Ok(rules)
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -3081,6 +3081,41 @@ fn include_from_nested_path_allows_parent_dirs() {
 }
 
 #[test]
+fn include_from_list_transfers_nested_paths() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::create_dir_all(src.join("a/b")).unwrap();
+    fs::create_dir_all(src.join("a/d/sub")).unwrap();
+    fs::write(src.join("a/b/file.txt"), b"f").unwrap();
+    fs::write(src.join("a/b/other.txt"), b"o").unwrap();
+    fs::write(src.join("a/d/sub/nested.txt"), b"n").unwrap();
+    fs::write(src.join("unlisted.txt"), b"u").unwrap();
+    let inc = dir.path().join("inc.lst");
+    fs::write(&inc, "a/b/file.txt\na/d/\n").unwrap();
+
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--recursive",
+            "--include-from",
+            inc.to_str().unwrap(),
+            "--exclude",
+            "*",
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(dst.join("a/b/file.txt").exists());
+    assert!(dst.join("a/d/sub/nested.txt").exists());
+    assert!(!dst.join("a/b/other.txt").exists());
+    assert!(!dst.join("unlisted.txt").exists());
+}
+
+#[test]
 fn per_dir_merge_can_override_later_include() {
     let dir = tempdir().unwrap();
     let src = dir.path().join("src");


### PR DESCRIPTION
## Summary
- Anchor rule list patterns to root and mark directory entries as dir_only
- Test nested `--include-from` behavior alongside existing `--files-from` coverage

## Testing
- `RUSTFLAGS="-C target-feature=+avx512f,+avx512bw" make lint` *(fails: could not compile `checksums`)*
- `make verify-comments`
- `RUSTFLAGS="-C target-feature=+avx512f,+avx512bw" cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `RUSTFLAGS="-C target-feature=+avx512f,+avx512bw" cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: mismatched types in `checksums`)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc04fb0c4832390f04862c67a7e8a