### PR TITLE
chore: update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
 name = "engine"
 version = "0.1.0"
 dependencies = [
+ "caps",
  "checksums",
  "compress",
  "criterion",
@@ -473,6 +474,7 @@ dependencies = [
  "meta",
  "nix",
  "posix-acl",
+ "proptest",
  "protocol",
  "rand 0.8.5",
  "sha1",


### PR DESCRIPTION
## Summary
- update Cargo.lock with proptest dependency

## Testing
- `cargo test` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint` *(fails: import ordering / formatting differences)*

------
https://chatgpt.com/codex/tasks/task_e_68c040c88ca0832397a26bbb54873291