### PR TITLE
Refactor libacl detection to use pkg-config and env overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 Run `scripts/preflight.sh` to verify these dependencies before building. Then
 install from crates.io or build from a local checkout:
 
+`libacl` is detected with `pkg-config` (package name `libacl`). If that probe
+fails, the build script scans common library directories along with the
+`LD_LIBRARY_PATH`/`LIBRARY_PATH` variables. Override the search logic with
+`LIBACL_PATH` when cross-compiling or when `libacl` lives in a non-standard
+location.
+
 The build script embeds the current year into the binary for copyright
 messages. If the `CURRENT_YEAR` environment variable is not set, the build
 defaults to the system year. Set this variable when you need reproducible


### PR DESCRIPTION
## Summary
- search for `libacl` using pkg-config or standard library paths only
- allow custom search via `LIBACL_PATH` env var
- document ACL detection logic and cross-compile overrides

## Testing
- `make verify-comments`
- `make lint`
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast` *(fails: compile errors in engine crate)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: unresolved import in engine crate)*
- `LIBACL_PATH=/usr/lib/x86_64-linux-gnu cargo build --target x86_64-unknown-linux-gnu`


------
https://chatgpt.com/codex/tasks/task_e_68bcc3311460832398866c0a20e0837f