### PR TITLE
refactor: split block size tests

### DIFF
--- a/tests/block_size/large_file.rs
+++ b/tests/block_size/large_file.rs
@@ -1,0 +1,99 @@
+use checksums::ChecksumConfigBuilder;
+use compress::available_codecs;
+use engine::{Op, SyncOptions, compute_delta, sync};
+use filters::Matcher;
+use std::fs;
+use tempfile::tempdir;
+use super::common::parse_literal;
+
+#[test]
+fn delta_block_size_large_file() {
+    let block_size = 8192usize;
+    let size = 8 * 1024 * 1024;
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+    let src_file = src_dir.join("file.bin");
+    let dst_file = dst_dir.join("file.bin");
+
+    let mut basis = vec![0u8; size];
+    for i in 0..size {
+        basis[i] = (i % 256) as u8;
+    }
+    let mut target = basis.clone();
+    let off = size / 2;
+    target[off..off + block_size].fill(0xAA);
+    fs::write(&src_file, &target).unwrap();
+    fs::write(&dst_file, &basis).unwrap();
+
+    let cfg = ChecksumConfigBuilder::new().build();
+    let mut basis_f = fs::File::open(&dst_file).unwrap();
+    let mut target_f = fs::File::open(&src_file).unwrap();
+    let ops: Vec<Op> = compute_delta(
+        &cfg,
+        &mut basis_f,
+        &mut target_f,
+        block_size,
+        usize::MAX,
+        &SyncOptions::default(),
+    )
+    .unwrap()
+    .map(Result::unwrap)
+    .collect();
+    let literal: usize = ops
+        .iter()
+        .map(|op| match op {
+            Op::Data(d) => d.len(),
+            _ => 0,
+        })
+        .sum();
+
+    let stats =
+        fs::read_to_string("tests/golden/block_size/delta_block_size_large_file.stdout").unwrap();
+    let rsync_literal = parse_literal(&stats);
+    assert_eq!(literal, rsync_literal);
+    assert_eq!(literal, block_size);
+}
+
+#[test]
+fn sync_block_size_large_file_stats_match_rsync() {
+    let block_size = 8192usize;
+    let size = 8 * 1024 * 1024;
+    let dir = tempdir().unwrap();
+    let src_dir = dir.path().join("src");
+    let dst_dir = dir.path().join("dst");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(&dst_dir).unwrap();
+    let src_file = src_dir.join("file.bin");
+    let dst_file = dst_dir.join("file.bin");
+
+    let mut basis = vec![0u8; size];
+    for i in 0..size {
+        basis[i] = (i % 256) as u8;
+    }
+    let mut target = basis.clone();
+    let off = size / 2;
+    target[off..off + block_size].fill(0xAA);
+    fs::write(&src_file, &target).unwrap();
+    fs::write(&dst_file, &basis).unwrap();
+
+    let stats = sync(
+        &src_dir,
+        &dst_dir,
+        &Matcher::default(),
+        &available_codecs(),
+        &SyncOptions {
+            block_size,
+            checksum: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let rsync_stats =
+        fs::read_to_string("tests/golden/block_size/delta_block_size_large_file.stdout").unwrap();
+    let rsync_literal = parse_literal(&rsync_stats) as u64;
+    assert_eq!(stats.literal_data, rsync_literal);
+    assert_eq!(stats.literal_data, block_size as u64);
+}

--- a/tests/block_size/mod.rs
+++ b/tests/block_size/mod.rs
@@ -1,0 +1,6 @@
+#[path = "../common/mod.rs"]
+mod common;
+
+mod unit_block_size;
+mod delta_block_size;
+mod large_file;

--- a/tests/block_size/unit_block_size.rs
+++ b/tests/block_size/unit_block_size.rs
@@ -1,0 +1,58 @@
+use engine::block_size;
+use std::fs;
+
+fn expected(len: u64) -> usize {
+    let data = fs::read_to_string("tests/golden/block_size/upstream_block_sizes.txt").unwrap();
+    for line in data.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        let l: u64 = parts.next().unwrap().parse().unwrap();
+        if l == len {
+            return parts.next().unwrap().parse().unwrap();
+        }
+    }
+    panic!("length {len} not found");
+}
+
+#[test]
+fn len_100() {
+    assert_eq!(block_size(100), expected(100));
+}
+
+#[test]
+fn len_490000() {
+    assert_eq!(block_size(490_000), expected(490_000));
+}
+
+#[test]
+fn len_500000() {
+    assert_eq!(block_size(500_000), expected(500_000));
+}
+
+#[test]
+fn len_1048576() {
+    assert_eq!(block_size(1_048_576), expected(1_048_576));
+}
+
+#[test]
+fn len_10000000() {
+    assert_eq!(block_size(10_000_000), expected(10_000_000));
+}
+
+#[test]
+fn len_100000000() {
+    assert_eq!(block_size(100_000_000), expected(100_000_000));
+}
+
+#[test]
+fn len_1000000000() {
+    assert_eq!(block_size(1_000_000_000), expected(1_000_000_000));
+}
+
+#[test]
+fn len_1000000000000() {
+    assert_eq!(block_size(1_000_000_000_000), expected(1_000_000_000_000));
+}


### PR DESCRIPTION
## Summary
- split block size tests into modular unit, delta, and large-file suites
- replace block-size and CLI error loops with individual tests

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: 287 failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(aborted: build interrupted)*
- `make verify-comments` *(fails: Error 1)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c08ec4b8f88323a41354f0eed0f73b