### PR TITLE
Handle timestamp formatting errors

### DIFF
--- a/crates/logging/src/util.rs
+++ b/crates/logging/src/util.rs
@@ -220,7 +220,10 @@ pub fn render_out_format(format: &str, opts: &OutFormatOptions<'_>) -> String {
                             .unwrap_or_else(|_| OffsetDateTime::now_utc());
                         let fmt =
                             format_description!("[year]/[month]/[day] [hour]:[minute]:[second]");
-                        out.push_str(&now.format(&fmt).expect("timestamp format should be valid"));
+                        let ts = now
+                            .format(&fmt)
+                            .unwrap_or_else(|_| String::from("0000/00/00 00:00:00"));
+                        out.push_str(&ts);
                     }
                     '%' => out.push('%'),
                     other => {


### PR DESCRIPTION
## Summary
- Avoid panic when rendering timestamps in logging by replacing `expect` with `unwrap_or_else`
- Default to `0000/00/00 00:00:00` if timestamp formatting fails

## Testing
- `make verify-comments` *(fails: crates/cli/tests/... additional comments)*
- `make lint`
- `make test` *(installation and compilation of cargo-nextest interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c10b64dd9883238d003956664a7f20