### PR TITLE
Print daemon bound port

### DIFF
--- a/crates/daemon/src/service.rs
+++ b/crates/daemon/src/service.rs
@@ -555,7 +555,9 @@ pub fn run_daemon(
         }
     }
 
-    let (listener, _port) = TcpTransport::listen(address, port, family)?;
+    let (listener, port) = TcpTransport::listen(address, port, family)?;
+    let _ = writeln!(io::stdout(), "{port}");
+    let _ = io::stdout().flush();
     #[cfg(unix)]
     let _ = sd_notify::notify(false, &[NotifyState::Ready]);
 

--- a/src/bin/oc-rsync/main.rs
+++ b/src/bin/oc-rsync/main.rs
@@ -23,6 +23,11 @@ fn main() {
             eprintln!("failed to set stdio buffers: {err}");
             std::process::exit(u8::from(ExitCode::FileIo) as i32);
         }
+    } else if matches.get_flag("daemon") {
+        if let Err(err) = stdio::set_std_buffering(OutBuf::L) {
+            eprintln!("failed to set stdio buffers: {err}");
+            std::process::exit(u8::from(ExitCode::FileIo) as i32);
+        }
     }
     if let Err(e) = oc_rsync_cli::run(&matches) {
         eprintln!("{e}");


### PR DESCRIPTION
## Summary
- Ensure the daemon prints its runtime port once the listener is active
- Default stdout to line buffering in daemon mode for prompt port output

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68c0686b0dd48323a94469376ebcc522