### PR TITLE
docs: note filter directory-boundary gap

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -74,6 +74,7 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | CVS ignore semantics (`--cvs-exclude`) | ✅ | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Complex glob patterns | Implemented | [crates/filters/tests/advanced_globs.rs](../crates/filters/tests/advanced_globs.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | `--files-from` directory entries | Implemented | [crates/filters/tests/files_from.rs](../crates/filters/tests/files_from.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| Directory boundary handling | Partial | [tests/cli.rs](../tests/cli.rs) (`single_star_does_not_cross_directories`) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 
 ## File Selection
 | Feature | Status | Tests | Source |

--- a/tests/bin_branding.rs
+++ b/tests/bin_branding.rs
@@ -6,7 +6,9 @@ use serial_test::serial;
 #[test]
 #[serial]
 fn errors_use_program_name() {
-    std::env::set_var("OC_RSYNC_NAME", "myrsync");
+    unsafe {
+        std::env::set_var("OC_RSYNC_NAME", "myrsync");
+    }
     Command::cargo_bin("oc-rsync")
         .unwrap()
         .arg("--bogus")
@@ -14,7 +16,9 @@ fn errors_use_program_name() {
         .failure()
         .stderr(contains("myrsync:"))
         .stderr(contains("myrsync error:"));
-    std::env::remove_var("OC_RSYNC_NAME");
+    unsafe {
+        std::env::remove_var("OC_RSYNC_NAME");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- clarify filter table: directory boundary handling is partial and failing `single_star_does_not_cross_directories`
- adjust branding test for Rust's unsafe env API

## Testing
- `cargo nextest run --no-fail-fast --test cli` *(fails: many filter-related tests including `single_star_does_not_cross_directories`)*
- `make lint` *(fails: unsafe env var mutations in daemon tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd85989cc88323bb8c207ecc5f0095