### PR TITLE
ci: upload coverage artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,13 @@ jobs:
         if: steps.install_nextest.outcome == 'success' && steps.install_llvm_cov.outcome == 'success'
         run: ls -l coverage.lcov
 
+      - name: Upload coverage artifact
+        if: steps.install_nextest.outcome == 'success' && steps.install_llvm_cov.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage.lcov
+
 
   interop:
     needs: test-linux


### PR DESCRIPTION
## Summary
- upload coverage.lcov as artifact in test-linux workflow

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: tests interrupted; 87 failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(terminated after starting compilation)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05d5a72488323a46461f9721d954e