### PR TITLE
refactor: add env var guard helper

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -31,6 +31,16 @@ impl Drop for EnvVarGuard {
     }
 }
 
+pub fn with_env_var<K, V, F, R>(key: K, value: V, f: F) -> R
+where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+    F: FnOnce() -> R,
+{
+    let _guard = temp_env(key, value);
+    f()
+}
+
 pub fn read_golden(name: &str) -> (Vec<u8>, Vec<u8>, i32) {
     let base = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/golden")

--- a/tests/daemon_journald.rs
+++ b/tests/daemon_journald.rs
@@ -3,29 +3,11 @@
 
 use daemon::init_logging;
 use serial_test::serial;
-use std::ffi::OsStr;
 use std::os::unix::net::UnixDatagram;
 use tempfile::tempdir;
 use tracing::warn;
 mod common;
-use common::temp_env;
-
-fn with_env_var<K, V, F, R>(key: K, value: V, f: F) -> R
-where
-    K: AsRef<OsStr>,
-    V: AsRef<OsStr>,
-    F: FnOnce() -> R,
-{
-    let key = key.as_ref();
-    let old = std::env::var_os(key);
-    unsafe { std::env::set_var(key, value) };
-    let result = f();
-    match old {
-        Some(v) => unsafe { std::env::set_var(key, v) },
-        None => unsafe { std::env::remove_var(key) },
-    }
-    result
-}
+use common::{temp_env, with_env_var};
 
 #[test]
 #[serial]


### PR DESCRIPTION
## Summary
- wrap env var changes with a safe `with_env_var` helper
- update tests to use the helper instead of direct `env` calls

## Testing
- `make verify-comments`
- `make lint`
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast` *(fails: apply_with_existing_partial, devices_roundtrip, copy_devices_creates_regular_files, copy_devices_handles_zero, hard_links_roundtrip, links_roundtrip, omit_dir_times_skips_dirs, omit_link_times_skips_symlinks, apply_without_existing_partial)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: interrupted after 92/1091 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c0923752c48323b3255b55963a483a