### PR TITLE
Handle empty module name as list in daemon

### DIFF
--- a/crates/daemon/src/service.rs
+++ b/crates/daemon/src/service.rs
@@ -267,15 +267,7 @@ pub fn handle_connection(
         let mut name_buf = [0u8; 256];
         let n = transport.receive(&mut name_buf)?;
         let name = String::from_utf8_lossy(&name_buf[..n]).trim().to_string();
-        if name.is_empty() {
-            let _ = transport.send(b"@ERROR: no module specified");
-            finish_session(transport);
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "no module specified",
-            ));
-        }
-        if name == "#list" {
+        if name.is_empty() || name == "#list" {
             if !list {
                 let _ = transport.send(b"@ERROR: list denied");
             } else {

--- a/crates/daemon/tests/no_token.rs
+++ b/crates/daemon/tests/no_token.rs
@@ -3,19 +3,29 @@ use daemon::{Handler, Module, handle_connection};
 use protocol::SUPPORTED_PROTOCOLS;
 use std::collections::HashMap;
 use std::io::Cursor;
+use std::path::PathBuf;
 use std::sync::Arc;
 use transport::LocalPipeTransport;
 
 #[test]
-fn handle_connection_empty_module_name() {
+fn handle_connection_empty_module_name_lists_modules() {
     let mut input = Vec::new();
     input.extend_from_slice(&SUPPORTED_PROTOCOLS[0].to_be_bytes());
-    input.extend_from_slice(b"\n\n");
+    input.extend_from_slice(b"auth\n\n\n");
     let reader = Cursor::new(input);
     let writer = Cursor::new(Vec::new());
     let mut transport = LocalPipeTransport::new(reader, writer);
 
-    let modules: HashMap<String, Module> = HashMap::new();
+    let mut modules: HashMap<String, Module> = HashMap::new();
+    modules.insert(
+        "foo".to_string(),
+        Module {
+            name: "foo".to_string(),
+            path: PathBuf::from("."),
+            list: true,
+            ..Module::default()
+        },
+    );
     let handler: Arc<Handler> = Arc::new(|_, _| Ok(()));
 
     handle_connection(
@@ -26,7 +36,7 @@ fn handle_connection_empty_module_name() {
         None,
         None,
         None,
-        false,
+        true,
         &[],
         "127.0.0.1",
         0,
@@ -34,9 +44,9 @@ fn handle_connection_empty_module_name() {
         &handler,
         None,
     )
-    .expect("empty module name should succeed");
+    .expect("empty module name should list modules");
 
     let (_, writer) = transport.into_inner();
     let out = writer.into_inner();
-    assert_eq!(&out[4..], b"@RSYNCD: OK\n\n");
+    assert_eq!(&out[4..], b"@RSYNCD: OK\nfoo\n\n");
 }


### PR DESCRIPTION
## Summary
- treat empty module name the same as `#list`
- test that empty name returns module list
- fix sequential connection test to supply auth token

## Testing
- `make verify-comments`
- `make lint`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run -p daemon --features meta/acl`

------
https://chatgpt.com/codex/tasks/task_e_68c016d677188323841b1e3bc151d87f