### PR TITLE
Handle missing per-directory filter files

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -998,6 +998,9 @@ impl Matcher {
 
         let mut content = match fs::read_to_string(path) {
             Ok(c) => c,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok((Vec::new(), Vec::new()));
+            }
             Err(err) => {
                 tracing::warn!(
                     target: InfoFlag::Filter.target(),


### PR DESCRIPTION
## Summary
- avoid treating absent `.rsync-filter` files as fatal parse errors

## Testing
- `cargo test --test block_size cli_block_size_matches_rsync`
- `make lint`
- `make verify-comments` *(fails: crates/cli/tests/non_utf8_path.rs: additional comments)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: unresolved import `engine::fuzzy_match`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: unresolved import `engine::fuzzy_match`)*

------
https://chatgpt.com/codex/tasks/task_e_68bd51f382248323b05915c089a6fa78