### PR TITLE
Refactor ACL detection logic in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,23 +25,24 @@ fn main() {
                 Err(_) => {
                     let mut lib_dir: Option<PathBuf> = None;
 
-                    if let Ok(output) = Command::new("ldconfig").arg("-p").output()
-                        && output.status.success()
-                    {
-                        let stdout = String::from_utf8_lossy(&output.stdout);
-                        for line in stdout.lines() {
-                            if line.contains("libacl.so")
-                                && let Some(path) = line.split("=>").nth(1)
-                                && let Some(dir) = Path::new(path.trim()).parent()
-                            {
-                                lib_dir = Some(dir.to_path_buf());
-                                break;
+                    if let Ok(output) = Command::new("ldconfig").arg("-p").output() {
+                        if output.status.success() {
+                            let stdout = String::from_utf8_lossy(&output.stdout);
+                            for line in stdout.lines() {
+                                if line.contains("libacl.so") {
+                                    if let Some(path) = line.split("=>").nth(1) {
+                                        if let Some(dir) = Path::new(path.trim()).parent() {
+                                            lib_dir = Some(dir.to_path_buf());
+                                            break;
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
 
-                    if lib_dir.is_none()
-                        && let Ok(output) = Command::new("find")
+                    if lib_dir.is_none() {
+                        if let Ok(output) = Command::new("find")
                             .args([
                                 "/usr/lib",
                                 "/usr/lib64",
@@ -55,11 +56,17 @@ fn main() {
                             .arg("-print")
                             .arg("-quit")
                             .output()
-                        && output.status.success()
-                        && let Some(path) = String::from_utf8_lossy(&output.stdout).lines().next()
-                        && let Some(dir) = Path::new(path.trim()).parent()
-                    {
-                        lib_dir = Some(dir.to_path_buf());
+                        {
+                            if output.status.success() {
+                                if let Some(path) =
+                                    String::from_utf8_lossy(&output.stdout).lines().next()
+                                {
+                                    if let Some(dir) = Path::new(path.trim()).parent() {
+                                        lib_dir = Some(dir.to_path_buf());
+                                    }
+                                }
+                            }
+                        }
                     }
 
                     if let Some(dir) = lib_dir {


### PR DESCRIPTION
## Summary
- remove unstable let chains from ACL probing logic
- retain libacl discovery via `ldconfig` or `find`

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `cargo build` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc326f2548323931cb62f79923a54