### PR TITLE
chore: remove unused imports and simplify cfg flags

### DIFF
--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -9,7 +9,7 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 
 use compress::available_codecs;
 use engine::{IdMapper, SyncOptions, sync};
-use filetime::{FileTime, set_file_atime, set_file_mtime, set_file_times, set_symlink_file_times};
+use filetime::{FileTime, set_file_mtime, set_file_times, set_symlink_file_times};
 use filters::Matcher;
 use meta::{IdKind, parse_chmod, parse_chown, parse_id_map};
 use nix::sys::stat::{Mode, SFlag, mknod};
@@ -17,8 +17,6 @@ use nix::unistd::{Gid, Uid, chown, mkfifo};
 #[cfg(feature = "acl")]
 use posix_acl::{ACL_READ, ACL_WRITE, PosixACL, Qualifier};
 use tempfile::tempdir;
-#[cfg(feature = "xattr")]
-use xattr;
 
 #[test]
 fn perms_roundtrip() {
@@ -925,7 +923,7 @@ fn metadata_matches_source() {
     assert!(cr_dst.is_some());
 }
 
-#[cfg(all(feature = "xattr"))]
+#[cfg(feature = "xattr")]
 #[test]
 fn fake_super_stores_xattrs() {
     let tmp = tempdir().unwrap();
@@ -980,7 +978,7 @@ fn super_overrides_fake_super() {
     assert!(xattr::get(&dst_file, "user.rsync.uid").unwrap().is_none());
 }
 
-#[cfg(all(feature = "xattr"))]
+#[cfg(feature = "xattr")]
 #[test]
 fn xattrs_roundtrip_fake_super() {
     let tmp = tempdir().unwrap();
@@ -1006,7 +1004,7 @@ fn xattrs_roundtrip_fake_super() {
     assert_eq!(&val[..], b"val");
 }
 
-#[cfg(all(feature = "acl"))]
+#[cfg(feature = "acl")]
 #[test]
 fn acls_roundtrip_default_acl() {
     let tmp = tempdir().unwrap();

--- a/crates/meta/tests/acl_prune.rs
+++ b/crates/meta/tests/acl_prune.rs
@@ -64,8 +64,6 @@ fn write_prunes_and_removes_default() -> std::io::Result<()> {
 #[cfg(feature = "xattr")]
 #[test]
 fn fake_super_stores_acls() -> std::io::Result<()> {
-    use xattr;
-
     let dir = tempdir()?;
     let file = dir.path().join("f");
     fs::write(&file, b"hi")?;

--- a/crates/meta/tests/roundtrip.rs
+++ b/crates/meta/tests/roundtrip.rs
@@ -107,8 +107,6 @@ fn default_skips_owner_group_perms() -> std::io::Result<()> {
 #[cfg(feature = "xattr")]
 #[test]
 fn roundtrip_xattrs() -> std::io::Result<()> {
-    use xattr;
-
     let dir = tempdir()?;
     let src = dir.path().join("src");
     let dst = dir.path().join("dst");

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -23,8 +23,6 @@ use std::time::Duration;
 use tempfile::{TempDir, tempdir, tempdir_in};
 #[cfg(unix)]
 use users::{get_current_gid, get_current_uid, get_group_by_gid, get_user_by_uid};
-#[cfg(all(unix, feature = "xattr"))]
-use xattr as _;
 mod common;
 use common::read_golden;
 


### PR DESCRIPTION
## Summary
- remove unused `xattr` and `set_file_atime` imports
- simplify feature cfgs for xattr and acl tests
- address lint warnings and ensure clippy passes

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*


------
https://chatgpt.com/codex/tasks/task_e_68be9910adc08323a3842e607a6b7c85