### PR TITLE
Propagate Walk initialization errors

### DIFF
--- a/crates/walk/src/lib.rs
+++ b/crates/walk/src/lib.rs
@@ -64,7 +64,7 @@ impl Walk {
         max_file_size: Option<u64>,
         include_links: bool,
         one_file_system: bool,
-    ) -> Self {
+    ) -> std::io::Result<Self> {
         #[cfg(windows)]
         let walk_root = normalize_path(&root);
         #[cfg(windows)]
@@ -76,9 +76,7 @@ impl Walk {
 
         #[cfg(unix)]
         let root_dev = if one_file_system {
-            std::fs::symlink_metadata(&root)
-                .map(|m| m.dev())
-                .unwrap_or(0)
+            std::fs::symlink_metadata(&root)?.dev()
         } else {
             0
         };
@@ -94,7 +92,7 @@ impl Walk {
             .sort_by(|a, b| a.file_name().cmp(b.file_name()))
             .into_iter();
 
-        Walk {
+        Ok(Walk {
             iter,
             prev_path: String::new(),
             batch_size,
@@ -110,7 +108,7 @@ impl Walk {
             dev_table: Vec::new(),
             inode_map: HashMap::new(),
             inode_table: Vec::new(),
-        }
+        })
     }
 
     pub fn skip_current_dir(&mut self) {
@@ -139,7 +137,7 @@ pub fn walk(
     batch_size: usize,
     include_links: bool,
     one_file_system: bool,
-) -> Walk {
+) -> std::io::Result<Walk> {
     Walk::new(
         root.as_ref().to_path_buf(),
         batch_size,
@@ -155,7 +153,7 @@ pub fn walk_with_max_size(
     max_file_size: u64,
     include_links: bool,
     one_file_system: bool,
-) -> Walk {
+) -> std::io::Result<Walk> {
     Walk::new(
         root.as_ref().to_path_buf(),
         batch_size,

--- a/crates/walk/tests/walk.rs
+++ b/crates/walk/tests/walk.rs
@@ -23,7 +23,7 @@ fn walk_includes_files_dirs_and_symlinks() {
 
     let mut entries = Vec::new();
     let mut state = String::new();
-    for batch in walk(root, 10, true, false) {
+    for batch in walk(root, 10, true, false).unwrap() {
         let batch = batch.unwrap();
         for e in batch {
             let path = e.apply(&mut state);
@@ -31,26 +31,18 @@ fn walk_includes_files_dirs_and_symlinks() {
         }
     }
     assert!(entries.iter().any(|(p, t)| p == root && t.is_dir()));
-    assert!(
-        entries
-            .iter()
-            .any(|(p, t)| p.as_path() == root.join("dir").as_path() && t.is_dir())
-    );
-    assert!(
-        entries
-            .iter()
-            .any(|(p, t)| p.as_path() == root.join("dir/large.txt").as_path() && t.is_file())
-    );
-    assert!(
-        entries
-            .iter()
-            .any(|(p, t)| p == link_path.as_path() && t.is_symlink())
-    );
-    assert!(
-        entries
-            .iter()
-            .any(|(p, t)| p.as_path() == root.join("small.txt").as_path() && t.is_file())
-    );
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p.as_path() == root.join("dir").as_path() && t.is_dir()));
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p.as_path() == root.join("dir/large.txt").as_path() && t.is_file()));
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p == link_path.as_path() && t.is_symlink()));
+    assert!(entries
+        .iter()
+        .any(|(p, t)| p.as_path() == root.join("small.txt").as_path() && t.is_file()));
 }
 
 #[test]
@@ -66,7 +58,7 @@ fn walk_preserves_order_and_bounds_batches() {
 
     let mut paths = Vec::new();
     let mut state = String::new();
-    for batch in walk(root, 2, false, false) {
+    for batch in walk(root, 2, false, false).unwrap() {
         let batch = batch.unwrap();
         assert!(batch.len() <= 2);
         for e in batch {
@@ -96,7 +88,7 @@ fn walk_skips_files_over_threshold() {
 
     let mut paths = Vec::new();
     let mut state = String::new();
-    for batch in walk_with_max_size(root, 10, 1024, false, false) {
+    for batch in walk_with_max_size(root, 10, 1024, false, false).unwrap() {
         let batch = batch.unwrap();
         for e in batch {
             let path = e.apply(&mut state);
@@ -118,7 +110,7 @@ fn walk_skips_cross_device_entries() {
 
     let mut state = String::new();
     let mut found_pts = false;
-    for batch in walk(root, 100, false, false) {
+    for batch in walk(root, 100, false, false).unwrap() {
         let batch = batch.unwrap();
         for e in batch {
             let path = e.apply(&mut state);
@@ -134,7 +126,7 @@ fn walk_skips_cross_device_entries() {
     assert!(found_pts, "expected to see /dev/pts without restriction");
 
     state.clear();
-    for batch in walk(root, 100, false, true) {
+    for batch in walk(root, 100, false, true).unwrap() {
         let batch = batch.unwrap();
         for e in batch {
             let path = e.apply(&mut state);

--- a/tests/daemon_journald.rs
+++ b/tests/daemon_journald.rs
@@ -50,3 +50,4 @@ fn daemon_journald_emits_message() {
         let expected = "PRIORITY=4\nSYSLOG_IDENTIFIER=rsync\nMESSAGE=daemon journald\n";
         assert_eq!(msg, expected);
     });
+}


### PR DESCRIPTION
## Summary
- propagate `symlink_metadata` errors in `Walk::new` and return `io::Result`
- update public walk helpers and engine to handle new `Result` type
- adjust tests for new API and repair `daemon_journald` test

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `cargo test -p walk`
- `cargo nextest run --workspace --no-fail-fast` *(failed: cargo-nextest not installed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(failed: cargo-nextest not installed)*
- `make lint` *(failed: cargo fmt --all --check reported formatting differences)*


------
https://chatgpt.com/codex/tasks/task_e_68bda4fe0d708323aee583ff21232c4d