### PR TITLE
Use filters rooted_and_parents for CLI includes

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -748,33 +748,10 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
     }
 
     fn root_and_parents(pat: &str) -> (String, Vec<String>) {
-        let rooted = if pat.starts_with('/') {
-            pat.to_string()
-        } else {
-            format!("/{pat}")
-        };
-        let mut base = String::new();
-        let mut dirs = Vec::new();
-        let mut finished = true;
-        let trimmed = rooted.trim_end_matches('/');
-        for part in trimmed.trim_start_matches('/').split('/') {
-            if !base.is_empty() {
-                base.push('/');
-            }
-            base.push_str(part);
-            let has_glob = part.contains(['*', '?', '[', ']']);
-            if has_glob {
-                dirs.push(format!("/{base}/"));
-                dirs.push(format!("/{base}/**"));
-                finished = false;
-                break;
-            }
-            dirs.push(format!("/{base}/"));
-        }
-        if finished {
-            dirs.pop();
-        }
-        (rooted, dirs)
+        let (rooted, parents) = filters::rooted_and_parents(pat);
+        let rooted = format!("/{rooted}");
+        let parents = parents.into_iter().map(|d| format!("/{d}")).collect();
+        (rooted, parents)
     }
 
     let mut entries: Vec<(usize, usize, Rule)> = Vec::new();

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -2276,7 +2276,7 @@ pub fn parse_file(
     parse_from_bytes(&data, from0, visited, depth, source)
 }
 
-fn rooted_and_parents(pat: &str) -> (String, Vec<String>) {
+pub fn rooted_and_parents(pat: &str) -> (String, Vec<String>) {
     let rooted = pat.trim_start_matches('/').to_string();
     let trimmed = rooted.trim_end_matches('/');
     let mut base = String::new();


### PR DESCRIPTION
## Summary
- reuse filters' `rooted_and_parents` for CLI includes
- expose `filters::rooted_and_parents`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot re-export private `fuzzy_match`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: `engine::fuzzy_match` not found)*
- `cargo nextest run -p oc-rsync-cli --no-fail-fast` *(fails: multiple CLI tests)
- `make verify-comments` *(fails: crates/cli/tests/non_utf8_path.rs: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd641ae6c883239718ef8493b3290f