### PR TITLE
test: retry upstream download in run_matrix

### DIFF
--- a/tests/interop/run_matrix.sh
+++ b/tests/interop/run_matrix.sh
@@ -74,7 +74,7 @@ download_rsync() {
     mkdir -p "$ROOT/target/upstream"
     pushd "$ROOT/target/upstream" >/dev/null
     tarball="rsync-$ver.tar.gz"
-    curl -L "https://download.samba.org/pub/rsync/src/$tarball" -o "$tarball"
+    curl -fL --retry 3 -o "$tarball" "https://download.samba.org/pub/rsync/src/$tarball"
     sha256="${RSYNC_SHA256[$ver]}"
     if [[ -z "$sha256" ]]; then
       echo "Unknown SHA256 for rsync $ver" >&2


### PR DESCRIPTION
## Summary
- ensure upstream rsync downloads fail on HTTP errors or transient issues

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: struct `ClientOpts` is private)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: struct `ClientOpts` is private)*

------
https://chatgpt.com/codex/tasks/task_e_68be992323a08323854dfb83932c2769