### PR TITLE
fix: ignore missing per-dir filter files

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -999,6 +999,9 @@ impl Matcher {
         let mut content = match fs::read_to_string(path) {
             Ok(c) => c,
             Err(err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    return Ok((Vec::new(), Vec::new()));
+                }
                 tracing::warn!(
                     target: InfoFlag::Filter.target(),
                     ?path,


### PR DESCRIPTION
## Summary
- avoid failing when per-directory filter files are absent by treating `NotFound` as empty

## Testing
- `cargo nextest run --test block_size cli_block_size_matches_rsync`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: unresolved import `engine::fuzzy_match`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(failed to complete)*
- `make verify-comments` *(fails: crates/cli/tests/non_utf8_path.rs additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd519433108323b7fa5e2626577666