### PR TITLE
Add exclusions for include-from ancestors

### DIFF
--- a/crates/filters/tests/include_from.rs
+++ b/crates/filters/tests/include_from.rs
@@ -37,6 +37,17 @@ fn include_from_nested_paths_include_ancestors() {
     assert!(!matcher.is_included("foo/bar/qux").unwrap());
 }
 
+#[test]
+fn include_from_nested_paths_exclude_siblings() {
+    let data = b"foo/bar/baz\n";
+    let mut v = HashSet::new();
+    let rules = parse_rule_list_from_bytes(data, false, '+', &mut v, 0, None).unwrap();
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("foo/bar/baz").unwrap());
+    assert!(!matcher.is_included("foo/bar/qux").unwrap());
+    assert!(!matcher.is_included("foo/qux").unwrap());
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(16))]
     #[test]


### PR DESCRIPTION
## Summary
- Emit ancestor-specific include and exclude rules when parsing include lists
- Add tests covering nested include behaviour and sibling exclusion

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: use of undeclared type `Cursor`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: unresolved import `engine::fuzzy_match`)*
- `cargo nextest run --test cli -p oc-rsync -E 'test(/include_/)' --no-fail-fast` *(fails: multiple include_* tests failing)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc94d4e848323b7ddbc25ff019cb0