### PR TITLE
refactor: gate xattrs field

### DIFF
--- a/crates/meta/src/types.rs
+++ b/crates/meta/src/types.rs
@@ -3,7 +3,9 @@ use filetime::FileTime;
 #[cfg(all(unix, feature = "acl"))]
 use posix_acl::ACLEntry;
 #[cfg(unix)]
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
+#[cfg(all(unix, feature = "xattr"))]
+use std::ffi::OsString;
 use std::fmt;
 #[cfg(unix)]
 use std::rc::Rc;
@@ -111,7 +113,7 @@ pub struct Metadata {
     pub mtime: FileTime,
     pub atime: Option<FileTime>,
     pub crtime: Option<FileTime>,
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "xattr"))]
     pub xattrs: Vec<(OsString, Vec<u8>)>,
     #[cfg(all(unix, feature = "acl"))]
     pub acl: Vec<ACLEntry>,

--- a/crates/meta/src/unix/mod.rs
+++ b/crates/meta/src/unix/mod.rs
@@ -141,6 +141,7 @@ impl Metadata {
             (uid, gid, mode)
         };
 
+        #[cfg(feature = "xattr")]
         let xattrs = if opts.xattrs || opts.fake_super {
             let mut attrs = Vec::new();
             match xattr::list(path) {
@@ -199,6 +200,7 @@ impl Metadata {
             mtime,
             atime,
             crtime,
+            #[cfg(feature = "xattr")]
             xattrs,
             acl,
             default_acl,
@@ -419,6 +421,7 @@ impl Metadata {
             }
         }
 
+        #[cfg(feature = "xattr")]
         if opts.xattrs || opts.fake_super {
             crate::apply_xattrs(
                 path,
@@ -967,6 +970,7 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
+    #[cfg(feature = "xattr")]
     #[test]
     fn missing_xattr_between_list_and_get() -> io::Result<()> {
         let dir = tempdir()?;

--- a/crates/meta/src/windows/mod.rs
+++ b/crates/meta/src/windows/mod.rs
@@ -31,8 +31,6 @@ impl Metadata {
             mtime,
             atime,
             crtime,
-            #[cfg(feature = "xattr")]
-            xattrs: Vec::new(),
             #[cfg(feature = "acl")]
             acl: Vec::new(),
             #[cfg(feature = "acl")]

--- a/crates/meta/tests/apply.rs
+++ b/crates/meta/tests/apply.rs
@@ -4,12 +4,12 @@ use meta::{Metadata, Options};
 use std::fs;
 use tempfile::tempdir;
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "xattr"))]
 use nix::unistd::{getgid, getuid};
-#[cfg(unix)]
+#[cfg(all(unix, feature = "xattr"))]
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn apply_permissions_and_ownership() -> std::io::Result<()> {
     let dir = tempdir()?;
@@ -24,7 +24,6 @@ fn apply_permissions_and_ownership() -> std::io::Result<()> {
         mtime: FileTime::from_unix_time(0, 0),
         atime: None,
         crtime: None,
-        #[cfg(feature = "xattr")]
         xattrs: Vec::new(),
         #[cfg(feature = "acl")]
         acl: Vec::new(),
@@ -60,8 +59,6 @@ fn apply_permissions_and_ownership() -> std::io::Result<()> {
         mtime: FileTime::from_unix_time(0, 0),
         atime: None,
         crtime: None,
-        #[cfg(feature = "xattr")]
-        xattrs: Vec::new(),
         #[cfg(feature = "acl")]
         acl: Vec::new(),
         #[cfg(feature = "acl")]


### PR DESCRIPTION
## Summary
- remove conditional xattr initialization in `apply` tests and guard function with feature
- gate Metadata `xattrs` field and related Unix code behind the `xattr` feature
- drop unused xattr handling in Windows metadata implementation

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 545 passed, 191 failed, 340 not run)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted during build)*

------
https://chatgpt.com/codex/tasks/task_e_68c0044d48748323964b2515abbd4f9a