### PR TITLE
fix: ignore missing per-directory filter files

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1005,6 +1005,9 @@ impl Matcher {
                     ?err,
                     "unable to open",
                 );
+                if err.kind() == io::ErrorKind::NotFound {
+                    return Ok((Vec::new(), Vec::new()));
+                }
                 return Err(ParseError::Io(err));
             }
         };


### PR DESCRIPTION
## Summary
- handle missing `.rsync-filter` files gracefully when loading per-directory filters

## Testing
- `cargo test --test block_size cli_block_size_matches_rsync -- --exact`
- `cargo test --test block_size`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: unresolved import `fuzzy_match`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: unresolved import `fuzzy_match`)*
- `make verify-comments` *(fails: crates/cli/tests/non_utf8_path.rs: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd4de93bc88323b9f2663441337478