### PR TITLE
lint: flag doc comments beyond first line

### DIFF
--- a/xtask/src/bin/comment_lint.rs
+++ b/xtask/src/bin/comment_lint.rs
@@ -27,26 +27,27 @@ fn check_file(path: &Path, root: &Path) -> bool {
         }
     }
     let mut pos = 0;
-    let mut first_line = true;
+    let mut line = 1;
     for token in tokenize(&content) {
         let text = &content[pos..pos + token.len];
         if matches!(
             token.kind,
             TokenKind::LineComment | TokenKind::BlockComment { .. }
         ) {
-            if first_line {
+            if line == 1 {
                 if text.starts_with("///") {
-                    eprintln!("{}: doc comment", rel_str);
+                    eprintln!("{}:{}: doc comment", rel_str, line);
                     return false;
                 }
-            } else if !text.starts_with("///") {
-                eprintln!("{}: additional comments", rel_str);
+            } else if text.starts_with("///") {
+                eprintln!("{}:{}: doc comment", rel_str, line);
+                return false;
+            } else {
+                eprintln!("{}:{}: additional comments", rel_str, line);
                 return false;
             }
         }
-        if text.contains('\n') {
-            first_line = false;
-        }
+        line += text.matches('\n').count();
         pos += token.len;
     }
     true


### PR DESCRIPTION
## Summary
- ensure comment_lint flags `///` comments after the header and report file/line

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments` *(fails: doc comment)*
- `make lint`
- `bash tools/comment_lint.sh` *(doc comments flagged)*

------
https://chatgpt.com/codex/tasks/task_e_68c0438d56c88323a809eeec06a06fe9