### PR TITLE
chore: simplify comment lint invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,8 @@ RSYNC_UPSTREAM_VER ?= $(UPSTREAM)
 OFFICIAL_BUILD     ?= $(OFFICIAL)
 BUILD_REVISION     ?= $(shell git rev-parse --short=12 HEAD)
 
-VERIFY_COMMENT_FILES := $(shell git ls-files '*.rs')
-
 verify-comments:
-	@bash tools/comment_lint.sh $(VERIFY_COMMENT_FILES)
+	@bash tools/comment_lint.sh
 
 lint:
 	cargo fmt --all --check

--- a/tools/comment_lint.sh
+++ b/tools/comment_lint.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ $# -eq 0 ]; then
-    readarray -d '' -t files < <(git ls-files -z '*.rs')
-else
-    files=("$@")
-fi
+readarray -d '' -t files < <(git ls-files -z '*.rs')
 cargo run --quiet -p xtask --bin comment_lint -- "${files[@]}"


### PR DESCRIPTION
## Summary
- simplify verify-comments target to let script discover Rust files
- streamline comment linter to use git ls-files internally

## Testing
- `make lint` *(fails: formatting differences in tests/util/mod.rs)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: linker cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: linker cannot find -lacl)*
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68c00457da5083239d95c6a92b9dad8d