### PR TITLE
Add repo-relative path headers to comment-linted files

### DIFF
--- a/crates/meta/src/types.rs
+++ b/crates/meta/src/types.rs
@@ -1,3 +1,4 @@
+// crates/meta/src/types.rs
 use filetime::FileTime;
 #[cfg(all(unix, feature = "acl"))]
 use posix_acl::ACLEntry;

--- a/crates/meta/tests/apply.rs
+++ b/crates/meta/tests/apply.rs
@@ -1,3 +1,4 @@
+// crates/meta/tests/apply.rs
 use filetime::FileTime;
 use meta::{Metadata, Options};
 use std::fs;

--- a/crates/protocol/src/frames.rs
+++ b/crates/protocol/src/frames.rs
@@ -1,3 +1,4 @@
+// crates/protocol/src/frames.rs
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::io::{self, Read, Write};
 

--- a/crates/protocol/src/handshake.rs
+++ b/crates/protocol/src/handshake.rs
@@ -1,3 +1,4 @@
+// crates/protocol/src/handshake.rs
 use std::fmt;
 use std::io;
 

--- a/crates/protocol/src/types.rs
+++ b/crates/protocol/src/types.rs
@@ -1,3 +1,4 @@
+// crates/protocol/src/types.rs
 use byteorder::{BigEndian, ReadBytesExt};
 use encoding_rs::Encoding;
 use filelist::{Decoder as FlistDecoder, Encoder as FlistEncoder, Entry as FlistEntry};

--- a/crates/protocol/src/versions.rs
+++ b/crates/protocol/src/versions.rs
@@ -1,3 +1,4 @@
+// crates/protocol/src/versions.rs
 pub const V32: u32 = 32;
 pub const V31: u32 = 31;
 pub const V30: u32 = 30;

--- a/crates/transport/tests/config.rs
+++ b/crates/transport/tests/config.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/config.rs
 use std::time::Duration;
 
 use transport::TransportConfig;

--- a/crates/transport/tests/factory.rs
+++ b/crates/transport/tests/factory.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/factory.rs
 use std::env;
 use std::io;
 

--- a/crates/transport/tests/raii_cleanup.rs
+++ b/crates/transport/tests/raii_cleanup.rs
@@ -1,3 +1,4 @@
+// crates/transport/tests/raii_cleanup.rs
 use std::fs;
 use tempfile::tempdir;
 use transport::{TempFileGuard, TempSocketGuard};


### PR DESCRIPTION
## Summary
- add repo-relative header comments to files flagged by comment_lint
- keep remaining code free of `//` comments

## Testing
- `cargo fmt --all`
- `bash tools/comment_lint.sh`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf64463a188323b387ab7597b98463