### PR TITLE
Add remaining POSIX class matchers

### DIFF
--- a/crates/filters/src/lib.rs
+++ b/crates/filters/src/lib.rs
@@ -243,6 +243,12 @@ fn expand_posix_classes(pat: &str) -> String {
             "lower" => Some("a-z"),
             "upper" => Some("A-Z"),
             "xdigit" => Some("0-9A-Fa-f"),
+            "space" => Some("\t\n\r\x0B\x0C "),
+            "punct" => Some("!\"#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]\\^_`{|}~"),
+            "blank" => Some("\t "),
+            "cntrl" => Some("\x00-\x1F\x7F"),
+            "graph" => Some("!-~"),
+            "print" => Some(" -~"),
             _ => None,
         }
     }

--- a/crates/filters/tests/posix_classes.rs
+++ b/crates/filters/tests/posix_classes.rs
@@ -1,0 +1,134 @@
+// crates/filters/tests/posix_classes.rs
+use filters::{Matcher, parse};
+use std::collections::HashSet;
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+fn sanitize(name: &str) -> String {
+    let mut out = String::new();
+    for ch in name.chars() {
+        if ((ch as u32) < 0x20 && ch != '\t') || (ch as u32) == 0x7F {
+            out.push('\\');
+            out.push('#');
+            out.push_str(&format!("{:03o}", ch as u32));
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn parity(class: &str, cases: &[(&str, bool)]) {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path().join("src");
+    fs::create_dir_all(&root).unwrap();
+    for (name, _) in cases {
+        fs::write(root.join(name), "").unwrap();
+    }
+    let inc = format!("+ file[[:{}:]]name", class);
+    let exc = "- *";
+    let rules_src = format!("{inc}\n{exc}\n");
+    let mut visited = HashSet::new();
+    let rules = parse(&rules_src, &mut visited, 0).unwrap();
+    let matcher = Matcher::new(rules).with_root(&root);
+
+    let dest = tmp.path().join("dest");
+    fs::create_dir_all(&dest).unwrap();
+    let root_arg = format!("{}/", root.display());
+    let output = Command::new("rsync")
+        .arg("-r")
+        .arg("-n")
+        .arg("--out-format=%n")
+        .arg("-FF")
+        .arg("-f")
+        .arg(&inc)
+        .arg("-f")
+        .arg(&exc)
+        .arg(&root_arg)
+        .arg(&dest)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let rsync_included: Vec<String> = stdout.lines().map(|l| l.to_string()).collect();
+
+    for (name, should_match) in cases {
+        let ours = matcher.is_included(name).unwrap();
+        assert_eq!(ours, *should_match, "class {class} file {:?}", name);
+        let theirs = rsync_included.contains(&sanitize(name));
+        assert_eq!(ours, theirs, "parity for class {class} file {:?}", name);
+    }
+}
+
+#[test]
+fn space_class_parity() {
+    parity(
+        "space",
+        &[
+            ("file name", true),
+            ("file\tname", true),
+            ("file\nname", true),
+            ("filename", false),
+        ],
+    );
+}
+
+#[test]
+fn blank_class_parity() {
+    parity(
+        "blank",
+        &[
+            ("file name", true),
+            ("file\tname", true),
+            ("file\nname", false),
+            ("filename", false),
+        ],
+    );
+}
+
+#[test]
+fn punct_class_parity() {
+    parity(
+        "punct",
+        &[
+            ("file-name", true),
+            ("file.name", true),
+            ("filename", false),
+            ("file name", false),
+        ],
+    );
+}
+
+#[test]
+fn cntrl_class_parity() {
+    parity("cntrl", &[("file\u{1}name", true), ("filename", false)]);
+}
+
+#[test]
+fn graph_class_parity() {
+    parity(
+        "graph",
+        &[
+            ("file-name", true),
+            ("file1name", true),
+            ("file name", false),
+        ],
+    );
+}
+
+#[test]
+fn print_class_parity() {
+    parity(
+        "print",
+        &[
+            ("file-name", true),
+            ("file name", true),
+            ("file\u{1}name", false),
+        ],
+    );
+}


### PR DESCRIPTION
## Summary
- support remaining POSIX character classes in filter glob translation
- test each new class against stock rsync

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, apply_with_existing_partial, apply_without_existing_partial, append_errors_when_destination_missing)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: hides_temp_files, replay_is_deterministic, cleans_up_temp_dir_on_rename_failure, removes_partial_dir_after_sync, backups_use_custom_suffix, resume_from_partial_file, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bd7edc81cc83239eb09393cb56627e