### PR TITLE
Add test verifying digit glob limited to one directory level

### DIFF
--- a/crates/filters/tests/advanced_globs.rs
+++ b/crates/filters/tests/advanced_globs.rs
@@ -107,6 +107,13 @@ fn character_class_confined_to_segment() {
 }
 
 #[test]
+fn character_class_does_not_cross_directories() {
+    let m = p("+ [0-9]/*\n- *\n");
+    assert!(m.is_included("1/keep.txt").unwrap());
+    assert!(!m.is_included("1/2/keep.txt").unwrap());
+}
+
+#[test]
 fn brace_expansion_limit_range() {
     let mut v = HashSet::new();
     let pattern = format!("+ file{{1..{}}}.txt\n- *\n", MAX_BRACE_EXPANSIONS + 1);


### PR DESCRIPTION
## Summary
- test that single-segment digit glob `[0-9]/*` includes `1/keep.txt` but excludes deeper paths

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` (fails: could not compile `engine` due to non-public `cleanup::fuzzy_match`)
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` (fails: could not compile `engine` integration tests: no `fuzzy_match`)
- `make verify-comments` (fails: crates/cli/tests/non_utf8_path.rs additional comments)
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd5ab63f448323a0429a5fb07b849f