### PR TITLE
test: compare upstream client against oc-rsync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,8 +93,8 @@ jobs:
           components: llvm-tools-preview,clippy,rustfmt
           cache: true
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
+        - name: Install system dependencies
+          run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev libpopt-dev libxxhash-dev
 
       - name: Pre-flight check
         run: scripts/preflight.sh
@@ -139,8 +139,8 @@ jobs:
           toolchain: 1.87
           cache: true
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev acl attr openssh-server rsync
+        - name: Install system dependencies
+          run: sudo apt-get update && sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev libpopt-dev libxxhash-dev acl attr openssh-server rsync
 
       - name: Build oc-rsync (release)
         run: |
@@ -161,6 +161,9 @@ jobs:
 
       - name: Run interop tests
         run: cargo nextest run --workspace --no-fail-fast --features "cli nightly interop" --run-ignored=only-tests
+
+      - name: Run upstream interop matrix
+        run: tests/interop/run_matrix.sh
   build-matrix:
     needs: [lint, test-linux]
     strategy:


### PR DESCRIPTION
## Summary
- test upstream rsync clients against oc-rsync daemon and diff outputs for parity
- wire CI to run the upstream interop matrix and compare results

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: exit status 1, 190 failed tests)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: 8 failed, 920 not run)*
- `make verify-comments`
- `make lint`
- `SCENARIOS_OVERRIDE='base' RSYNC_VERSIONS_OVERRIDE='3.4.1' tests/interop/run_matrix.sh` *(fails: curl 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd2adc57883238978e76aeac82eb5