### PR TITLE
Handle unsupported xattrs gracefully

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -19,6 +19,7 @@ pub mod block;
 pub mod flist;
 pub mod io;
 pub mod session;
+pub mod xattrs;
 
 pub use batch::{Batch, decode_batch, encode_batch};
 pub use block::block_size;

--- a/crates/engine/src/xattrs.rs
+++ b/crates/engine/src/xattrs.rs
@@ -1,0 +1,58 @@
+use crate::{EngineError, Result};
+
+/// Ensure that extended attributes are supported at runtime.
+///
+/// Returns `Ok(())` when xattrs are available.  When the feature is
+/// disabled at compile time or the filesystem does not support xattrs,
+/// a descriptive `EngineError` is returned instead of panicking.
+pub fn ensure_supported() -> Result<()> {
+    #[cfg(feature = "xattr")]
+    {
+        if meta::xattrs_supported() {
+            Ok(())
+        } else {
+            Err(EngineError::Other(
+                "filesystem does not support extended attributes".into(),
+            ))
+        }
+    }
+    #[cfg(not(feature = "xattr"))]
+    {
+        Err(EngineError::Other(
+            "binary was built without xattr support".into(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "xattr")]
+    #[test]
+    fn supported_fs_returns_ok() {
+        if meta::xattrs_supported() {
+            ensure_supported().unwrap();
+        } else {
+            // Skip when the underlying filesystem lacks xattr support.
+            println!("skipping: xattrs unsupported");
+        }
+    }
+
+    #[cfg(feature = "xattr")]
+    #[test]
+    fn unsupported_fs_returns_err() {
+        if meta::xattrs_supported() {
+            // Skip because the filesystem actually supports xattrs.
+            println!("skipping: xattrs supported");
+        } else {
+            assert!(ensure_supported().is_err());
+        }
+    }
+
+    #[cfg(not(feature = "xattr"))]
+    #[test]
+    fn feature_disabled_returns_err() {
+        assert!(ensure_supported().is_err());
+    }
+}

--- a/crates/engine/tests/attrs.rs
+++ b/crates/engine/tests/attrs.rs
@@ -456,7 +456,8 @@ fn hard_links_roundtrip() {
 #[cfg(feature = "xattr")]
 #[test]
 fn xattrs_roundtrip() {
-    if !tests::requires_capability(tests::CapabilityCheck::Xattrs) {
+    if let Err(e) = engine::xattrs::ensure_supported() {
+        println!("Skipping test: {e}");
         return;
     }
     let tmp = tempdir().unwrap();
@@ -485,7 +486,8 @@ fn xattrs_roundtrip() {
 #[cfg(feature = "xattr")]
 #[test]
 fn symlink_xattrs_roundtrip() {
-    if !tests::requires_capability(tests::CapabilityCheck::Xattrs) {
+    if let Err(e) = engine::xattrs::ensure_supported() {
+        println!("Skipping test: {e}");
         return;
     }
     let tmp = tempdir().unwrap();
@@ -955,7 +957,8 @@ fn metadata_matches_source() {
 #[cfg(feature = "xattr")]
 #[test]
 fn fake_super_stores_xattrs() {
-    if !tests::requires_capability(tests::CapabilityCheck::Xattrs) {
+    if let Err(e) = engine::xattrs::ensure_supported() {
+        println!("Skipping test: {e}");
         return;
     }
     let tmp = tempdir().unwrap();
@@ -983,9 +986,11 @@ fn fake_super_stores_xattrs() {
 #[cfg(all(unix, feature = "xattr"))]
 #[test]
 fn super_overrides_fake_super() {
-    if !tests::requires_capability(tests::CapabilityCheck::CapChown)
-        || !tests::requires_capability(tests::CapabilityCheck::Xattrs)
-    {
+    if !tests::requires_capability(tests::CapabilityCheck::CapChown) {
+        return;
+    }
+    if let Err(e) = engine::xattrs::ensure_supported() {
+        println!("Skipping test: {e}");
         return;
     }
     let tmp = tempdir().unwrap();
@@ -1014,7 +1019,8 @@ fn super_overrides_fake_super() {
 #[cfg(feature = "xattr")]
 #[test]
 fn xattrs_roundtrip_fake_super() {
-    if !tests::requires_capability(tests::CapabilityCheck::Xattrs) {
+    if let Err(e) = engine::xattrs::ensure_supported() {
+        println!("Skipping test: {e}");
         return;
     }
     let tmp = tempdir().unwrap();


### PR DESCRIPTION
## Summary
- add runtime xattr support check returning error instead of unwrap
- skip xattr tests when filesystem lacks support

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: field `pattern` of `RuleData` is private)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: field `pattern` of `RuleData` is private)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0700c8bf08323bdf31846c4f8f40e