### PR TITLE
chore: remove unused OpenOptions import

### DIFF
--- a/crates/engine/src/cleanup.rs
+++ b/crates/engine/src/cleanup.rs
@@ -2,7 +2,7 @@
 
 use rand::{Rng, distributions::Alphanumeric};
 use std::ffi::{OsStr, OsString};
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use tempfile::Builder;
@@ -222,7 +222,7 @@ pub(crate) fn open_for_read(path: &Path, _opts: &SyncOptions) -> std::io::Result
     {
         use std::os::unix::fs::OpenOptionsExt;
         if _opts.open_noatime {
-            let mut o = OpenOptions::new();
+            let mut o = std::fs::OpenOptions::new();
             o.read(true).custom_flags(libc::O_NOATIME);
             if let Ok(f) = o.open(path) {
                 return Ok(f);


### PR DESCRIPTION
## Summary
- remove unused `OpenOptions` import from cleanup module
- use fully-qualified `std::fs::OpenOptions` under Linux

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `cargo clippy --all-targets --all-features -- -D warnings`


------
https://chatgpt.com/codex/tasks/task_e_68be9c70e3248323bd0aec08ead0a055