### PR TITLE
chore: normalize comment headers

### DIFF
--- a/crates/filters/src/matcher.rs
+++ b/crates/filters/src/matcher.rs
@@ -1,4 +1,4 @@
-// crates/filters/src/matcher.rs — extracted from lib.rs to handle rule matching and caching; public API preserved via re-exports.
+// crates/filters/src/matcher.rs
 #![allow(clippy::collapsible_if)]
 
 use crate::{

--- a/crates/filters/src/perdir.rs
+++ b/crates/filters/src/perdir.rs
@@ -1,4 +1,4 @@
-// crates/filters/src/perdir.rs — extracted from lib.rs to model per-directory filter files; public API preserved via re-exports.
+// crates/filters/src/perdir.rs
 
 use crate::rule::RuleFlags;
 

--- a/crates/filters/src/rule.rs
+++ b/crates/filters/src/rule.rs
@@ -1,4 +1,4 @@
-// crates/filters/src/rule.rs — extracted from lib.rs to define filter rules and flags; public API preserved via re-exports.
+// crates/filters/src/rule.rs
 
 use globset::{GlobBuilder, GlobMatcher};
 use std::path::{Path, PathBuf};

--- a/crates/filters/src/stats.rs
+++ b/crates/filters/src/stats.rs
@@ -1,4 +1,4 @@
-// crates/filters/src/stats.rs — extracted from lib.rs to collect filter match statistics; public API preserved via re-exports.
+// crates/filters/src/stats.rs
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Summary
- standardize comment headers in filters modules

## Testing
- `make verify-comments`
- `cargo fmt --all --check` *(fails: expected import order in unrelated files)*
- `cargo clippy --all-targets -- -D warnings` *(fails: `let` expressions unstable)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: missing `-lacl` library)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: missing `-lacl` library)*

------
https://chatgpt.com/codex/tasks/task_e_68c036baef908323908b3128ed5e15b5