### PR TITLE
Respect block size option in delta engine

### DIFF
--- a/crates/cli/src/exec.rs
+++ b/crates/cli/src/exec.rs
@@ -2,18 +2,18 @@
 
 use std::path::Path;
 
-use clap::{parser::ValueSource, ArgMatches};
+use clap::{ArgMatches, parser::ValueSource};
 
 use crate::options::ClientOpts;
 use crate::session::check_session_errors;
 use crate::utils::{RemoteSpec, RshCommand};
-use crate::{spawn_daemon_session, EngineError};
+use crate::{EngineError, spawn_daemon_session};
 
 use compress::available_codecs;
-use engine::{pipe_sessions, sync, Result, Stats, SyncOptions};
+use engine::{Result, Stats, SyncOptions, pipe_sessions, sync};
 use filters::Matcher;
-use protocol::{CharsetConv, ExitCode, CAP_ACLS, CAP_CODECS, CAP_XATTRS};
-use transport::{daemon_remote_opts, AddressFamily, RateLimitedTransport, SshStdioTransport};
+use protocol::{CAP_ACLS, CAP_CODECS, CAP_XATTRS, CharsetConv, ExitCode};
+use transport::{AddressFamily, RateLimitedTransport, SshStdioTransport, daemon_remote_opts};
 
 #[cfg(unix)]
 use nix::unistd;

--- a/crates/cli/tests/cli_parity.rs
+++ b/crates/cli/tests/cli_parity.rs
@@ -168,7 +168,9 @@ fn misuse_matches_upstream() {
     let our_lines: Vec<_> = ours_stderr.lines().collect();
     assert_eq!(ours.status.code(), Some(1));
     assert_eq!(our_lines.first(), golden_lines.first());
-    assert!(our_lines
-        .get(1)
-        .is_some_and(|l| l.starts_with(golden_lines[1])));
+    assert!(
+        our_lines
+            .get(1)
+            .is_some_and(|l| l.starts_with(golden_lines[1]))
+    );
 }

--- a/crates/compress/tests/codecs.rs
+++ b/crates/compress/tests/codecs.rs
@@ -1,6 +1,6 @@
 // crates/compress/tests/codecs.rs
 use compress::{
-    available_codecs, decode_codecs, encode_codecs, negotiate_codec, should_compress, Codec,
+    Codec, available_codecs, decode_codecs, encode_codecs, negotiate_codec, should_compress,
 };
 
 #[cfg(any(feature = "zlib", feature = "zstd"))]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1182,7 +1182,7 @@ pub fn sync(
         }
     }
 
-    let mut sender = Sender::new(opts.block_size, matcher.clone(), codec, opts.clone());
+    let mut sender = Sender::new(matcher.clone(), codec, opts.clone());
     let mut receiver = Receiver::new(codec, opts.clone());
     receiver.matcher = matcher.clone();
     let mut dir_meta: Vec<(PathBuf, PathBuf)> = Vec::new();
@@ -1842,7 +1842,6 @@ mod tests {
         fs::write(&outside, b"outside").unwrap();
 
         let mut sender = Sender::new(
-            1024,
             Matcher::default(),
             Some(Codec::Zlib),
             SyncOptions::default(),
@@ -1955,12 +1954,7 @@ mod tests {
             tmp.write_all(&chunk).unwrap();
         }
         let path = tmp.path().to_path_buf();
-        let sender = Sender::new(
-            RSYNC_BLOCK_SIZE,
-            Matcher::default(),
-            None,
-            SyncOptions::default(),
-        );
+        let sender = Sender::new(Matcher::default(), None, SyncOptions::default());
         let new_sum = sender.strong_file_checksum(&path).unwrap();
         let data = fs::read(&path).unwrap();
         let old_sum = sender.cfg.checksum(&data).strong;

--- a/crates/engine/src/receiver.rs
+++ b/crates/engine/src/receiver.rs
@@ -179,10 +179,10 @@ impl Receiver {
             .seed(self.opts.checksum_seed)
             .build();
         let src_len = fs::metadata(src).map(|m| m.len()).unwrap_or(0);
-        let block_size = if self.opts.block_size == 0 {
-            block_size(src_len)
-        } else {
+        let block_size = if self.opts.block_size > 0 {
             self.opts.block_size
+        } else {
+            block_size(src_len)
         };
         let resume_basis = existing_partial.as_ref().unwrap_or(&tmp_dest);
         let mut resume = if self.opts.partial || self.opts.append || self.opts.append_verify {

--- a/crates/walk/tests/walk.rs
+++ b/crates/walk/tests/walk.rs
@@ -31,18 +31,26 @@ fn walk_includes_files_dirs_and_symlinks() {
         }
     }
     assert!(entries.iter().any(|(p, t)| p == root && t.is_dir()));
-    assert!(entries
-        .iter()
-        .any(|(p, t)| p.as_path() == root.join("dir").as_path() && t.is_dir()));
-    assert!(entries
-        .iter()
-        .any(|(p, t)| p.as_path() == root.join("dir/large.txt").as_path() && t.is_file()));
-    assert!(entries
-        .iter()
-        .any(|(p, t)| p == link_path.as_path() && t.is_symlink()));
-    assert!(entries
-        .iter()
-        .any(|(p, t)| p.as_path() == root.join("small.txt").as_path() && t.is_file()));
+    assert!(
+        entries
+            .iter()
+            .any(|(p, t)| p.as_path() == root.join("dir").as_path() && t.is_dir())
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(p, t)| p.as_path() == root.join("dir/large.txt").as_path() && t.is_file())
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(p, t)| p == link_path.as_path() && t.is_symlink())
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|(p, t)| p.as_path() == root.join("small.txt").as_path() && t.is_file())
+    );
 }
 
 #[test]

--- a/tests/comment_lint_spaces.rs
+++ b/tests/comment_lint_spaces.rs
@@ -1,4 +1,5 @@
 // tests/comment_lint_spaces.rs
+
 use std::fs;
 use std::process::Command;
 use tempfile::tempdir;
@@ -8,7 +9,6 @@ fn comment_lint_handles_space_paths() {
     let worktree = tempdir().expect("tempdir");
     let worktree_path = worktree.path();
 
-    // Create a detached worktree based on HEAD
     let status = Command::new("git")
         .args([
             "worktree",
@@ -20,7 +20,6 @@ fn comment_lint_handles_space_paths() {
         .expect("git worktree add");
     assert!(status.success());
 
-    // Create a Rust file with spaces in its name
     let file_path = worktree_path.join("space file.rs");
     fs::write(&file_path, "// space file.rs\n").expect("write file");
     let status = Command::new("git")
@@ -34,7 +33,6 @@ fn comment_lint_handles_space_paths() {
         .expect("git add");
     assert!(status.success());
 
-    // Run comment_lint.sh without arguments to trigger git ls-files -z
     let status = Command::new("bash")
         .arg("tools/comment_lint.sh")
         .current_dir(worktree_path)
@@ -42,7 +40,6 @@ fn comment_lint_handles_space_paths() {
         .expect("run comment_lint.sh");
     assert!(status.success());
 
-    // Clean up worktree
     let _ = Command::new("git")
         .args([
             "worktree",


### PR DESCRIPTION
## Summary
- forward CLI block size through `SyncOptions` into delta calculations
- honor `SyncOptions.block_size` in sender and receiver
- test stats reporting when custom block size is used

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: `/usr/bin/ld: cannot find -lacl`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: `/usr/bin/ld: cannot find -lacl`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdff4149b883239ad30ba259b7517b