### PR TITLE
refactor: remove nightly if-let &&

### DIFF
--- a/crates/cli/src/client.rs
+++ b/crates/cli/src/client.rs
@@ -638,16 +638,16 @@ fn build_matcher(opts: &ClientOpts, matches: &ArgMatches) -> Result<Matcher> {
             add_rules(idx + 1, rs);
         }
     }
-    if matches.contains_id("filter_shorthand")
-        && let Some(idx) = matches.index_of("filter_shorthand")
-    {
-        let count = matches.get_count("filter_shorthand");
-        let rule_str = if count >= 2 { "-FF" } else { "-F" };
-        add_rules(
-            idx + 1,
-            parse_filters(rule_str, opts.from0)
-                .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
-        );
+    if matches.contains_id("filter_shorthand") {
+        if let Some(idx) = matches.index_of("filter_shorthand") {
+            let count = matches.get_count("filter_shorthand");
+            let rule_str = if count >= 2 { "-FF" } else { "-F" };
+            add_rules(
+                idx + 1,
+                parse_filters(rule_str, opts.from0)
+                    .map_err(|e| EngineError::Other(format!("{:?}", e)))?,
+            );
+        }
     }
     if !opts.files_from.is_empty() {
         add_rules(

--- a/crates/cli/src/daemon.rs
+++ b/crates/cli/src/daemon.rs
@@ -86,10 +86,10 @@ pub fn spawn_daemon_session(
         .map_err(EngineError::from)?;
     t.set_write_timeout(handshake_timeout)
         .map_err(EngineError::from)?;
-    if let Some(p) = early_input
-        && let Ok(data) = fs::read(p)
-    {
-        t.send(&data).map_err(EngineError::from)?;
+    if let Some(p) = early_input {
+        if let Ok(data) = fs::read(p) {
+            t.send(&data).map_err(EngineError::from)?;
+        }
     }
     t.send(&version.to_be_bytes()).map_err(EngineError::from)?;
     let mut buf = [0u8; 4];

--- a/crates/transport/src/config.rs
+++ b/crates/transport/src/config.rs
@@ -68,14 +68,10 @@ impl TransportConfigBuilder {
     }
 
     pub fn build(self) -> Result<TransportConfig> {
-        if let Some(t) = self.timeout
-            && t.is_zero()
-        {
+        if self.timeout.is_some_and(|t| t.is_zero()) {
             return Err(TransportConfigError("timeout must be nonzero"));
         }
-        if let Some(rl) = self.rate_limit
-            && rl == 0
-        {
+        if self.rate_limit.is_some_and(|rl| rl == 0) {
             return Err(TransportConfigError("rate limit must be nonzero"));
         }
         Ok(TransportConfig {

--- a/crates/transport/src/stdio.rs
+++ b/crates/transport/src/stdio.rs
@@ -70,9 +70,7 @@ impl<T: Transport> TimeoutTransport<T> {
     }
 
     fn check_timeout(&self) -> io::Result<()> {
-        if let Some(dur) = self.timeout
-            && self.last.elapsed() >= dur
-        {
+        if self.timeout.is_some_and(|dur| self.last.elapsed() >= dur) {
             return Err(io::Error::new(
                 io::ErrorKind::TimedOut,
                 "connection timed out",

--- a/src/bin/oc-rsync/main.rs
+++ b/src/bin/oc-rsync/main.rs
@@ -18,11 +18,11 @@ fn main() {
         print!("{}", oc_rsync_cli::dump_help_body(&cmd));
         return;
     }
-    if let Some(mode) = matches.get_one::<OutBuf>("outbuf")
-        && let Err(err) = stdio::set_std_buffering(*mode)
-    {
-        eprintln!("failed to set stdio buffers: {err}");
-        std::process::exit(u8::from(ExitCode::FileIo) as i32);
+    if let Some(mode) = matches.get_one::<OutBuf>("outbuf") {
+        if let Err(err) = stdio::set_std_buffering(*mode) {
+            eprintln!("failed to set stdio buffers: {err}");
+            std::process::exit(u8::from(ExitCode::FileIo) as i32);
+        }
     }
     if let Err(e) = oc_rsync_cli::run(&matches) {
         eprintln!("{e}");

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -176,8 +176,10 @@ fn daemon_preserves_xattrs() {
             Err(e) => panic!("get security.test: {e}"),
         }
     }
-    if keep_ok && let Ok(Some(keep)) = xattr::get(srv.join("file"), "security.keep") {
-        assert_eq!(&keep[..], b"dest");
+    if keep_ok {
+        if let Ok(Some(keep)) = xattr::get(srv.join("file"), "security.keep") {
+            assert_eq!(&keep[..], b"dest");
+        }
     }
 
     let _ = child.kill();
@@ -265,8 +267,10 @@ fn daemon_preserves_xattrs_rr_client() {
             Err(e) => panic!("get security.test: {e}"),
         }
     }
-    if keep_ok && let Ok(Some(keep)) = xattr::get(srv.join("file"), "security.keep") {
-        assert_eq!(&keep[..], b"dest");
+    if keep_ok {
+        if let Ok(Some(keep)) = xattr::get(srv.join("file"), "security.keep") {
+            assert_eq!(&keep[..], b"dest");
+        }
     }
 
     let _ = child.kill();
@@ -318,8 +322,10 @@ fn daemon_preserves_xattrs_rr_daemon() {
             Err(e) => panic!("get security.test: {e}"),
         }
     }
-    if keep_ok && let Ok(Some(keep)) = xattr::get(srv.join("file"), "security.keep") {
-        assert_eq!(&keep[..], b"dest");
+    if keep_ok {
+        if let Ok(Some(keep)) = xattr::get(srv.join("file"), "security.keep") {
+            assert_eq!(&keep[..], b"dest");
+        }
     }
 
     let _ = child.kill();

--- a/tools/flag_matrix.rs
+++ b/tools/flag_matrix.rs
@@ -52,10 +52,10 @@ fn parse_help(
             .filter(|t| t.starts_with("--"))
             .max_by_key(|t| t.len())
             .cloned();
-        if desc.contains("alias for")
-            && let Some(idx) = desc.find("--")
-        {
-            canonical = Some(clean_flag(&desc[idx..]));
+        if desc.contains("alias for") {
+            if let Some(idx) = desc.find("--") {
+                canonical = Some(clean_flag(&desc[idx..]));
+            }
         }
         let Some(canonical) = canonical else {
             continue;


### PR DESCRIPTION
## Summary
- avoid unstable `if let` with `&&` by nesting conditions
- adjust config builders for stable `Option::is_some_and`
- update tests and utilities accordingly

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(failed: receiver::tests::apply_with_existing_partial etc.)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68c05337f3a0832391ef885f99859df7