### PR TITLE
chore: auto-install cargo-nextest for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ doc:
 	cargo doc --no-deps --all-features
 
 test:
+	command -v cargo-nextest >/dev/null || cargo install cargo-nextest --locked
 	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast
 	env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly"
 


### PR DESCRIPTION
## Summary
- ensure `cargo-nextest` is installed before running tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `make test` *(fails: linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c00acc462c8323bcea4088250b8ede