### PR TITLE
Enforce pinned rsync in interop script

### DIFF
--- a/crates/logging/src/json_format.rs
+++ b/crates/logging/src/json_format.rs
@@ -7,8 +7,6 @@ use tracing::{Event, Subscriber};
 use tracing_serde::{AsSerde, fields::AsMap};
 use tracing_subscriber::fmt::{FmtContext, FormatEvent, FormatFields, format::Writer};
 use tracing_subscriber::registry::LookupSpan;
-
-/// Formats tracing events as newline-delimited JSON objects.
 #[derive(Default)]
 pub struct JsonFormatter;
 

--- a/scripts/interop/run.sh
+++ b/scripts/interop/run.sh
@@ -4,18 +4,20 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 OUT_DIR="$ROOT/tests/interop/streams"
 OC_RSYNC="$ROOT/target/debug/oc-rsync"
-# Use a specific upstream rsync if provided.  If missing, attempt to download a
-# pinned release and fall back to the system binary when that fails.
+# Use a specific upstream rsync if provided. If missing, download and verify a
+# pinned release. This script requires the rsync-3.4.1 binary; it will exit if
+# the download or verification fails.
 UPSTREAM="${RSYNC_BIN:-}"
 if [[ -z "$UPSTREAM" ]]; then
   UPSTREAM_DIR="$ROOT/target/upstream"
   mkdir -p "$UPSTREAM_DIR"
   pushd "$UPSTREAM_DIR" >/dev/null
-  "$ROOT/scripts/fetch-rsync.sh" >/dev/null || true
+  "$ROOT/scripts/fetch-rsync.sh" >/dev/null
   popd >/dev/null
   UPSTREAM="$UPSTREAM_DIR/rsync-3.4.1/rsync"
   if [[ ! -x "$UPSTREAM" ]]; then
-    UPSTREAM=rsync
+    echo "Pinned upstream rsync binary not found: $UPSTREAM" >&2
+    exit 1
   fi
 fi
 FLAGS=(--archive --compress --delete)


### PR DESCRIPTION
## Summary
- require downloading the pinned rsync-3.4.1 binary instead of falling back to system rsync
- remove stray comment in `json_format.rs` to satisfy comment linter

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: field `pattern` of struct `RuleData` is private)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted: compilation in progress)*

------
https://chatgpt.com/codex/tasks/task_e_68c0750ed7608323a6c0c5aad462a987