### PR TITLE
Propagate include ancestors for files-from and include-from

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1698,7 +1698,7 @@ pub fn parse_with_options(
                         }
                     }
                     rules.extend(parse_with_options(
-                        "- *\n",
+                        "- /**\n",
                         from0,
                         visited,
                         depth + 1,
@@ -2073,6 +2073,36 @@ pub fn parse_file(
     parse_from_bytes(&data, from0, visited, depth, source)
 }
 
+fn rooted_and_parents(pat: &str) -> (String, Vec<String>) {
+    let rooted = if pat.starts_with('/') {
+        pat.to_string()
+    } else {
+        format!("/{pat}")
+    };
+    let trimmed = rooted.trim_end_matches('/');
+    let mut base = String::new();
+    let mut dirs = Vec::new();
+    let mut finished = true;
+    for part in trimmed.trim_start_matches('/').split('/') {
+        if !base.is_empty() {
+            base.push('/');
+        }
+        base.push_str(part);
+        let has_glob = part.contains(['*', '?', '[', ']']);
+        if has_glob {
+            dirs.push(format!("/{base}/"));
+            dirs.push(format!("/{base}/**"));
+            finished = false;
+            break;
+        }
+        dirs.push(format!("/{base}/"));
+    }
+    if finished {
+        dirs.pop();
+    }
+    (rooted, dirs)
+}
+
 pub fn parse_rule_list_from_bytes(
     input: &[u8],
     from0: bool,
@@ -2084,18 +2114,51 @@ pub fn parse_rule_list_from_bytes(
     let pats = parse_list(input, from0);
     let mut rules = Vec::new();
     for pat in pats {
-        let line = if from0 {
-            format!("{sign}{pat}\n")
+        if pat.is_empty() {
+            continue;
+        }
+        if sign == '+' && !pat.starts_with(['+', '-', ':']) {
+            let (rooted, parents) = rooted_and_parents(&pat);
+            let line = if from0 {
+                format!("+{rooted}\n")
+            } else {
+                format!("+ {rooted}\n")
+            };
+            rules.extend(parse_with_options(
+                &line,
+                from0,
+                visited,
+                depth,
+                source.clone(),
+            )?);
+            for dir in parents {
+                let rule = if from0 {
+                    format!("+{dir}\n")
+                } else {
+                    format!("+ {dir}\n")
+                };
+                rules.extend(parse_with_options(
+                    &rule,
+                    from0,
+                    visited,
+                    depth,
+                    source.clone(),
+                )?);
+            }
         } else {
-            format!("{sign} {pat}\n")
-        };
-        rules.extend(parse_with_options(
-            &line,
-            from0,
-            visited,
-            depth,
-            source.clone(),
-        )?);
+            let line = if from0 {
+                format!("{sign}{pat}\n")
+            } else {
+                format!("{sign} {pat}\n")
+            };
+            rules.extend(parse_with_options(
+                &line,
+                from0,
+                visited,
+                depth,
+                source.clone(),
+            )?);
+        }
     }
     Ok(rules)
 }

--- a/crates/filters/tests/files_from.rs
+++ b/crates/filters/tests/files_from.rs
@@ -83,9 +83,11 @@ fn files_from_mixed_file_dir_entries() {
     assert!(m.is_included("foo").unwrap());
     assert!(m.is_included("foo/bar").unwrap());
     assert!(m.is_included("foo/bar/baz").unwrap());
+    assert!(!m.is_included("foo/bar/qux").unwrap());
     assert!(m.is_included("qux").unwrap());
     assert!(m.is_included("qux/inner").unwrap());
     assert!(!m.is_included("other").unwrap());
+    assert!(!m.is_included("qux/other").unwrap());
 }
 
 #[test]

--- a/crates/filters/tests/include_from.rs
+++ b/crates/filters/tests/include_from.rs
@@ -25,6 +25,18 @@ fn exclude_from_null_separated() {
     assert!(matcher.is_included("baz").unwrap());
 }
 
+#[test]
+fn include_from_nested_paths_include_ancestors() {
+    let data = b"foo/bar/baz\n";
+    let mut v = HashSet::new();
+    let rules = parse_rule_list_from_bytes(data, false, '+', &mut v, 0, None).unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("foo").unwrap());
+    assert!(matcher.is_included("foo/bar").unwrap());
+    assert!(matcher.is_included("foo/bar/baz").unwrap());
+    assert!(!matcher.is_included("foo/bar/qux").unwrap());
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(16))]
     #[test]

--- a/tests/files_from.rs
+++ b/tests/files_from.rs
@@ -1,0 +1,35 @@
+// tests/files_from.rs
+use assert_cmd::Command;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn files_from_creates_parents_and_excludes_siblings() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(src.join("a/b")).unwrap();
+    fs::write(src.join("a/b/keep.txt"), b"data").unwrap();
+    fs::write(src.join("a/b/skip.txt"), b"no").unwrap();
+    fs::write(src.join("a/other.txt"), b"no").unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    let list = tmp.path().join("list");
+    fs::write(&list, "a/b/keep.txt\n").unwrap();
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--recursive",
+            "--files-from",
+            list.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(dst.join("a").is_dir());
+    assert!(dst.join("a/b").is_dir());
+    assert!(dst.join("a/b/keep.txt").is_file());
+    assert!(!dst.join("a/b/skip.txt").exists());
+    assert!(!dst.join("a/other.txt").exists());
+}

--- a/tests/files_from_dirs.rs
+++ b/tests/files_from_dirs.rs
@@ -16,7 +16,10 @@ fn files_from_mixed_entries_integration() {
     assert!(m.is_included("foo").unwrap());
     assert!(m.is_included("foo/bar").unwrap());
     assert!(m.is_included("foo/bar/baz").unwrap());
+    assert!(!m.is_included("foo/bar/qux").unwrap());
+    assert!(!m.is_included("foo/other").unwrap());
     assert!(m.is_included("qux").unwrap());
     assert!(m.is_included("qux/sub").unwrap());
     assert!(!m.is_included("other").unwrap());
+    assert!(!m.is_included("qux/other").unwrap());
 }


### PR DESCRIPTION
## Summary
- ensure `files-from` excludes non-listed siblings and prepends directory ancestors
- propagate parent includes for entries from include-from and files-from lists
- add tests for nested include lists and `--files-from` directory creation

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: expected `*const __m512i`, found `*const i32`)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: unresolved import `engine::fuzzy_match`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: expected `*mut __m512i`, found `*mut i32`)*
- `make verify-comments`
- `make lint` *(fails: expected `*mut __m512i`, found `*mut i32`)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc02da15c8323920a8d49f565dfc1