### PR TITLE
Signal unsupported metadata on non-Unix platforms

### DIFF
--- a/crates/meta/src/stub.rs
+++ b/crates/meta/src/stub.rs
@@ -100,21 +100,17 @@ mod non_unix {
 
     impl Metadata {
         pub fn from_path(_path: &Path, _opts: Options) -> io::Result<Self> {
-            Ok(Metadata {
-                uid: 0,
-                gid: 0,
-                mode: 0,
-                mtime: FileTime::from_unix_time(0, 0),
-                atime: None,
-                crtime: None,
-                xattrs: Vec::new(),
-                acl: Vec::new(),
-                default_acl: Vec::new(),
-            })
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "metadata operations are not supported on this platform",
+            ))
         }
 
         pub fn apply(&self, _path: &Path, _opts: Options) -> io::Result<()> {
-            Ok(())
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "metadata operations are not supported on this platform",
+            ))
         }
     }
 
@@ -123,20 +119,26 @@ mod non_unix {
 
     impl HardLinks {
         pub fn register(&mut self, _id: u64, _path: &Path) -> bool {
-            false
+            unimplemented!("hard links are not supported on this platform")
         }
 
         pub fn finalize(&mut self) -> io::Result<()> {
-            Ok(())
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "hard links are not supported on this platform",
+            ))
         }
     }
 
     pub fn hard_link_id(_dev: u64, _ino: u64) -> u64 {
-        0
+        unimplemented!("hard links are not supported on this platform")
     }
 
     pub fn read_acl(_path: &Path, _fake_super: bool) -> io::Result<(Vec<()>, Vec<()>)> {
-        Ok((Vec::new(), Vec::new()))
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "ACLs are not supported on this platform",
+        ))
     }
 
     pub fn write_acl(
@@ -146,10 +148,15 @@ mod non_unix {
         _fake_super: bool,
         _super_user: bool,
     ) -> io::Result<()> {
-        Ok(())
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "ACLs are not supported on this platform",
+        ))
     }
 
-    pub fn store_fake_super(_path: &Path, _uid: u32, _gid: u32, _mode: u32) {}
+    pub fn store_fake_super(_path: &Path, _uid: u32, _gid: u32, _mode: u32) {
+        unimplemented!("fake super is not supported on this platform")
+    }
 }
 
 #[cfg(not(unix))]

--- a/crates/meta/tests/non_unix_stub.rs
+++ b/crates/meta/tests/non_unix_stub.rs
@@ -1,0 +1,48 @@
+// crates/meta/tests/non_unix_stub.rs
+#![cfg(all(not(unix), not(target_os = "windows")))]
+
+use std::io::ErrorKind;
+use std::panic::catch_unwind;
+use std::path::Path;
+
+use filetime::FileTime;
+use meta::{HardLinks, Metadata, Options, hard_link_id, read_acl, store_fake_super, write_acl};
+
+#[test]
+fn metadata_from_path_is_unsupported() {
+    let err = Metadata::from_path(Path::new("."), Options::default()).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Unsupported);
+}
+
+#[test]
+fn metadata_apply_is_unsupported() {
+    let md = Metadata {
+        uid: 0,
+        gid: 0,
+        mode: 0,
+        mtime: FileTime::from_unix_time(0, 0),
+        atime: None,
+        crtime: None,
+        xattrs: Vec::new(),
+        acl: Vec::new(),
+        default_acl: Vec::new(),
+    };
+    let err = md.apply(Path::new("."), Options::default()).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Unsupported);
+}
+
+#[test]
+fn hard_link_operations_panic() {
+    let mut hl = HardLinks::default();
+    assert!(catch_unwind(|| hl.register(1, Path::new("foo"))).is_err());
+    assert!(catch_unwind(|| hard_link_id(0, 0)).is_err());
+    assert!(catch_unwind(|| store_fake_super(Path::new("foo"), 0, 0, 0)).is_err());
+}
+
+#[test]
+fn acl_operations_are_unsupported() {
+    let err = read_acl(Path::new("foo"), false).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Unsupported);
+    let err = write_acl(Path::new("foo"), &[], &[], false, false).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Unsupported);
+}


### PR DESCRIPTION
## Summary
- return `io::ErrorKind::Unsupported` for non-Unix metadata operations
- add non-Unix tests verifying unsupported metadata, ACL, and hard link behavior

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 338 tests failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted during build)*


------
https://chatgpt.com/codex/tasks/task_e_68bdf766160c8323a9676896313b676b