### PR TITLE
Remove redundant comment in CVS exclude test

### DIFF
--- a/tests/cvs_exclude.rs
+++ b/tests/cvs_exclude.rs
@@ -61,7 +61,6 @@ fn cvs_exclude_parity() {
 
 #[test]
 fn cvs_exclude_nested_override() {
-    /* Regression test for duplicate :C rules with --cvs-exclude (GH-1667) */
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     fs::create_dir_all(&src).unwrap();


### PR DESCRIPTION
## Summary
- remove extraneous block comment from cvs_exclude nested override test

## Testing
- `bash tools/comment_lint.sh`
- `cargo nextest run -p oc-rsync --test comment_lint_spaces`


------
https://chatgpt.com/codex/tasks/task_e_68c08b830c788323807e52bedc93702c