### PR TITLE
Import ErrorKind in receiver

### DIFF
--- a/crates/engine/src/receiver.rs
+++ b/crates/engine/src/receiver.rs
@@ -3,7 +3,7 @@
 #[cfg(unix)]
 use nix::unistd::{Gid, Uid, chown};
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, BufReader, Cursor, Seek, SeekFrom};
+use std::io::{self, BufReader, Cursor, ErrorKind, Seek, SeekFrom};
 #[cfg(unix)]
 use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary
- import ErrorKind from std::io in engine receiver to fix missing import

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: linking with `cc` failed: exit status: 1)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`
- `cargo test -p engine` *(fails: linking with `cc` failed: exit status: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c0224ce12883239baa7c0b2704c885