### PR TITLE
ci: regex README version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Verify README version string
         run: |
-          grep -Fq 'rsync 3.4.1 (protocol 32)' README.md
+          grep -E 'rsync[[:space:]]+3\.4\.1.*protocol[[:space:]]+32' README.md
 
   lint:
     needs: [readme-version]


### PR DESCRIPTION
## Summary
- use regex for README version check in ci

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0566d3e148323b78eba4b0663ae88