### PR TITLE
Fix anchored character-class matching in filters

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -1999,6 +1999,7 @@ pub fn parse_with_options(
 
         let mut pats: Vec<(String, bool)> = Vec::new();
         for b in bases {
+            let b = if anchored { format!("/{}", b) } else { b };
             if dir_all || dir_only {
                 pats.push((b.clone(), false));
                 pats.push((format!("{}/**", b), false));


### PR DESCRIPTION
## Summary
- ensure anchored patterns are prefixed with `/` so leading character classes match only one directory

## Testing
- `cargo test -p filters --test directory_boundaries`
- `cargo clippy -p filters --all-targets --all-features -- -D warnings` *(fails: there is no argument named `rule` in rsync_special_chars.rs)*
- `make verify-comments` *(fails: crates/cli/tests/non_utf8_path.rs: additional comments)*
- `make lint` *(interrupted)*
- `cargo nextest run --workspace --no-fail-fast` *(not run: cargo-nextest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5a4bc8008323b60ee1f515b0d296