### PR TITLE
ci: fix interop script path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,10 +151,10 @@ jobs:
       - name: Build upstream rsync 3.4.1
         run: echo "UPSTREAM_RSYNC=$(tests/interop/build_upstream.sh)" >> $GITHUB_ENV
 
-      - name: Run interop matrix
+      - name: Collect interop snapshots
         env:
           UPSTREAM_RSYNC: ${{ env.UPSTREAM_RSYNC }}
-        run: scripts/interop.sh
+        run: scripts/interop/run.sh
 
       - name: Install cargo-nextest
         run: cargo install cargo-nextest --locked


### PR DESCRIPTION
## Summary
- fix interop workflow step to use `scripts/interop/run.sh`

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: assertion left == right; No such file or directory)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7b708ec8323820fb7477c913ac5