### PR TITLE
Anchor slash-containing filter patterns

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1840,6 +1840,9 @@ pub fn parse_with_options(
         if has_anchor && !pattern.starts_with('/') {
             pattern = format!("/{}", pattern);
         }
+        if pattern.contains('/') && !pattern.starts_with('/') {
+            pattern.insert(0, '/');
+        }
         let anchored = pattern.starts_with('/') || pattern.contains('/');
         let dir_all = pattern.ends_with("/***");
         let dir_only = !dir_all && pattern.ends_with('/');

--- a/crates/filters/tests/directory_boundaries.rs
+++ b/crates/filters/tests/directory_boundaries.rs
@@ -24,6 +24,15 @@ fn class_slash_star() {
 }
 
 #[test]
+fn char_class_first_level_only() {
+    let rules = p("+ [0-9]/*\n- *\n");
+    let matcher = Matcher::new(rules);
+    assert!(matcher.is_included("1/file.txt").unwrap());
+    assert!(!matcher.is_included("1/2/file.txt").unwrap());
+    assert!(!matcher.is_included("dir/1/file.txt").unwrap());
+}
+
+#[test]
 fn dir_prefix_double_star() {
     let rules = p("+ dir*/**/keep[0-9].txt\n- *\n");
     let matcher = Matcher::new(rules);


### PR DESCRIPTION
## Summary
- anchor patterns with slashes during filter parsing
- add regression test ensuring `[0-9]/*` only matches first-level entries

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bce1f6d98c83239860ba2b24c8fe1e