### PR TITLE
docs: update interop script path

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -10,10 +10,10 @@ when available. Do not exceed functionality of upstream at <https://rsync.samba.
 ## Interop matrix scenarios
 
 The interoperability matrix builds upstream `rsync 3.4.1` via
-[scripts/interop.sh](../scripts/interop.sh) and exercises real
+[tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh) and exercises real
 transfers across the following scenarios:
 
-  - `base`: baseline transfer using [scripts/interop.sh](../scripts/interop.sh)
+  - `base`: baseline transfer using [tests/interop/run_matrix.sh](../tests/interop/run_matrix.sh)
   - `delete`: `--delete` removes extraneous files
   - `compress_zlib`: zlib negotiation using [codec_negotiation.rs](../tests/interop/codec_negotiation.rs)
   - `compress_zstd`: zstd negotiation using [codec_negotiation.rs](../tests/interop/codec_negotiation.rs)


### PR DESCRIPTION
## Summary
- fix interop matrix script links in `docs/gaps.md`
- verify internal documentation links

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 235 passed, 99 failed, 681 not run)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_68bdec47ee188323965667c96076fa9f