### PR TITLE
daemon: reject connections without tokens

### DIFF
--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -136,12 +136,13 @@ pub fn authenticate(
         }
         Ok((Some(token_str), Vec::new(), no_motd))
     } else {
-        let token_opt = if token_str.is_empty() {
-            None
-        } else {
-            Some(token_str)
-        };
-        Ok((token_opt, Vec::new(), no_motd))
+        if token_str.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "missing token",
+            ));
+        }
+        Ok((Some(token_str), Vec::new(), no_motd))
     }
 }
 


### PR DESCRIPTION
## Summary
- return `PermissionDenied` if no auth token was supplied and no password/secrets file is configured

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run -p daemon` *(fails: no such command `nextest`)*
- `cargo test -p daemon` *(fails: unresolved import `posix_acl`)*

------
https://chatgpt.com/codex/tasks/task_e_68c00ec7618c8323949e3440ded5f746