### PR TITLE
Add RPM summary and license metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,8 @@ assets = [
 [package.metadata.rpm]
 maintainer = "Project Maintainers <maintainers@oc-rsync.project>"
 requires = ["zlib", "libzstd"]
+summary = "Pure-Rust rsync replica"
+license = "Apache-2.0 OR MIT"
 
 [package.metadata.rpm.targets.oc-rsync]
 path = "/usr/bin/oc-rsync"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,3 +25,7 @@ support using:
 cargo build --no-default-features --features xattr
 ```
 
+### RPM packaging
+
+The RPM metadata is defined in `Cargo.toml` under `[package.metadata.rpm]` and includes the package summary and license. Run `cargo rpm build --release` to produce an RPM spec file containing these fields.
+


### PR DESCRIPTION
## Summary
- specify summary and license in RPM metadata
- document RPM packaging details

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linking with `cc`)*
- `make verify-comments`
- `make lint`
- `cargo rpm build` *(fails: linking with `cc`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb1ff1444832389513d06aa68b412