### PR TITLE
Handle partial basis errors and add receiver tests

### DIFF
--- a/crates/engine/src/receiver.rs
+++ b/crates/engine/src/receiver.rs
@@ -3,7 +3,7 @@
 #[cfg(unix)]
 use nix::unistd::{Gid, Uid, chown};
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufReader, Cursor, Seek, SeekFrom};
+use std::io::{BufReader, Cursor, ErrorKind, Seek, SeekFrom};
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
@@ -119,9 +119,11 @@ impl Receiver {
         } else if (self.opts.partial || self.opts.append || self.opts.append_verify)
             && existing_partial.is_some()
         {
-            existing_partial
-                .clone()
-                .expect("existing partial path should exist when resuming transfers")
+            existing_partial.clone().ok_or_else(|| {
+                EngineError::Other(
+                    "existing partial path should exist when resuming transfers".into(),
+                )
+            })?
         } else {
             dest.clone()
         };
@@ -148,9 +150,11 @@ impl Receiver {
         } else if (self.opts.partial || self.opts.append || self.opts.append_verify)
             && existing_partial.is_some()
         {
-            existing_partial
-                .clone()
-                .expect("existing partial path should exist when resuming transfers")
+            existing_partial.clone().ok_or_else(|| {
+                EngineError::Other(
+                    "existing partial path should exist when resuming transfers".into(),
+                )
+            })?
         } else if self.opts.partial {
             partial.clone()
         } else {
@@ -329,7 +333,17 @@ impl Receiver {
             }
             Ok(op)
         });
-        apply_delta(&mut basis, ops, &mut out, &self.opts, 0, &mut progress)?;
+        if let Err(e) = apply_delta(&mut basis, ops, &mut out, &self.opts, 0, &mut progress) {
+            if let EngineError::Io(ref io) = e {
+                if io.kind() == ErrorKind::UnexpectedEof || io.kind() == ErrorKind::NotFound {
+                    return Err(EngineError::Other(format!(
+                        "basis file '{}' is missing or too short",
+                        basis_path.display(),
+                    )));
+                }
+            }
+            return Err(e);
+        }
         if let Some(mut p) = progress {
             p.finish();
         }

--- a/crates/engine/tests/receiver.rs
+++ b/crates/engine/tests/receiver.rs
@@ -1,0 +1,51 @@
+// crates/engine/tests/receiver.rs
+use engine::{Op, Receiver, SyncOptions};
+use std::fs;
+use std::path::Path;
+use tempfile::tempdir;
+
+#[test]
+#[allow(clippy::field_reassign_with_default)]
+fn apply_without_existing_partial() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src.txt");
+    let dest = tmp.path().join("dest.txt");
+    fs::write(&src, b"hello").unwrap();
+
+    let mut opts = SyncOptions::default();
+    opts.partial = true;
+    let mut recv = Receiver::new(None, opts);
+
+    let delta = vec![Ok(Op::Data(b"hello".to_vec()))];
+    recv.apply(&src, &dest, Path::new(""), delta).unwrap();
+
+    let output = fs::read(&dest).unwrap();
+    assert_eq!(output, b"hello");
+}
+
+#[test]
+#[allow(clippy::field_reassign_with_default)]
+fn apply_with_existing_partial() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src.txt");
+    let dest = tmp.path().join("dest.txt");
+    fs::write(&src, b"old!").unwrap();
+    let mut name = dest.file_name().unwrap().to_os_string();
+    name.push(".partial");
+    let partial = dest.with_file_name(name);
+    fs::write(&partial, b"old").unwrap();
+
+    let mut opts = SyncOptions::default();
+    opts.partial = true;
+    let mut recv = Receiver::new(None, opts);
+
+    let delta = vec![
+        Ok(Op::Copy { offset: 0, len: 3 }),
+        Ok(Op::Data(b"!".to_vec())),
+    ];
+    recv.apply(&src, &dest, Path::new(""), delta).unwrap();
+
+    let output = fs::read(&dest).unwrap();
+    assert_eq!(output, b"old!");
+    assert!(!partial.exists());
+}


### PR DESCRIPTION
## Summary
- return explicit error if partial basis is missing or truncated
- add error handling around delta application
- test receiver behavior with and without existing partial files

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` (fails: missing token in daemon tests and others)
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` (fails: multiple tests not executed due to interrupt)


------
https://chatgpt.com/codex/tasks/task_e_68c01823f6f08323bb1887c929e81a6f