### PR TITLE
Fix ACL write check in engine tests

### DIFF
--- a/crates/engine/tests/tests/mod.rs
+++ b/crates/engine/tests/tests/mod.rs
@@ -91,7 +91,8 @@ pub fn requires_capability(cap: CapabilityCheck) -> bool {
                 fs::write(&file, b"hi").unwrap();
                 match PosixACL::read_acl(&file) {
                     Ok(mut acl) => {
-                        if acl.set(Qualifier::User(12345), ACL_READ).is_ok() {
+                        acl.set(Qualifier::User(12345), ACL_READ);
+                        if acl.write_acl(&file).is_ok() {
                             return true;
                         }
                         println!("Skipping test: ACLs not supported");


### PR DESCRIPTION
## Summary
- ensure ACL capability test writes ACLs to file

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`
- `cargo test -p engine` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68c03b79d5b083239517b377a08f4376