### PR TITLE
ci: add no-binaries and README version checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,28 @@ env:
   COLUMNS: 80
 
 jobs:
-  lint:  
+  no-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure no binary files are tracked
+        run: |
+          set -e
+          if git ls-files -z | xargs -0 -I{} sh -c 'if [ ! -L "{}" ] && [ -s "{}" ]; then file --mime "{}"; fi' | grep -q "charset=binary"; then
+            echo "Binary files detected" >&2
+            exit 1
+          fi
+
+  readme-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify README version string
+        run: |
+          grep -Fq 'rsync 3.4.1 (protocol 32)' README.md
+
+  lint:
+    needs: [no-binaries, readme-version]
     # runs-on: self-hosted
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- add CI job to detect committed binary files
- verify README.md references expected upstream rsync version
- gate linting and tests on new checks

## Testing
- `cargo install cargo-nextest --locked`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl; rerun interrupted after installing libacl1-dev)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdce2d125c8323bece69f92be6a45c