### PR TITLE
filters: retain dirs for char-class includes

### DIFF
--- a/crates/cli/tests/non_utf8_path.rs
+++ b/crates/cli/tests/non_utf8_path.rs
@@ -5,7 +5,6 @@ use std::ffi::OsString;
 #[test]
 fn parses_non_utf8_path() {
     let bytes = b"nonutf8\x80path";
-    // SAFETY: constructing an OsString from arbitrary bytes for test purposes
     let path = unsafe { OsString::from_encoded_bytes_unchecked(bytes.to_vec()) };
     assert!(parse_remote_spec(&path).is_ok());
 }

--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -2329,6 +2329,11 @@ pub fn parse_rule_list_from_bytes(
                 source.clone(),
             )?);
 
+            let skip_exclude = rooted
+                .rsplit('/')
+                .next()
+                .is_some_and(|seg| seg.chars().all(|c| c == '*'));
+
             for dir in &parents {
                 let glob = format!("/{}", dir.trim_end_matches('/'));
                 let matcher = compile_glob(&glob)?;
@@ -2344,19 +2349,21 @@ pub fn parse_rule_list_from_bytes(
                 rules.push(Rule::Include(data));
             }
 
-            for dir in parents {
-                let exc_pat = format!("/{}*", dir);
-                let matcher = compile_glob(&exc_pat)?;
-                let data = RuleData {
-                    matcher,
-                    invert: false,
-                    flags: RuleFlags::default(),
-                    source: source.clone(),
-                    dir_only: false,
-                    has_slash: true,
-                    pattern: exc_pat.clone(),
-                };
-                rules.push(Rule::Exclude(data));
+            if !skip_exclude {
+                for dir in &parents {
+                    let exc_pat = format!("/{}*", dir);
+                    let matcher = compile_glob(&exc_pat)?;
+                    let data = RuleData {
+                        matcher,
+                        invert: false,
+                        flags: RuleFlags::default(),
+                        source: source.clone(),
+                        dir_only: false,
+                        has_slash: true,
+                        pattern: exc_pat.clone(),
+                    };
+                    rules.push(Rule::Exclude(data));
+                }
             }
         } else {
             let line = if from0 {

--- a/crates/filters/tests/char_class_retains_dirs.rs
+++ b/crates/filters/tests/char_class_retains_dirs.rs
@@ -1,0 +1,25 @@
+// crates/filters/tests/char_class_retains_dirs.rs
+use filters::{Matcher, parse};
+use std::collections::HashSet;
+use std::fs;
+use tempfile::tempdir;
+
+fn p(input: &str) -> Vec<filters::Rule> {
+    let mut v = HashSet::new();
+    parse(input, &mut v, 0).unwrap()
+}
+
+#[test]
+fn include_char_class_retains_dirs() {
+    let tmp = tempdir().unwrap();
+    fs::create_dir_all(tmp.path().join("1/2")).unwrap();
+    fs::write(tmp.path().join("1/keep.txt"), b"k").unwrap();
+    fs::write(tmp.path().join("1/2/keep.txt"), b"x").unwrap();
+
+    let rules = p("+ [0-9]/*\n- *\n");
+    let matcher = Matcher::new(rules).with_root(tmp.path());
+    assert!(matcher.is_included("1/keep.txt").unwrap());
+    assert!(!matcher.is_included("1/2/keep.txt").unwrap());
+    assert!(matcher.is_included_with_dir("1").unwrap().0);
+    assert!(!matcher.is_included_with_dir("1/2").unwrap().0);
+}

--- a/crates/filters/tests/rsync_special_chars.proptest-regressions
+++ b/crates/filters/tests/rsync_special_chars.proptest-regressions
@@ -4,3 +4,4 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
+cc 18215db34a5558f09eeafb7b01cf06d4d769e7b34f4971aba3f981994e54ea0d # shrinks to rule = "- dir/[!a]"

--- a/crates/filters/tests/rsync_special_chars.rs
+++ b/crates/filters/tests/rsync_special_chars.rs
@@ -68,7 +68,7 @@ proptest! {
             let ours = matcher.is_included(p).unwrap();
             let candidate = if p == "dir" { format!("{p}/") } else { p.to_string() };
             let theirs = rsync_included.contains(&candidate);
-            prop_assert_eq!(ours, theirs, "rule {rule} path {p}");
+            prop_assert_eq!(ours, theirs, "rule {} path {}", rule, p);
         }
     }
 }


### PR DESCRIPTION
## Summary
- avoid excluding directories for include patterns whose last segment is only wildcards
- add regression test covering directory retention for `[0-9]/*`

## Testing
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `cargo nextest run --no-fail-fast tests::char_class_respects_directory_boundaries -p oc-rsync` *(fails: cannot find -lacl)*
- `cargo nextest run -p filters --no-fail-fast` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bd59e33b3883238b54be63c70c8032