### PR TITLE
test: scope environment variable usage

### DIFF
--- a/tests/daemon_journald.rs
+++ b/tests/daemon_journald.rs
@@ -3,9 +3,27 @@
 
 use daemon::init_logging;
 use serial_test::serial;
+use std::ffi::OsStr;
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::warn;
+
+fn with_env_var<K, V, F, R>(key: K, value: V, f: F) -> R
+where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+    F: FnOnce() -> R,
+{
+    let key = key.as_ref();
+    let old = std::env::var_os(key);
+    unsafe { std::env::set_var(key, value) };
+    let result = f();
+    match old {
+        Some(v) => unsafe { std::env::set_var(key, v) },
+        None => unsafe { std::env::remove_var(key) },
+    }
+    result
+}
 
 #[test]
 #[serial]
@@ -13,13 +31,13 @@ fn daemon_journald_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    unsafe { std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path) };
-    init_logging(None, None, false, true, false).unwrap();
-    warn!(target: "test", "daemon journald");
-    let mut buf = [0u8; 256];
-    let (n, _) = server.recv_from(&mut buf).unwrap();
-    let msg = std::str::from_utf8(&buf[..n]).unwrap();
-    let expected = "PRIORITY=4\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=daemon journald\n";
-    assert_eq!(msg, expected);
-    unsafe { std::env::remove_var("OC_RSYNC_JOURNALD_PATH") };
+    with_env_var("OC_RSYNC_JOURNALD_PATH", &path, || {
+        init_logging(None, None, false, true, false).unwrap();
+        warn!(target: "test", "daemon journald");
+        let mut buf = [0u8; 256];
+        let (n, _) = server.recv_from(&mut buf).unwrap();
+        let msg = std::str::from_utf8(&buf[..n]).unwrap();
+        let expected = "PRIORITY=4\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=daemon journald\n";
+        assert_eq!(msg, expected);
+    });
 }

--- a/tests/daemon_syslog.rs
+++ b/tests/daemon_syslog.rs
@@ -3,9 +3,27 @@
 
 use daemon::init_logging;
 use serial_test::serial;
+use std::ffi::OsStr;
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::warn;
+
+fn with_env_var<K, V, F, R>(key: K, value: V, f: F) -> R
+where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+    F: FnOnce() -> R,
+{
+    let key = key.as_ref();
+    let old = std::env::var_os(key);
+    unsafe { std::env::set_var(key, value) };
+    let result = f();
+    match old {
+        Some(v) => unsafe { std::env::set_var(key, v) },
+        None => unsafe { std::env::remove_var(key) },
+    }
+    result
+}
 
 #[test]
 #[serial]
@@ -13,13 +31,13 @@ fn daemon_syslog_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    unsafe { std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path) };
-    init_logging(None, None, true, false, false).unwrap();
-    warn!(target: "test", "daemon syslog");
-    let mut buf = [0u8; 256];
-    let (n, _) = server.recv_from(&mut buf).unwrap();
-    let msg = std::str::from_utf8(&buf[..n]).unwrap();
-    let expected = format!("<12>rsync[{}]: daemon syslog", std::process::id());
-    assert_eq!(msg, expected);
-    unsafe { std::env::remove_var("OC_RSYNC_SYSLOG_PATH") };
+    with_env_var("OC_RSYNC_SYSLOG_PATH", &path, || {
+        init_logging(None, None, true, false, false).unwrap();
+        warn!(target: "test", "daemon syslog");
+        let mut buf = [0u8; 256];
+        let (n, _) = server.recv_from(&mut buf).unwrap();
+        let msg = std::str::from_utf8(&buf[..n]).unwrap();
+        let expected = format!("<12>rsync[{}]: daemon syslog", std::process::id());
+        assert_eq!(msg, expected);
+    });
 }


### PR DESCRIPTION
## Summary
- introduce `with_env_var` helper to safely set and restore environment variables in tests
- use helper in syslog, journald, and sync_config tests

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bd94475f808323a209d0b649b1e141