### PR TITLE
Fix per-dir filter handling for explicit block sizes

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -31,6 +31,8 @@ use logging::{InfoFlag, escape_path};
 use protocol::ExitCode;
 use thiserror::Error;
 mod cleanup;
+#[cfg(test)]
+pub use cleanup::fuzzy_match;
 mod delta;
 mod receiver;
 mod sender;

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -899,11 +899,14 @@ impl Matcher {
             };
 
             let key = (path.clone(), pd.sign, pd.word_split);
-            let meta = fs::metadata(&path).ok();
-            let (mtime, len) = match &meta {
-                Some(m) => (m.modified().ok(), m.len()),
-                None => (None, 0),
+            let meta = match fs::metadata(&path) {
+                Ok(m) => m,
+                Err(_) => {
+                    continue;
+                }
             };
+            let mtime = meta.modified().ok();
+            let len = meta.len();
 
             let state = {
                 let cache = self.cached.borrow();

--- a/crates/filters/tests/rsync_special_chars.rs
+++ b/crates/filters/tests/rsync_special_chars.rs
@@ -8,7 +8,7 @@ use tempfile::tempdir;
 
 fn pattern_strategy() -> impl Strategy<Value = String> {
     let chars =
-        prop::collection::vec(prop::sample::select(['a', 'b', 'c']), 1..4).prop_map(|mut v| {
+        prop::collection::vec(prop::sample::select(&['a', 'b', 'c']), 1..4).prop_map(|mut v| {
             v.sort();
             v.dedup();
             v.into_iter().collect::<String>()


### PR DESCRIPTION
## Summary
- skip missing per-directory filter files instead of erroring
- expose `fuzzy_match` for tests
- fix filter test strategy

## Testing
- `cargo nextest run --test block_size cli_block_size_matches_rsync --nocapture`
- `cargo nextest run --workspace --no-fail-fast` *(fails: build in progress / cancelled)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(terminated early)*
- `make verify-comments` *(fails: additional comments in crates/cli/tests/non_utf8_path.rs)*
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bd47a3590483238425bdb9465fa986