### PR TITLE
cli: enforce old-dirs exclusions

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -120,6 +120,7 @@ fn run_single(
     }
     if opts.old_dirs {
         opts.dirs = true;
+        opts.recursive = true;
     }
     if !opts.files_from.is_empty() {
         opts.dirs = true;
@@ -693,6 +694,13 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
                 .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
         );
         add_rules(usize::MAX, cvs);
+    }
+    if opts.old_dirs {
+        add_rules(
+            usize::MAX,
+            parse_filters("- /*/*", opts.from0)
+                .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
+        );
     }
 
     entries.sort_by(|a, b| {


### PR DESCRIPTION
## Summary
- ensure `--old-dirs` sets recursive mode
- add exclusion rule matching legacy `--old-dirs`

## Testing
- `make lint`
- `make verify-comments` *(fails: crates/filters/tests/posix_classes_golden.rs: additional comments)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: /usr/bin/ld: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: /usr/bin/ld: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc679cda08323946f59169feb959f