### PR TITLE
Add block size and checksum options test

### DIFF
--- a/crates/cli/tests/options_block_size.rs
+++ b/crates/cli/tests/options_block_size.rs
@@ -1,0 +1,29 @@
+// crates/cli/tests/options_block_size.rs
+use engine::SyncOptions;
+use oc_rsync_cli::options::ClientOpts as Options;
+
+fn build_sync_options(opts: &Options) -> SyncOptions {
+    SyncOptions {
+        checksum: opts.checksum,
+        block_size: opts.block_size.unwrap_or(0),
+        ..SyncOptions::default()
+    }
+}
+
+#[test]
+fn options_block_size_and_checksum() {
+    let opts = Options::try_parse_from([
+        "oc-rsync",
+        "--block-size",
+        "1k",
+        "--checksum",
+        "src/",
+        "dst",
+    ])
+    .unwrap();
+
+    let sync_opts = build_sync_options(&opts);
+
+    assert_eq!(sync_opts.block_size, 1024);
+    assert!(sync_opts.checksum);
+}


### PR DESCRIPTION
## Summary
- test building SyncOptions from CLI options

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cargo-nextest not installed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cargo-nextest not installed)*
- `make verify-comments` *(fails: crates/cli/tests/checksum.rs: additional comments)*
- `make lint` *(fails: interrupted during build)*
- `cargo fmt --all --check`


------
https://chatgpt.com/codex/tasks/task_e_68be15c94c308323ad78c2b76d216aab