### PR TITLE
feat(cli): handle raw OS bytes in remote spec parsing

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -27,11 +27,11 @@ mod utils;
 use crate::daemon::run_daemon;
 pub use daemon::spawn_daemon_session;
 use options::{ClientOpts, ProbeOpts};
-use utils::{
-    RemoteSpec, init_logging, parse_filters, parse_name_map, parse_remote_spec, parse_remote_specs,
-    parse_rsync_path,
+pub use utils::{
+    PathSpec, RemoteSpec, parse_iconv, parse_logging_flags, parse_remote_spec, parse_rsh,
+    print_version_if_requested,
 };
-pub use utils::{parse_iconv, parse_logging_flags, parse_rsh, print_version_if_requested};
+use utils::{init_logging, parse_filters, parse_name_map, parse_remote_specs, parse_rsync_path};
 
 use compress::{Codec, available_codecs};
 pub use engine::EngineError;

--- a/crates/cli/tests/non_utf8_path.rs
+++ b/crates/cli/tests/non_utf8_path.rs
@@ -1,0 +1,11 @@
+// crates/cli/tests/non_utf8_path.rs
+use oc_rsync_cli::parse_remote_spec;
+use std::ffi::OsString;
+
+#[test]
+fn parses_non_utf8_path() {
+    let bytes = b"nonutf8\x80path";
+    // SAFETY: constructing an OsString from arbitrary bytes for test purposes
+    let path = unsafe { OsString::from_encoded_bytes_unchecked(bytes.to_vec()) };
+    assert!(parse_remote_spec(&path).is_ok());
+}


### PR DESCRIPTION
## Summary
- parse remote specs using `OsStr` byte APIs
- expose path metadata types and add non-UTF8 parsing test

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bd47c2f4d88323b93ae1bdc498ce30