### PR TITLE
Report unreadable rsync-filter files

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -968,7 +968,15 @@ impl Matcher {
 
         let mut content = match fs::read_to_string(path) {
             Ok(c) => c,
-            Err(_) => return Ok((Vec::new(), Vec::new())),
+            Err(err) => {
+                tracing::warn!(
+                    target: InfoFlag::Filter.target(),
+                    ?path,
+                    ?err,
+                    "unable to open",
+                );
+                return Err(ParseError::Io(err));
+            }
         };
 
         let adjusted = if cvs {

--- a/crates/filters/tests/unreadable_filter.rs
+++ b/crates/filters/tests/unreadable_filter.rs
@@ -1,0 +1,20 @@
+// crates/filters/tests/unreadable_filter.rs
+use filters::{Matcher, ParseError, parse};
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn unreadable_filter_file_errors() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path();
+    // Create a directory named `.rsync-filter` so attempts to read it fail.
+    fs::create_dir(root.join(".rsync-filter")).unwrap();
+
+    let mut v = HashSet::new();
+    let rules = parse(": /.rsync-filter\n", &mut v, 0).unwrap();
+    let matcher = Matcher::new(rules).with_root(root);
+
+    let err = matcher.is_included("foo").unwrap_err();
+    assert!(matches!(err, ParseError::Io(_)));
+}


### PR DESCRIPTION
## Summary
- map merge file read failures to `ParseError::Io`
- log a warning when a per-dir filter file can't be opened
- add test ensuring unreadable `.rsync-filter` surfaces an IO error

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linking with `cc` failed: cannot find -lacl)*


------
https://chatgpt.com/codex/tasks/task_e_68bce49b5440832383827eb1a113b47e