### PR TITLE
Ensure CLI include rules override per-dir exclusions

### DIFF
--- a/crates/filters/src/matcher.rs
+++ b/crates/filters/src/matcher.rs
@@ -225,6 +225,8 @@ impl Matcher {
             seq += 1;
         }
 
+        let per_dir_offset = self.rules.iter().map(|(i, _)| *i).max().unwrap_or(0) + 1;
+
         if let Some(root) = &self.root {
             let mut dirs = vec![root.clone()];
             if let Some(parent) = path.parent() {
@@ -243,7 +245,7 @@ impl Matcher {
             for (depth_idx, d) in dirs.iter().enumerate() {
                 let depth = depth_idx + 1;
                 for (idx, rule) in self.dir_rules_at(d, for_delete, xattr)? {
-                    let mut idx_adj = idx;
+                    let mut idx_adj = per_dir_offset + idx;
                     if let Some(ref f) = fname {
                         let mut is_merge = self.per_dir.iter().any(|(_, pd)| pd.file == *f);
                         if !is_merge {


### PR DESCRIPTION
## Summary
- prioritize top-level include rules before per-directory exclusions in `Matcher`
- extend CVS exclude test to cover directory and file include cases

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: 541 passed, 207 failed, 335 not run)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(timeout while compiling)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a12384ac8323995176e705b8e6a7