### PR TITLE
refactor: share parse_literal test helper

### DIFF
--- a/crates/cli/tests/block_size.rs
+++ b/crates/cli/tests/block_size.rs
@@ -1,17 +1,9 @@
 // crates/cli/tests/block_size.rs
+
 use assert_cmd::Command;
 use tempfile::tempdir;
-
-fn parse_literal(stats: &str) -> usize {
-    for line in stats.lines() {
-        let line = line.trim();
-        if let Some(rest) = line.strip_prefix("Literal data: ") {
-            let num_str = rest.split_whitespace().next().unwrap().replace(",", "");
-            return num_str.parse().unwrap();
-        }
-    }
-    panic!("no literal data in stats: {stats}");
-}
+mod common;
+use common::parse_literal;
 
 #[test]
 fn block_size_literal_data_matches() {

--- a/crates/cli/tests/checksum.rs
+++ b/crates/cli/tests/checksum.rs
@@ -1,18 +1,10 @@
 // crates/cli/tests/checksum.rs
+
 use assert_cmd::Command;
 use filetime::{FileTime, set_file_mtime};
 use tempfile::tempdir;
-
-fn parse_literal(output: &str) -> usize {
-    for line in output.lines() {
-        let line = line.trim();
-        if let Some(rest) = line.strip_prefix("Literal data: ") {
-            let num_str = rest.split_whitespace().next().unwrap().replace(",", "");
-            return num_str.parse().unwrap();
-        }
-    }
-    panic!("no literal data in stats: {output}");
-}
+mod common;
+use common::parse_literal;
 
 #[test]
 fn checksum_transfers_when_timestamps_match() {
@@ -34,7 +26,6 @@ fn checksum_transfers_when_timestamps_match() {
     set_file_mtime(&src_file, mtime).unwrap();
     set_file_mtime(&dst_file, mtime).unwrap();
 
-    // With --checksum, differing content should be transferred
     let out = Command::cargo_bin("oc-rsync")
         .unwrap()
         .args([

--- a/crates/cli/tests/common/mod.rs
+++ b/crates/cli/tests/common/mod.rs
@@ -1,0 +1,16 @@
+// crates/cli/tests/common/mod.rs
+#![allow(dead_code)]
+
+pub fn parse_literal(stats: &str) -> usize {
+    for line in stats.lines() {
+        let line = line.trim();
+        if let Some(rest) = line
+            .strip_prefix("Literal data: ")
+            .or_else(|| line.strip_prefix("Unmatched data: "))
+        {
+            let num_str = rest.split_whitespace().next().unwrap().replace(",", "");
+            return num_str.parse().unwrap();
+        }
+    }
+    panic!("no literal data in stats: {stats}");
+}

--- a/tests/block_size.rs
+++ b/tests/block_size.rs
@@ -8,20 +8,8 @@ use engine::{Op, SyncOptions, block_size, compute_delta, sync};
 use filters::Matcher;
 use std::fs;
 use tempfile::tempdir;
-
-fn parse_literal(stats: &str) -> usize {
-    for line in stats.lines() {
-        let line = line.trim();
-        if let Some(rest) = line
-            .strip_prefix("Literal data: ")
-            .or_else(|| line.strip_prefix("Unmatched data: "))
-        {
-            let num_str = rest.split_whitespace().next().unwrap().replace(",", "");
-            return num_str.parse().unwrap();
-        }
-    }
-    panic!("no literal data in stats: {stats}");
-}
+mod common;
+use common::parse_literal;
 
 #[test]
 fn block_size_matches_upstream() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -52,3 +52,17 @@ pub fn normalize_paths(data: &[u8], root: &Path) -> String {
     let root_str = root.to_string_lossy().replace("\\", "/");
     text.replace(&root_str, "TMP")
 }
+
+pub fn parse_literal(stats: &str) -> usize {
+    for line in stats.lines() {
+        let line = line.trim();
+        if let Some(rest) = line
+            .strip_prefix("Literal data: ")
+            .or_else(|| line.strip_prefix("Unmatched data: "))
+        {
+            let num_str = rest.split_whitespace().next().unwrap().replace(",", "");
+            return num_str.parse().unwrap();
+        }
+    }
+    panic!("no literal data in stats: {stats}");
+}


### PR DESCRIPTION
## Summary
- move parse_literal helper into common test modules
- replace inline parse_literal helpers with the shared version

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68be16057dec8323afb55c6e8a080625