### PR TITLE
Capture interop outputs

### DIFF
--- a/docs/interop-grid.md
+++ b/docs/interop-grid.md
@@ -10,6 +10,12 @@ scripts/interop-grid.sh
 
 Results are written to `tests/interop/interop-grid.log` for inspection alongside other interoperability fixtures.
 
+`scripts/interop/run.sh` provides a lower‑level view of these transfers.  It
+records each `rsync` invocation's stdout, stderr, and exit code in versioned
+files under `tests/interop/streams/`.  The companion
+`scripts/interop/validate.sh` compares the captured streams from `oc-rsync` and
+upstream `rsync`, failing fast on any mismatch in output or exit status.
+
 ## Extended matrix coverage
 
 `scripts/interop.sh` exercises a wider set of options to ensure

--- a/scripts/interop/run.sh
+++ b/scripts/interop/run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+OUT_DIR="$ROOT/tests/interop/streams"
+OC_RSYNC="$ROOT/target/debug/oc-rsync"
+UPSTREAM="${UPSTREAM_RSYNC:-rsync}"
+FLAGS=(--archive --compress --delete)
+N=${#FLAGS[@]}
+
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+# Build oc-rsync if the binary is missing
+if [ ! -x "$OC_RSYNC" ]; then
+  ensure_build_deps() {
+    if ! command -v gcc >/dev/null 2>&1; then
+      apt-get update >/dev/null
+      apt-get install -y build-essential >/dev/null
+    fi
+    apt-get update >/dev/null
+    apt-get install -y libpopt-dev libzstd-dev zlib1g-dev libacl1-dev libxxhash-dev >/dev/null
+  }
+  ensure_build_deps
+  cargo build --quiet -p oc-rsync --bin oc-rsync
+fi
+
+OC_VER="$($OC_RSYNC --version 2>/dev/null | head -n1 | awk '{print $2}')"
+UP_VER="$($UPSTREAM --version | head -n1 | awk '{print $3}')"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SRC="$TMP/src"
+mkdir -p "$SRC"
+echo data > "$SRC/file.txt"
+
+for ((mask=0; mask< (1<<N); mask++)); do
+  args=()
+  for ((i=0; i<N; i++)); do
+    if ((mask & (1<<i))); then
+      args+=("${FLAGS[i]}")
+    fi
+  done
+  combo="${args[*]:-(none)}"
+  prefix="${combo// /_}"
+
+  RSYNC_DST="$TMP/rsync_dst"
+  OC_DST="$TMP/oc_dst"
+  mkdir -p "$RSYNC_DST" "$OC_DST"
+
+  set +e
+  "$UPSTREAM" "${args[@]}" "$SRC/" "$RSYNC_DST/" >"$OUT_DIR/${prefix}.rsync-${UP_VER}.stdout" 2>"$OUT_DIR/${prefix}.rsync-${UP_VER}.stderr"
+  echo $? >"$OUT_DIR/${prefix}.rsync-${UP_VER}.exit"
+  set -e
+
+  set +e
+  "$OC_RSYNC" "${args[@]}" "$SRC/" "$OC_DST/" >"$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.stdout" 2>"$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.stderr"
+  echo $? >"$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.exit"
+  set -e
+
+  rm -rf "$RSYNC_DST" "$OC_DST"
+done

--- a/scripts/interop/validate.sh
+++ b/scripts/interop/validate.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+OUT_DIR="$ROOT/tests/interop/streams"
+OC_RSYNC="$ROOT/target/debug/oc-rsync"
+UPSTREAM="${UPSTREAM_RSYNC:-rsync}"
+
+# Build oc-rsync if the binary is missing so we can determine its version
+if [ ! -x "$OC_RSYNC" ]; then
+  cargo build --quiet -p oc-rsync --bin oc-rsync
+fi
+
+OC_VER="$($OC_RSYNC --version 2>/dev/null | head -n1 | awk '{print $2}')"
+UP_VER="$($UPSTREAM --version | head -n1 | awk '{print $3}')"
+
+FLAGS=(--archive --compress --delete)
+N=${#FLAGS[@]}
+
+for ((mask=0; mask< (1<<N); mask++)); do
+  args=()
+  for ((i=0; i<N; i++)); do
+    if ((mask & (1<<i))); then
+      args+=("${FLAGS[i]}")
+    fi
+  done
+  combo="${args[*]:-(none)}"
+  prefix="${combo// /_}"
+
+  diff -u "$OUT_DIR/${prefix}.rsync-${UP_VER}.stdout" "$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.stdout"
+  diff -u "$OUT_DIR/${prefix}.rsync-${UP_VER}.stderr" "$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.stderr"
+
+  rsync_exit=$(cat "$OUT_DIR/${prefix}.rsync-${UP_VER}.exit")
+  oc_exit=$(cat "$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.exit")
+  if [[ "$rsync_exit" -ne "$oc_exit" ]]; then
+    echo "exit codes differ for $combo: rsync=$rsync_exit oc-rsync=$oc_exit" >&2
+    exit 1
+  fi
+
+done


### PR DESCRIPTION
## Summary
- capture stdout, stderr, and exit codes for each rsync run
- compare captured streams between oc-rsync and upstream
- document new interop artifacts and validation scripts

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: handle_sequential_chrooted_connections, apply_with_existing_partial, apply_without_existing_partial, sync_dir, backup_dir_uses_suffix, ...)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: nested_filters_apply_in_order, parity_with_stock_rsync, random_rule_parity, dir_merge_no_inherit, dir_merge_word_split, evaluate_rule_sender_only, chmod_masks_file_type_bits, client_local_sync, complex_glob_matches, copy_dirlinks_transforms_directory_symlinks, copy_links_errors_on_dangling_symlink, copy_links_resolves_relative_and_absolute_targets, backup_dir_uses_suffix, ...)*
- `make verify-comments`
- `make lint` *(fails: cargo fmt --all --check)*

------
https://chatgpt.com/codex/tasks/task_e_68bddee910a88323b3d52878175f62db