### PR TITLE
Remove unused test imports

### DIFF
--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -696,13 +696,11 @@ pub fn load_config(path: Option<&Path>) -> io::Result<DaemonConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use std::io;
     use std::time::Duration;
     use tempfile::tempdir;
 
     #[cfg(unix)]
-    use std::os::unix::fs::{PermissionsExt, symlink};
+    use std::os::unix::fs::symlink;
 
     #[test]
     fn parse_config_invalid_port() {

--- a/crates/walk/tests/walk.rs
+++ b/crates/walk/tests/walk.rs
@@ -171,7 +171,6 @@ fn walk_skips_ignored_paths() {
 #[cfg(unix)]
 #[test]
 fn walk_handles_symlink_loops() {
-    use std::path::PathBuf;
     let tmp = tempdir().unwrap();
     let root = tmp.path();
     fs::create_dir(root.join("a")).unwrap();


### PR DESCRIPTION
## Summary
- drop unused fs, io, and PermissionsExt imports in daemon config tests
- fix unused PathBuf import in walk tests

## Testing
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: mismatched types in protocol tests)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: could not find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: could not find -lacl)*
- `make verify-comments`
- `make lint` *(fails: `tests/util/mod.rs` formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe69f98a08323b9bf7cff588a1120