### PR TITLE
test: compare downstream dirs in interop

### DIFF
--- a/scripts/interop.sh
+++ b/scripts/interop.sh
@@ -109,4 +109,16 @@ for ver in "${VERSIONS[@]}"; do
 
   diff -u "$WIRE_DIR/rsync-$ver.log" "$OC_RSYNC_LOG"
   diff -u "$FILELIST_DIR/rsync-$ver.txt" "$OC_RSYNC_LIST"
+
+  RSYNC_DST="/tmp/rsync_dst_$ver"
+  OC_RSYNC_DST="/tmp/oc_rsync_dst_$ver"
+
+  diff -r "$RSYNC_DST" "$OC_RSYNC_DST"
+
+  META_DIFF=$("$BIN" -acn --delete "$RSYNC_DST/" "$OC_RSYNC_DST/")
+  if [[ -n "$META_DIFF" ]]; then
+    echo "metadata mismatch for rsync $ver" >&2
+    echo "$META_DIFF" >&2
+    exit 1
+  fi
 done


### PR DESCRIPTION
## Summary
- compare upstream and oc-rsync destinations to ensure identical contents and metadata

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 194 failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(incomplete: interrupted during build)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc7f47ae483238cb96f957d014230