### PR TITLE
Use guard to unset env vars in tests

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,32 @@
+// tests/common/mod.rs
+#![allow(dead_code)]
+
+use std::env;
+use std::ffi::{OsStr, OsString};
+
+pub struct EnvVarGuard {
+    key: OsString,
+    old: Option<OsString>,
+}
+
+pub fn temp_env<K, V>(key: K, value: V) -> EnvVarGuard
+where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let key_os = key.as_ref().to_os_string();
+    let old = env::var_os(&key_os);
+    unsafe {
+        env::set_var(&key_os, value);
+    }
+    EnvVarGuard { key: key_os, old }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.old.take() {
+            Some(val) => unsafe { env::set_var(&self.key, val) },
+            None => unsafe { env::remove_var(&self.key) },
+        }
+    }
+}

--- a/tests/daemon_journald.rs
+++ b/tests/daemon_journald.rs
@@ -7,13 +7,16 @@ use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::warn;
 
+mod common;
+use common::temp_env;
+
 #[test]
 #[serial]
 fn daemon_journald_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    unsafe { std::env::set_var("OC_RSYNC_JOURNALD_PATH", &path) };
+    let _env = temp_env("OC_RSYNC_JOURNALD_PATH", &path);
     init_logging(None, None, false, true, false).unwrap();
     warn!(target: "test", "daemon journald");
     let mut buf = [0u8; 256];
@@ -21,5 +24,4 @@ fn daemon_journald_emits_message() {
     let msg = std::str::from_utf8(&buf[..n]).unwrap();
     let expected = "PRIORITY=4\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=daemon journald\n";
     assert_eq!(msg, expected);
-    unsafe { std::env::remove_var("OC_RSYNC_JOURNALD_PATH") };
 }

--- a/tests/daemon_syslog.rs
+++ b/tests/daemon_syslog.rs
@@ -7,13 +7,16 @@ use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::warn;
 
+mod common;
+use common::temp_env;
+
 #[test]
 #[serial]
 fn daemon_syslog_emits_message() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("sock");
     let server = UnixDatagram::bind(&path).unwrap();
-    unsafe { std::env::set_var("OC_RSYNC_SYSLOG_PATH", &path) };
+    let _env = temp_env("OC_RSYNC_SYSLOG_PATH", &path);
     init_logging(None, None, true, false, false).unwrap();
     warn!(target: "test", "daemon syslog");
     let mut buf = [0u8; 256];
@@ -21,5 +24,4 @@ fn daemon_syslog_emits_message() {
     let msg = std::str::from_utf8(&buf[..n]).unwrap();
     let expected = format!("<12>rsync[{}]: daemon syslog", std::process::id());
     assert_eq!(msg, expected);
-    unsafe { std::env::remove_var("OC_RSYNC_SYSLOG_PATH") };
 }


### PR DESCRIPTION
## Summary
- add `temp_env` helper to set and restore environment variables during tests
- replace manual `set_var`/`remove_var` in daemon/journald and sync config tests

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` exited with code 1)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linking with `cc` exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9721b22c8323bc2727260e0d03fb