### PR TITLE
Improve build_upstream download error handling

### DIFF
--- a/tests/interop/build_upstream.sh
+++ b/tests/interop/build_upstream.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Requires network access to download the upstream rsync source release.
 # Build a known upstream rsync release and verify its checksum before use.
 ROOT="$(git rev-parse --show-toplevel)"
 OUT_DIR="$ROOT/target/upstream"
@@ -26,7 +27,11 @@ apt-get update
 apt-get install -y libpopt-dev libzstd-dev zlib1g-dev libacl1-dev libxxhash-dev >/dev/null
 
 tarball="rsync-$VER.tar.gz"
-curl -L -O "https://download.samba.org/pub/rsync/src/$tarball"
+url="https://download.samba.org/pub/rsync/src/$tarball"
+if ! curl --fail --location --silent --show-error -O "$url"; then
+  echo "Failed to download $tarball from $url" >&2
+  exit 1
+fi
 echo "$SHA256  $tarball" | sha256sum -c -
 tar xzf "$tarball"
 cd "rsync-$VER"


### PR DESCRIPTION
## Summary
- Document network requirement and check curl exit status in `tests/interop/build_upstream.sh`.

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: daemon::sequential_connections::handle_sequential_chrooted_connections, engine receiver apply tests, engine append_errors_when_destination_missing, engine cleanup, engine backup, engine resume, etc.)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: same tests as above)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bec62853e8832398eb7015831427da