### PR TITLE
Ensure newline-terminated JSON logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,10 +851,12 @@ name = "logging"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "serde",
  "serde_json",
  "tempfile",
  "time",
  "tracing",
+ "tracing-serde",
  "tracing-subscriber",
 ]
 

--- a/crates/logging/Cargo.toml
+++ b/crates/logging/Cargo.toml
@@ -8,10 +8,12 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 clap = { version = "4.5.47", features = ["derive"] }
 time = { version = "0.3", features = ["macros", "formatting", "local-offset"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing-serde = "0.2"
 
 [dev-dependencies]
 tempfile = "3"
-serde_json = "1"
 
 [features]
 default = ["syslog", "journald"]

--- a/crates/logging/src/json_format.rs
+++ b/crates/logging/src/json_format.rs
@@ -1,0 +1,49 @@
+// crates/logging/src/json_format.rs
+#![allow(missing_docs)]
+
+use serde_json::{Map, Value};
+use time::OffsetDateTime;
+use tracing::{Event, Subscriber};
+use tracing_serde::{AsSerde, fields::AsMap};
+use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, format::Writer};
+use tracing_subscriber::registry::LookupSpan;
+
+/// Formats tracing events as newline-delimited JSON objects.
+#[derive(Default)]
+pub struct JsonFormatter;
+
+impl<S, N> FormatEvent<S, N> for JsonFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        _ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let mut obj = Map::new();
+        let timestamp = OffsetDateTime::now_utc()
+            .format(&time::macros::format_description!(
+                "[year]-[month]-[day]T[hour]:[minute]:[second]Z"
+            ))
+            .map_err(|_| std::fmt::Error)?;
+        obj.insert("timestamp".into(), Value::String(timestamp));
+        obj.insert(
+            "level".into(),
+            serde_json::to_value(event.metadata().level().as_serde())
+                .map_err(|_| std::fmt::Error)?,
+        );
+        obj.insert(
+            "target".into(),
+            Value::String(event.metadata().target().to_string()),
+        );
+        let fields = serde_json::to_value(event.field_map()).map_err(|_| std::fmt::Error)?;
+        obj.insert("fields".into(), fields);
+        let json = Value::Object(obj);
+        let data = serde_json::to_string(&json).map_err(|_| std::fmt::Error)?;
+        writer.write_str(&data)?;
+        writer.write_char('\n')
+    }
+}

--- a/crates/logging/src/lib.rs
+++ b/crates/logging/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod flags;
 mod formatter;
+mod json_format;
 mod sink;
 mod subscriber;
 mod util;

--- a/crates/logging/src/subscriber.rs
+++ b/crates/logging/src/subscriber.rs
@@ -3,6 +3,7 @@
 
 use crate::flags::{LogFormat, SubscriberConfig};
 use crate::formatter::RsyncFormatter;
+use crate::json_format::JsonFormatter;
 use crate::sink::{FileWriter, LogWriter};
 use std::fmt;
 use std::fs::OpenOptions;
@@ -213,13 +214,13 @@ pub fn subscriber(cfg: SubscriberConfig) -> io::Result<Box<dyn tracing::Subscrib
     let base = if colored { base } else { base.with_ansi(false) };
     let fmt_layer = if timestamps {
         match format {
-            LogFormat::Json => base.json().boxed(),
+            LogFormat::Json => base.event_format(JsonFormatter).boxed(),
             LogFormat::Text => base.event_format(RsyncFormatter::new(None)).boxed(),
         }
     } else {
         let base = base.without_time();
         match format {
-            LogFormat::Json => base.json().boxed(),
+            LogFormat::Json => base.event_format(JsonFormatter).boxed(),
             LogFormat::Text => base.event_format(RsyncFormatter::new(None)).boxed(),
         }
     };
@@ -268,7 +269,7 @@ pub fn subscriber(cfg: SubscriberConfig) -> io::Result<Box<dyn tracing::Subscrib
             .with_writer(FileWriter { file })
             .with_ansi(false);
         let layer = match fmt.as_deref() {
-            Some("json") => base.json().boxed(),
+            Some("json") => base.event_format(JsonFormatter).boxed(),
             Some(spec) => base
                 .event_format(RsyncFormatter::new(Some(spec.to_string())))
                 .boxed(),


### PR DESCRIPTION
## Summary
- add custom JSON formatter that writes newline-delimited objects
- use JsonFormatter for file and stderr logging
- stream parse JSON log test

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c06d1aead083239eeb04fc8bdf25fd