### PR TITLE
Gate rsync-dependent filter tests

### DIFF
--- a/crates/filters/tests/posix_classes.rs
+++ b/crates/filters/tests/posix_classes.rs
@@ -1,4 +1,6 @@
 // crates/filters/tests/posix_classes.rs
+#![cfg(all(unix, feature = "interop"))]
+
 use filters::{Matcher, parse};
 use std::collections::HashSet;
 use std::fs;
@@ -66,6 +68,7 @@ fn parity(class: &str, cases: &[(&str, bool)]) {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn space_class_parity() {
     parity(
         "space",
@@ -79,6 +82,7 @@ fn space_class_parity() {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn blank_class_parity() {
     parity(
         "blank",
@@ -92,6 +96,7 @@ fn blank_class_parity() {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn punct_class_parity() {
     parity(
         "punct",
@@ -105,11 +110,13 @@ fn punct_class_parity() {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn cntrl_class_parity() {
     parity("cntrl", &[("file\u{1}name", true), ("filename", false)]);
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn graph_class_parity() {
     parity(
         "graph",
@@ -122,6 +129,7 @@ fn graph_class_parity() {
 }
 
 #[test]
+#[ignore = "requires rsync"]
 fn print_class_parity() {
     parity(
         "print",

--- a/crates/filters/tests/rsync_special_chars.rs
+++ b/crates/filters/tests/rsync_special_chars.rs
@@ -1,4 +1,6 @@
 // crates/filters/tests/rsync_special_chars.rs
+#![cfg(all(unix, feature = "interop"))]
+
 use filters::{Matcher, parse};
 use proptest::prelude::*;
 use std::collections::HashSet;
@@ -28,6 +30,7 @@ fn pattern_strategy() -> impl Strategy<Value = String> {
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(64))]
     #[test]
+    #[ignore = "requires rsync"]
     fn special_chars_parity(rule in pattern_strategy()) {
         let tmp = tempdir().unwrap();
         let root = tmp.path().join("src");


### PR DESCRIPTION
## Summary
- gate filter parity tests behind `unix` and `interop` features
- mark parity tests as `#[ignore]` to avoid requiring upstream `rsync`

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: daemon::sequential_connections::handle_sequential_chrooted_connections, engine receiver::apply_with_existing_partial, engine receiver::apply_without_existing_partial, engine::append::append_errors_when_destination_missing)*


------
https://chatgpt.com/codex/tasks/task_e_68bdc884ab7483238fcffd92c28e6987