### PR TITLE
chore: format codebase

### DIFF
--- a/crates/checksums/src/strong.rs
+++ b/crates/checksums/src/strong.rs
@@ -3,7 +3,7 @@
 use md4::{Digest, Md4};
 use md5::Md5;
 use sha1::Sha1;
-use xxhash_rust::xxh64::{xxh64, Xxh64};
+use xxhash_rust::xxh64::{Xxh64, xxh64};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StrongHash {

--- a/crates/cli/src/exec.rs
+++ b/crates/cli/src/exec.rs
@@ -2,18 +2,18 @@
 
 use std::path::Path;
 
-use clap::{parser::ValueSource, ArgMatches};
+use clap::{ArgMatches, parser::ValueSource};
 
 use crate::options::ClientOpts;
 use crate::session::check_session_errors;
 use crate::utils::{RemoteSpec, RshCommand};
-use crate::{spawn_daemon_session, EngineError};
+use crate::{EngineError, spawn_daemon_session};
 
 use compress::available_codecs;
-use engine::{pipe_sessions, sync, Result, Stats, SyncOptions};
+use engine::{Result, Stats, SyncOptions, pipe_sessions, sync};
 use filters::Matcher;
-use protocol::{CharsetConv, ExitCode, CAP_ACLS, CAP_CODECS, CAP_XATTRS};
-use transport::{daemon_remote_opts, AddressFamily, RateLimitedTransport, SshStdioTransport};
+use protocol::{CAP_ACLS, CAP_CODECS, CAP_XATTRS, CharsetConv, ExitCode};
+use transport::{AddressFamily, RateLimitedTransport, SshStdioTransport, daemon_remote_opts};
 
 #[cfg(unix)]
 use nix::unistd;

--- a/crates/cli/src/print.rs
+++ b/crates/cli/src/print.rs
@@ -4,7 +4,7 @@ use crate::formatter::render_help;
 use crate::options::ClientOpts;
 use crate::validate::exit_code_from_error_kind;
 use engine::Stats;
-use logging::{human_bytes, progress_formatter, rate_formatter, InfoFlag};
+use logging::{InfoFlag, human_bytes, progress_formatter, rate_formatter};
 use protocol::ExitCode;
 
 pub fn handle_clap_error(cmd: &clap::Command, e: clap::Error) -> ! {

--- a/crates/filters/tests/files_from.rs
+++ b/crates/filters/tests/files_from.rs
@@ -1,6 +1,6 @@
 // crates/filters/tests/files_from.rs
 #![allow(unused_doc_comments)]
-use filters::{parse, parse_with_options, Matcher};
+use filters::{Matcher, parse, parse_with_options};
 use std::collections::HashSet;
 use std::fs;
 use tempfile::tempdir;

--- a/tests/files_from.rs
+++ b/tests/files_from.rs
@@ -2,12 +2,12 @@
 #![allow(unused_imports)]
 
 use assert_cmd::prelude::*;
-use assert_cmd::{cargo::cargo_bin, Command};
+use assert_cmd::{Command, cargo::cargo_bin};
 use engine::SyncOptions;
-use filetime::{set_file_mtime, FileTime};
+use filetime::{FileTime, set_file_mtime};
 use logging::progress_formatter;
 #[cfg(unix)]
-use nix::unistd::{chown, mkfifo, Gid, Uid};
+use nix::unistd::{Gid, Uid, chown, mkfifo};
 use oc_rsync_cli::{parse_iconv, spawn_daemon_session};
 use predicates::prelude::PredicateBooleanExt;
 use protocol::SUPPORTED_PROTOCOLS;
@@ -21,7 +21,7 @@ use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
 use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
-use tempfile::{tempdir, tempdir_in, TempDir};
+use tempfile::{TempDir, tempdir, tempdir_in};
 #[cfg(unix)]
 use users::{get_current_gid, get_current_uid, get_group_by_gid, get_user_by_uid};
 mod common;

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -3,7 +3,7 @@
 
 use std::fs;
 use std::path::PathBuf;
-use tempfile::{tempdir, TempDir};
+use tempfile::{TempDir, tempdir};
 
 pub fn setup_files_from_env(entries: &[(&str, &[u8])]) -> (TempDir, PathBuf, PathBuf) {
     let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- run `cargo fmt` across the workspace

## Testing
- `cargo fmt --all --check`
- `cargo nextest run --workspace --no-fail-fast` *(fails: could not compile engine tests)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(timed out during build)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c04526adcc83239becb3c25b32d30b