### PR TITLE
feat: harden interop curl downloads

### DIFF
--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -68,7 +68,8 @@ download_rsync() {
     mkdir -p "$ROOT/target/upstream"
     pushd "$ROOT/target/upstream" >/dev/null
     tarball="rsync-$ver.tar.gz"
-    curl -L "https://download.samba.org/pub/rsync/src/$tarball" -o "$tarball"
+    curl --fail --silent --show-error -L "https://download.samba.org/pub/rsync/src/$tarball" -o "$tarball" \
+      || { echo "failed to download $tarball" >&2; return 1; }
     sha="${RSYNC_SHA256[$ver]}"
     if [[ -z "$sha" ]]; then
       echo "missing checksum for rsync $ver" >&2


### PR DESCRIPTION
## Summary
- ensure interop curl fetches fail loudly and quietly
- stop interop script when rsync source download fails

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, apply_with_existing_partial, apply_without_existing_partial, append_errors_when_destination_missing, hides_temp_files, replay_is_deterministic, cleans_up_temp_dir_on_rename_failure, removes_partial_dir_after_sync, resume_from_partial_file)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(terminated: exceeded time)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc7d6065083238894e806625e4fcd