### PR TITLE
Refine interop cleanup trap

### DIFF
--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -38,7 +38,13 @@ if ! command -v sshd >/dev/null 2>&1; then
 fi
 
 TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
+cleanup() {
+  if [[ -f "$TMP/sshd.pid" ]]; then
+    kill "$(cat "$TMP/sshd.pid")" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
 
 # SSH server setup
 PORT=2222
@@ -56,7 +62,6 @@ PasswordAuthentication no
 PermitRootLogin yes
 CFG
 /usr/sbin/sshd -f "$TMP/sshd_config"
-trap 'kill $(cat "$TMP/sshd.pid") >/dev/null 2>&1 || true' EXIT
 SSH="ssh -p $PORT -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i $CLIENTKEY"
 
 download_rsync() {


### PR DESCRIPTION
## Summary
- consolidate interop script cleanup into a single `cleanup` function to kill `sshd` and remove temp dir

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(terminated)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc7c7dddc83238f55fdf0dda89463