### PR TITLE
Add header comments for block_size tests

### DIFF
--- a/tests/block_size/delta_block_size.rs
+++ b/tests/block_size/delta_block_size.rs
@@ -1,3 +1,4 @@
+// tests/block_size/delta_block_size.rs
 use assert_cmd::Command;
 use checksums::ChecksumConfigBuilder;
 use compress::available_codecs;

--- a/tests/block_size/large_file.rs
+++ b/tests/block_size/large_file.rs
@@ -1,3 +1,4 @@
+// tests/block_size/large_file.rs
 use checksums::ChecksumConfigBuilder;
 use compress::available_codecs;
 use engine::{Op, SyncOptions, compute_delta, sync};

--- a/tests/block_size/mod.rs
+++ b/tests/block_size/mod.rs
@@ -1,3 +1,4 @@
+// tests/block_size/mod.rs
 #[path = "../common/mod.rs"]
 mod common;
 

--- a/tests/block_size/unit_block_size.rs
+++ b/tests/block_size/unit_block_size.rs
@@ -1,3 +1,4 @@
+// tests/block_size/unit_block_size.rs
 use engine::block_size;
 use std::fs;
 


### PR DESCRIPTION
## Summary
- add header comments to block_size test files

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `bash tools/comment_lint.sh`
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c09e98b8e88323b36e300a52fbf5bc