### PR TITLE
test: split files-from path coverage

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -236,7 +236,7 @@ fn exclude_from_from0_matches_rsync() {
 }
 
 #[test]
-fn files_from_dirs_and_nested_paths() {
+fn files_from_nested_file_creates_parent_dirs() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let dst = tmp.path().join("dst");
@@ -251,7 +251,7 @@ fn files_from_dirs_and_nested_paths() {
     fs::write(src.join("other/file.txt"), b"no").unwrap();
     fs::create_dir_all(&dst).unwrap();
     let list = tmp.path().join("list");
-    fs::write(&list, "foo/bar/baz.txt\nqux/\n").unwrap();
+    fs::write(&list, "foo/bar/baz.txt\n").unwrap();
     let src_arg = format!("{}/", src.display());
     Command::cargo_bin("oc-rsync")
         .unwrap()
@@ -264,16 +264,102 @@ fn files_from_dirs_and_nested_paths() {
         ])
         .assert()
         .success();
-    assert!(dst.join("foo").is_dir());
-    assert!(dst.join("foo/bar").is_dir());
-    assert!(dst.join("foo/bar/baz.txt").is_file());
-    assert!(!dst.join("foo/bar/skip.txt").exists());
-    assert!(!dst.join("foo/other.txt").exists());
-    assert!(dst.join("qux").is_dir());
-    assert!(dst.join("qux/sub").is_dir());
-    assert!(dst.join("qux/sub/keep.txt").is_file());
-    assert!(dst.join("qux/junk.txt").is_file());
-    assert!(!dst.join("other").exists());
+    assert!(
+        dst.join("foo").is_dir(),
+        "path {}",
+        dst.join("foo").display()
+    );
+    assert!(
+        dst.join("foo/bar").is_dir(),
+        "path {}",
+        dst.join("foo/bar").display()
+    );
+    assert!(
+        dst.join("foo/bar/baz.txt").is_file(),
+        "path {}",
+        dst.join("foo/bar/baz.txt").display()
+    );
+    assert!(
+        !dst.join("foo/bar/skip.txt").exists(),
+        "path {}",
+        dst.join("foo/bar/skip.txt").display()
+    );
+    assert!(
+        !dst.join("foo/other.txt").exists(),
+        "path {}",
+        dst.join("foo/other.txt").display()
+    );
+    assert!(
+        !dst.join("qux").exists(),
+        "path {}",
+        dst.join("qux").display()
+    );
+    assert!(
+        !dst.join("other").exists(),
+        "path {}",
+        dst.join("other").display()
+    );
+}
+
+#[test]
+fn files_from_directory_copies_entire_tree() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let dst = tmp.path().join("dst");
+    fs::create_dir_all(src.join("foo/bar")).unwrap();
+    fs::create_dir_all(src.join("qux/sub")).unwrap();
+    fs::create_dir_all(src.join("other")).unwrap();
+    fs::write(src.join("foo/bar/baz.txt"), b"data").unwrap();
+    fs::write(src.join("foo/bar/skip.txt"), b"no").unwrap();
+    fs::write(src.join("foo/other.txt"), b"no").unwrap();
+    fs::write(src.join("qux/sub/keep.txt"), b"data").unwrap();
+    fs::write(src.join("qux/junk.txt"), b"data").unwrap();
+    fs::write(src.join("other/file.txt"), b"no").unwrap();
+    fs::create_dir_all(&dst).unwrap();
+    let list = tmp.path().join("list");
+    fs::write(&list, "qux/\n").unwrap();
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--recursive",
+            "--files-from",
+            list.to_str().unwrap(),
+            &src_arg,
+            dst.to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+    assert!(
+        dst.join("qux").is_dir(),
+        "path {}",
+        dst.join("qux").display()
+    );
+    assert!(
+        dst.join("qux/sub").is_dir(),
+        "path {}",
+        dst.join("qux/sub").display()
+    );
+    assert!(
+        dst.join("qux/sub/keep.txt").is_file(),
+        "path {}",
+        dst.join("qux/sub/keep.txt").display()
+    );
+    assert!(
+        dst.join("qux/junk.txt").is_file(),
+        "path {}",
+        dst.join("qux/junk.txt").display()
+    );
+    assert!(
+        !dst.join("foo").exists(),
+        "path {}",
+        dst.join("foo").display()
+    );
+    assert!(
+        !dst.join("other").exists(),
+        "path {}",
+        dst.join("other").display()
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `files_from_nested_file_creates_parent_dirs` checking parent dirs only
- add `files_from_directory_copies_entire_tree` verifying whole subtree copy

## Testing
- `cargo nextest run --tests files_from_nested_file_creates_parent_dirs files_from_directory_copies_entire_tree` *(fails: path assertions)*
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: path assertions)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(did not complete: aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68bec71287348323a2477ea5c3b70c88