### PR TITLE
Use mutable cursor for Frame::decode in protocol tests

### DIFF
--- a/crates/protocol/tests/protocol.rs
+++ b/crates/protocol/tests/protocol.rs
@@ -12,7 +12,8 @@ fn frame_roundtrip() {
     let frame = msg.to_frame(5, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded, frame);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -21,7 +22,8 @@ fn frame_roundtrip() {
     let frame4 = msg4.to_frame(3, None);
     let mut buf4 = Vec::new();
     frame4.encode(&mut buf4).unwrap();
-    let decoded4 = Frame::decode(&buf4[..]).unwrap();
+    let mut cursor = &buf4[..];
+    let decoded4 = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded4, frame4);
     let msg4_round = Message::from_frame(decoded4, None).unwrap();
     assert_eq!(msg4_round, msg4);
@@ -35,7 +37,8 @@ fn keepalive_roundtrip() {
     assert_eq!(frame.header.msg, Msg::KeepAlive);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded, frame);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, Message::KeepAlive);
@@ -83,7 +86,8 @@ fn captured_frames_roundtrip() {
     }
     .encode(&mut expected)
     .unwrap();
-    let frame = Frame::decode(&expected[..]).unwrap();
+    let mut cursor = &expected[..];
+    let frame = Frame::decode(&mut cursor).unwrap();
     assert_eq!(frame.header.msg, Msg::FileListEntry);
     let msg = Message::from_frame(frame.clone(), None).unwrap();
     assert_eq!(msg, Message::FileListEntry(payload.clone()));
@@ -99,7 +103,8 @@ fn captured_frames_roundtrip() {
     const ATTRS: [u8; 16] = [
         0, 0, 0, 244, 0, 0, 0, 8, b'm', b'o', b'd', b'e', b'=', b'7', b'5', b'5',
     ];
-    let frame = Frame::decode(&ATTRS[..]).unwrap();
+    let mut cursor = &ATTRS[..];
+    let frame = Frame::decode(&mut cursor).unwrap();
     assert_eq!(frame.header.msg, Msg::Attributes);
     let msg = Message::from_frame(frame.clone(), None).unwrap();
     assert_eq!(msg, Message::Attributes(b"mode=755".to_vec()));
@@ -111,7 +116,8 @@ fn captured_frames_roundtrip() {
     assert_eq!(buf, ATTRS);
 
     const ERR: [u8; 12] = [0, 0, 0, 3, 0, 0, 0, 4, b'o', b'o', b'p', b's'];
-    let frame = Frame::decode(&ERR[..]).unwrap();
+    let mut cursor = &ERR[..];
+    let frame = Frame::decode(&mut cursor).unwrap();
     assert_eq!(frame.header.msg, Msg::Error);
     let msg = Message::from_frame(frame.clone(), None).unwrap();
     assert_eq!(msg, Message::Error("oops".to_string()));
@@ -123,7 +129,8 @@ fn captured_frames_roundtrip() {
     assert_eq!(buf, ERR);
 
     const PROG: [u8; 16] = [0, 0, 0, 245, 0, 0, 0, 8, 0, 0, 0, 0, 0, 0, 0x30, 0x39];
-    let frame = Frame::decode(&PROG[..]).unwrap();
+    let mut cursor = &PROG[..];
+    let frame = Frame::decode(&mut cursor).unwrap();
     assert_eq!(frame.header.msg, Msg::Progress);
     let msg = Message::from_frame(frame.clone(), None).unwrap();
     assert_eq!(msg, Message::Progress(0x3039));
@@ -137,7 +144,8 @@ fn captured_frames_roundtrip() {
     const XATTRS: [u8; 14] = [
         0, 0, 0, 0xF7, 0, 0, 0, 6, b'u', b's', b'e', b'r', b'=', b'1',
     ];
-    let frame = Frame::decode(&XATTRS[..]).unwrap();
+    let mut cursor = &XATTRS[..];
+    let frame = Frame::decode(&mut cursor).unwrap();
     assert_eq!(frame.header.msg, Msg::Xattrs);
     let msg = Message::from_frame(frame.clone(), None).unwrap();
     assert_eq!(msg, Message::Xattrs(b"user=1".to_vec()));
@@ -155,7 +163,8 @@ fn extra_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::Codecs);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -164,7 +173,8 @@ fn extra_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::Redo);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -173,7 +183,8 @@ fn extra_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::Stats);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -182,7 +193,8 @@ fn extra_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::Success);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -191,7 +203,8 @@ fn extra_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::Deleted);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -200,7 +213,8 @@ fn extra_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::NoSend);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -209,7 +223,8 @@ fn extra_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::ErrorExit);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -255,7 +270,8 @@ fn log_messages_roundtrip() {
         let frame = msg.to_frame(0, None);
         let mut buf = Vec::new();
         frame.encode(&mut buf).unwrap();
-        let decoded = Frame::decode(&buf[..]).unwrap();
+        let mut cursor = &buf[..];
+        let decoded = Frame::decode(&mut cursor).unwrap();
         assert_eq!(decoded.header.msg, code);
         let round = Message::from_frame(decoded, None).unwrap();
         assert_eq!(round, msg);
@@ -265,7 +281,8 @@ fn log_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::IoError);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -274,7 +291,8 @@ fn log_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::IoTimeout);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);
@@ -283,7 +301,8 @@ fn log_messages_roundtrip() {
     let frame = msg.to_frame(0, None);
     let mut buf = Vec::new();
     frame.encode(&mut buf).unwrap();
-    let decoded = Frame::decode(&buf[..]).unwrap();
+    let mut cursor = &buf[..];
+    let decoded = Frame::decode(&mut cursor).unwrap();
     assert_eq!(decoded.header.msg, Msg::Noop);
     let msg2 = Message::from_frame(decoded, None).unwrap();
     assert_eq!(msg2, msg);


### PR DESCRIPTION
## Summary
- refactor protocol tests to decode using a mutable cursor instead of passing a slice directly

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfe692af388323b0c1034652c24d63