### PR TITLE
Validate host in rsync transport URIs

### DIFF
--- a/crates/transport/src/factory.rs
+++ b/crates/transport/src/factory.rs
@@ -55,7 +55,12 @@ impl TransportFactory {
                     return Err(io::Error::new(io::ErrorKind::InvalidInput, "missing host"));
                 }
                 let mut parts = host_port.split(':');
-                let host = parts.next().unwrap();
+                let host = parts
+                    .next()
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "missing host"))?;
+                if host.is_empty() {
+                    return Err(io::Error::new(io::ErrorKind::InvalidInput, "missing host"));
+                }
                 let port = parts.next().and_then(|p| p.parse().ok()).unwrap_or(873);
                 let transport = TcpTransport::connect(host, port, None, None)?;
                 Ok(Box::new(transport))

--- a/crates/transport/tests/factory.rs
+++ b/crates/transport/tests/factory.rs
@@ -25,3 +25,13 @@ fn ssh_spawn_failure() {
     };
     assert_eq!(err.kind(), io::ErrorKind::NotFound);
 }
+
+#[test]
+fn rsync_missing_host() {
+    for uri in ["rsync://", "rsync://:873"] {
+        let err = TransportFactory::from_uri(uri)
+            .err()
+            .expect("expected error");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure `rsync://` URIs include a host and produce `InvalidInput` otherwise
- add regression test for malformed `rsync://` URIs

## Testing
- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p transport` *(fails: unresolved import `posix_acl` in `meta` crate)*

------
https://chatgpt.com/codex/tasks/task_e_68c0573bae00832392830a0ae8b94fdf