### PR TITLE
interop: compare metadata

### DIFF
--- a/tests/interop/run_matrix.sh
+++ b/tests/interop/run_matrix.sh
@@ -101,7 +101,7 @@ CFG
 
 verify_tree() {
   local src="$1" dst="$2"
-  $UPSTREAM -an --delete "$src/" "$dst/" | tee /tmp/verify.log
+  $UPSTREAM -an --delete --acls --xattrs "$src/" "$dst/" | tee /tmp/verify.log
   if [[ -s /tmp/verify.log ]]; then
     echo "Trees differ" >&2
     exit 1


### PR DESCRIPTION
## Summary
- ensure interop test tree comparison checks ACLs and xattrs

## Testing
- `cargo nextest run --workspace --no-fail-fast` (fails: linking with `cc` failed)
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` (fails: linking with `cc` failed)
- `make verify-comments`
- `make lint` (fails: make: *** [Makefile:15: lint] Error 1)
- `bash tests/interop/run_matrix.sh` (fails: curl: (56) CONNECT tunnel failed, response 403)


------
https://chatgpt.com/codex/tasks/task_e_68bdbb728528832383d0aded5568edd8