### PR TITLE
Handle spaces in comment lint script

### DIFF
--- a/tests/comment_lint_spaces.rs
+++ b/tests/comment_lint_spaces.rs
@@ -1,0 +1,54 @@
+// tests/comment_lint_spaces.rs
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn comment_lint_handles_space_paths() {
+    let worktree = tempdir().expect("tempdir");
+    let worktree_path = worktree.path();
+
+    // Create a detached worktree based on HEAD
+    let status = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "--detach",
+            worktree_path.to_str().unwrap(),
+        ])
+        .status()
+        .expect("git worktree add");
+    assert!(status.success());
+
+    // Create a Rust file with spaces in its name
+    let file_path = worktree_path.join("space file.rs");
+    fs::write(&file_path, "// space file.rs\n").expect("write file");
+    let status = Command::new("git")
+        .args([
+            "-C",
+            worktree_path.to_str().unwrap(),
+            "add",
+            "space file.rs",
+        ])
+        .status()
+        .expect("git add");
+    assert!(status.success());
+
+    // Run comment_lint.sh without arguments to trigger git ls-files -z
+    let status = Command::new("bash")
+        .arg("tools/comment_lint.sh")
+        .current_dir(worktree_path)
+        .status()
+        .expect("run comment_lint.sh");
+    assert!(status.success());
+
+    // Clean up worktree
+    let _ = Command::new("git")
+        .args([
+            "worktree",
+            "remove",
+            "--force",
+            worktree_path.to_str().unwrap(),
+        ])
+        .status();
+}

--- a/tools/comment_lint.sh
+++ b/tools/comment_lint.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-files="$@"
 if [ $# -eq 0 ]; then
-    files=$(git ls-files '*.rs')
+    readarray -d '' -t files < <(git ls-files -z '*.rs')
+else
+    files=("$@")
 fi
-cargo run --quiet -p xtask --bin comment_lint -- $files
+cargo run --quiet -p xtask --bin comment_lint -- "${files[@]}"


### PR DESCRIPTION
## Summary
- fix comment_lint.sh to iterate over git ls-files using an array and null delimiters
- add regression test ensuring comment_lint.sh handles filenames with spaces

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: 430 passed, 339 failed, 247 not run due to interrupt)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(terminated early)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdf751f20483238b49a426414f3406