### PR TITLE
Forward block size option to remote side

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -597,6 +597,10 @@ impl SyncOptions {
         if self.one_file_system {
             self.remote_options.push("--one-file-system".into());
         }
+        if self.block_size > 0 {
+            self.remote_options
+                .push(format!("--block-size={}", self.block_size));
+        }
     }
 
     fn walk_links(&self) -> bool {


### PR DESCRIPTION
## Summary
- forward `--block-size` to remote rsync processes

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments` *(fails: crates/cli/tests/checksum.rs: additional comments)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command `nextest`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: no such command `nextest`)*

------
https://chatgpt.com/codex/tasks/task_e_68be1630f1c48323bf3e4af8767f708c