### PR TITLE
test: cover size parsing edge cases

### DIFF
--- a/crates/cli/src/utils.rs
+++ b/crates/cli/src/utils.rs
@@ -478,7 +478,20 @@ mod tests {
     }
 
     #[test]
+    fn parse_size_supports_k_suffixes() {
+        assert_eq!(parse_size::<u64>("1k").unwrap(), 1u64 << 10);
+        assert_eq!(parse_size::<u64>("1K").unwrap(), 1u64 << 10);
+    }
+
+    #[test]
+    fn parse_size_rejects_internal_spaces() {
+        assert!(parse_size::<u64>("1 k").is_err());
+    }
+
+    #[test]
     fn parse_size_overflow() {
         assert!(parse_size::<u64>("16384p").is_err());
+        assert!(parse_size::<u64>("18446744073709551616").is_err());
+        assert!(parse_size::<u32>("5g").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- add unit tests for `k` suffix and space handling
- check multiple overflow scenarios in `parse_size`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 79 failed, 796 not run)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*
- `make verify-comments`
- `make lint`
- `cargo test -p oc-rsync-cli` *(fails: 24 passed, 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68be0d4eb2ac8323ab9403841946d9ad