### PR TITLE
docs: clarify files-from directory entry coverage

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -72,7 +72,7 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | Additional rule modifiers | Implemented | [crates/filters/tests/rule_modifiers.rs](../crates/filters/tests/rule_modifiers.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | CVS ignore semantics (`--cvs-exclude`) | ✅ | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Complex glob patterns | Implemented | [crates/filters/tests/advanced_globs.rs](../crates/filters/tests/advanced_globs.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
-| `--files-from` directory entries | Implemented | [crates/filters/tests/files_from.rs](../crates/filters/tests/files_from.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| `--files-from` directory entries | Implemented | [crates/filters/tests/files_from.rs](../crates/filters/tests/files_from.rs)<br>[tests/files_from_dirs.rs](../tests/files_from_dirs.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs)<br>[crates/cli/src/lib.rs](../crates/cli/src/lib.rs) |
 | Directory boundary handling | Implemented | [tests/cli.rs](../tests/cli.rs) (`single_star_does_not_cross_directories`<br>`segment_star_does_not_cross_directories`) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 
 ## File Selection


### PR DESCRIPTION
## Summary
- document `--files-from` directory entry support with links to CLI source and integration tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot compile `oc-rsync-cli` tests because `ClientOpts` is private)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot compile `oc-rsync-cli` tests because `ClientOpts` is private)*
- `make verify-comments`
- `make lint`
- `cargo doc --no-deps`


------
https://chatgpt.com/codex/tasks/task_e_68bea298dcac83239d1de5210ad11073