### PR TITLE
test(filters): add rooted_and_parents edge cases

### DIFF
--- a/crates/filters/tests/rooted_and_parents.rs
+++ b/crates/filters/tests/rooted_and_parents.rs
@@ -1,0 +1,23 @@
+// crates/filters/tests/rooted_and_parents.rs
+use filters::rooted_and_parents;
+
+#[test]
+fn dir_prefix_double_star_and_class() {
+    let (rooted, parents) = rooted_and_parents("dir*/**/keep[0-9].txt");
+    assert_eq!(rooted, "dir*/**/keep[0-9].txt");
+    assert_eq!(parents, vec!["dir*/".to_string()]);
+}
+
+#[test]
+fn leading_double_star_with_question_mark() {
+    let (rooted, parents) = rooted_and_parents("**/file?.log");
+    assert_eq!(rooted, "**/file?.log");
+    assert!(parents.is_empty());
+}
+
+#[test]
+fn trailing_double_star() {
+    let (rooted, parents) = rooted_and_parents("dir/sub/**");
+    assert_eq!(rooted, "dir/sub/**");
+    assert_eq!(parents, vec!["dir/".to_string(), "dir/sub/".to_string()]);
+}


### PR DESCRIPTION
## Summary
- cover `rooted_and_parents` with globstar, wildcard, and trailing `**` patterns

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, apply_with_existing_partial, apply_without_existing_partial, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted: 82 passed, 8 failed)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd7eb96d448323a398878439328749