### PR TITLE
Handle unsupported metadata features on non-Unix

### DIFF
--- a/crates/meta/src/stub.rs
+++ b/crates/meta/src/stub.rs
@@ -14,7 +14,7 @@ mod non_unix {
 
     impl HardLinks {
         pub fn register(&mut self, _id: u64, _path: &Path) -> bool {
-            unimplemented!("hard links are not supported on this platform")
+            false
         }
 
         pub fn finalize(&mut self) -> io::Result<()> {
@@ -25,8 +25,11 @@ mod non_unix {
         }
     }
 
-    pub fn hard_link_id(_dev: u64, _ino: u64) -> u64 {
-        unimplemented!("hard links are not supported on this platform")
+    pub fn hard_link_id(_dev: u64, _ino: u64) -> io::Result<u64> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "hard links are not supported on this platform",
+        ))
     }
 
     pub fn read_acl(_path: &Path, _fake_super: bool) -> io::Result<(Vec<()>, Vec<()>)> {
@@ -49,8 +52,11 @@ mod non_unix {
         ))
     }
 
-    pub fn store_fake_super(_path: &Path, _uid: u32, _gid: u32, _mode: u32) {
-        unimplemented!("fake super is not supported on this platform")
+    pub fn store_fake_super(_path: &Path, _uid: u32, _gid: u32, _mode: u32) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "fake super is not supported on this platform",
+        ))
     }
 
     impl Metadata {

--- a/crates/meta/tests/non_unix_stub.rs
+++ b/crates/meta/tests/non_unix_stub.rs
@@ -2,7 +2,6 @@
 #![cfg(all(not(unix), not(target_os = "windows")))]
 
 use std::io::ErrorKind;
-use std::panic::catch_unwind;
 use std::path::Path;
 
 use filetime::FileTime;
@@ -32,11 +31,13 @@ fn metadata_apply_is_unsupported() {
 }
 
 #[test]
-fn hard_link_operations_panic() {
+fn hard_link_operations_are_unsupported() {
     let mut hl = HardLinks::default();
-    assert!(catch_unwind(|| hl.register(1, Path::new("foo"))).is_err());
-    assert!(catch_unwind(|| hard_link_id(0, 0)).is_err());
-    assert!(catch_unwind(|| store_fake_super(Path::new("foo"), 0, 0, 0)).is_err());
+    assert!(!hl.register(1, Path::new("foo")));
+    let err = hard_link_id(0, 0).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Unsupported);
+    let err = store_fake_super(Path::new("foo"), 0, 0, 0).unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Unsupported);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Return `false` or `io::ErrorKind::Unsupported` instead of panicking in non-Unix metadata stubs
- Add tests ensuring stubbed metadata APIs report `Unsupported` rather than panic

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` (fails: `cannot find -lacl`)
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` (fails: `cannot find -lacl`)


------
https://chatgpt.com/codex/tasks/task_e_68bfe0670f688323bfe2ff1f0d838c77