### PR TITLE
chore: pin upstream rsync for interop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,12 +140,17 @@ jobs:
           mkdir -p target/debug
           cp target/release/oc-rsync target/debug/oc-rsync
 
-      - name: Build upstream rsync 3.4.1
-        run: echo "UPSTREAM_RSYNC=$(tests/interop/build_upstream.sh)" >> $GITHUB_ENV
+      - name: Fetch upstream rsync 3.4.1
+        run: |
+          mkdir -p target/upstream
+          pushd target/upstream >/dev/null
+          ../../scripts/fetch-rsync.sh
+          echo "RSYNC_BIN=$(pwd)/rsync-3.4.1/rsync" >> $GITHUB_ENV
+          popd >/dev/null
 
       - name: Collect interop snapshots
         env:
-          UPSTREAM_RSYNC: ${{ env.UPSTREAM_RSYNC }}
+          RSYNC_BIN: ${{ env.RSYNC_BIN }}
         run: scripts/interop/run.sh
 
       - name: Install cargo-nextest

--- a/tests/interop/README.md
+++ b/tests/interop/README.md
@@ -19,14 +19,15 @@ filesystem trees for interoperability tests.
   verify their SHA256 checksums before extraction.
 
 The committed goldens were recorded in a controlled environment using upstream
-`rsync 3.4.1` and the local `oc-rsync` build. To record fresh goldens, point
-`UPSTREAM_RSYNC` at a built `rsync` binary and limit the scenarios to `base`:
+`rsync 3.4.1` and the local `oc-rsync` build.  The `scripts/fetch-rsync.sh`
+helper downloads and verifies this release.  To record fresh goldens, point
+`RSYNC_BIN` at a built `rsync` binary and limit the scenarios to `base`:
 
 ```
 SCENARIOS=base UPDATE=1 \
   CLIENT_VERSIONS="upstream oc-rsync" \
   SERVER_VERSIONS="upstream oc-rsync" \
-  UPSTREAM_RSYNC=/path/to/rsync scripts/interop.sh
+  RSYNC_BIN=/path/to/rsync scripts/interop.sh
 ```
 - `interop-grid.log` is produced by `scripts/interop-grid.sh` and records
   stdout, stderr, exit codes, and metadata checks for key flag combinations.


### PR DESCRIPTION
## Summary
- allow passing a pinned upstream rsync via `RSYNC_BIN`
- fetch and verify rsync 3.4.1 for CI interop tests
- document upstream rsync requirement for interop fixtures

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot compile `protocol` test)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot compile `protocol` test)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfe073e19483238f0e536cf891f331