### PR TITLE
Add interop output and directory checks

### DIFF
--- a/scripts/interop/run.sh
+++ b/scripts/interop/run.sh
@@ -59,5 +59,26 @@ for ((mask=0; mask< (1<<N); mask++)); do
   echo $? >"$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.exit"
   set -e
 
+  RSYNC_STDOUT="$OUT_DIR/${prefix}.rsync-${UP_VER}.stdout"
+  RSYNC_STDERR="$OUT_DIR/${prefix}.rsync-${UP_VER}.stderr"
+  RSYNC_EXIT="$OUT_DIR/${prefix}.rsync-${UP_VER}.exit"
+  OC_STDOUT="$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.stdout"
+  OC_STDERR="$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.stderr"
+  OC_EXIT="$OUT_DIR/${prefix}.oc-rsync-${OC_VER}.exit"
+
+  diff "$RSYNC_STDOUT" "$OC_STDOUT"
+  diff "$RSYNC_STDERR" "$OC_STDERR"
+  diff "$RSYNC_EXIT" "$OC_EXIT"
+
+  DIR_DIFF="$OUT_DIR/${prefix}.dir.diff"
+  if ! rsync -an --delete --acls --xattrs "$RSYNC_DST/" "$OC_DST/" >"$DIR_DIFF"; then
+    cat "$DIR_DIFF" >&2 || true
+    exit 1
+  fi
+  if [ -s "$DIR_DIFF" ]; then
+    cat "$DIR_DIFF" >&2
+    exit 1
+  fi
+
   rm -rf "$RSYNC_DST" "$OC_DST"
 done


### PR DESCRIPTION
## Summary
- compare oc-rsync and upstream rsync stdout/stderr/exit outputs in interop script
- verify directory contents and metadata via rsync dry-run and fail on mismatch

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 430 passed, 338 failed, interrupted)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*
- `make verify-comments`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68bdf050e62883239f544b39a041ea11