### PR TITLE
test: use rsync comparison for tree diff

### DIFF
--- a/scripts/interop/run.sh
+++ b/scripts/interop/run.sh
@@ -10,12 +10,9 @@ N=${#FLAGS[@]}
 
 cmp_trees() {
   local a="$1" b="$2" diff_file="$3"
-  if ! rsync -an --delete -rlptgoD --acls --xattrs "$a/" "$b/" >"$diff_file"; then
-    cat "$diff_file" >&2 || true
-    return 1
-  fi
-  if [ -s "$diff_file" ]; then
-    cat "$diff_file" >&2
+  rsync -an --delete -rlptgoD --acls --xattrs "$a/" "$b/" | tee "$diff_file"
+  if [[ -s "$diff_file" ]]; then
+    echo "Trees differ" >&2
     return 1
   fi
 }


### PR DESCRIPTION
## Summary
- compare directory trees in interop test harness using `rsync` and fail on differences

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: struct `ClientOpts` is private)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: struct `ClientOpts` is private)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68be9d1bd45483239cb5d5dcf09fb433