### PR TITLE
Improve logging error handling

### DIFF
--- a/crates/logging/src/subscriber.rs
+++ b/crates/logging/src/subscriber.rs
@@ -196,12 +196,16 @@ pub fn subscriber(cfg: SubscriberConfig) -> io::Result<Box<dyn tracing::Subscrib
     if !quiet {
         for flag in &info {
             let directive: tracing_subscriber::filter::Directive =
-                format!("{}=info", flag.target()).parse().unwrap();
+                format!("{}=info", flag.target())
+                    .parse()
+                    .expect("valid directive");
             filter = filter.add_directive(directive);
         }
         for flag in &debug {
             let directive: tracing_subscriber::filter::Directive =
-                format!("{}=trace", flag.target()).parse().unwrap();
+                format!("{}=trace", flag.target())
+                    .parse()
+                    .expect("valid directive");
             filter = filter.add_directive(directive);
         }
     }

--- a/crates/logging/src/util.rs
+++ b/crates/logging/src/util.rs
@@ -220,7 +220,7 @@ pub fn render_out_format(format: &str, opts: &OutFormatOptions<'_>) -> String {
                             .unwrap_or_else(|_| OffsetDateTime::now_utc());
                         let fmt =
                             format_description!("[year]/[month]/[day] [hour]:[minute]:[second]");
-                        out.push_str(&now.format(&fmt).unwrap());
+                        out.push_str(&now.format(&fmt).expect("timestamp format should be valid"));
                     }
                     '%' => out.push('%'),
                     other => {

--- a/tests/cvs_exclude.rs
+++ b/tests/cvs_exclude.rs
@@ -61,7 +61,6 @@ fn cvs_exclude_parity() {
 
 #[test]
 fn cvs_exclude_nested_override() {
-    /* Regression test for duplicate :C rules with --cvs-exclude (GH-1667) */
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     fs::create_dir_all(&src).unwrap();


### PR DESCRIPTION
## Summary
- refine timestamp formatting in logging utilities
- ensure log directive parsing uses `expect` with context
- remove stray test comment to satisfy `verify-comments`

## Testing
- `cargo fmt --all`
- `make verify-comments`
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast` *(fails: ConnectionRefused did not map to ConnTimeout)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c08c0b730c8323b643bcdfb1ca4da9