### PR TITLE
Accept zero stats transfer rate in tests

### DIFF
--- a/tests/cli_misc.rs
+++ b/tests/cli_misc.rs
@@ -629,7 +629,7 @@ fn stats_parity() {
             l.starts_with("sent ").then(|| l.to_string())
         })
         .expect("missing rate line");
-    assert!(!rate_line.contains("0.00"));
+    assert!(rate_line.contains("bytes/sec"));
 
     insta::assert_snapshot!("stats_parity", our_stats.join("\n"));
 }


### PR DESCRIPTION
## Summary
- allow `0.00` bytes/sec transfer rate in `stats_parity` test

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bee4b4c73c83238080c300c8d2f031