### PR TITLE
test: ensure checksum triggers transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,7 @@ dependencies = [
  "daemon",
  "encoding_rs",
  "engine",
+ "filetime",
  "filters",
  "insta",
  "logging",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -35,6 +35,7 @@ tempfile = "3"
 assert_cmd = "2"
 insta = { version = "1", features = ["json"] }
 serial_test = "2"
+filetime = "0.2"
 
 [features]
 default = []

--- a/crates/cli/tests/checksum.rs
+++ b/crates/cli/tests/checksum.rs
@@ -1,0 +1,54 @@
+// crates/cli/tests/checksum.rs
+use assert_cmd::Command;
+use filetime::{FileTime, set_file_mtime};
+use tempfile::tempdir;
+
+fn parse_literal(output: &str) -> usize {
+    for line in output.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("Literal data: ") {
+            let num_str = rest.split_whitespace().next().unwrap().replace(",", "");
+            return num_str.parse().unwrap();
+        }
+    }
+    panic!("no literal data in stats: {output}");
+}
+
+#[test]
+fn checksum_transfers_when_timestamps_match() {
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir_all(&dst).unwrap();
+
+    let src_file = src_dir.join("file.bin");
+    let dst_file = dst.join("file.bin");
+
+    let a = vec![0xAAu8; 1024];
+    let b = vec![0xBBu8; 1024];
+    std::fs::write(&src_file, &a).unwrap();
+    std::fs::write(&dst_file, &b).unwrap();
+
+    let mtime = FileTime::from_unix_time(1_600_000_000, 0);
+    set_file_mtime(&src_file, mtime).unwrap();
+    set_file_mtime(&dst_file, mtime).unwrap();
+
+    // With --checksum, differing content should be transferred
+    let out = Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--checksum",
+            "--block-size",
+            "1k",
+            "--no-whole-file",
+            "--stats",
+            src_file.to_str().unwrap(),
+            dst.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let literal = parse_literal(std::str::from_utf8(&out.stdout).unwrap());
+    assert!(literal > 0);
+}


### PR DESCRIPTION
## Summary
- add regression test for checksum-based transfer despite matching timestamps
- document filetime dev-dependency for tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast` *(fails: assertion failed, tests interrupted)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted during build)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68be0d8380788323b027d9657c93951a