### PR TITLE
test: add compare helper for tree equivalence

### DIFF
--- a/tests/files_from_dirs.rs
+++ b/tests/files_from_dirs.rs
@@ -3,11 +3,10 @@ use assert_cmd::Command;
 use filters::{Matcher, parse_with_options};
 use std::collections::HashSet;
 use std::fs;
-use std::process::Command as StdCommand;
 use tempfile::tempdir;
 use walk::walk;
 mod util;
-use util::setup_files_from_env;
+use util::{compare_trees, setup_files_from_env};
 mod common;
 use common::read_golden;
 
@@ -147,11 +146,5 @@ fn files_from_dirs_matches_rsync() {
 
     let golden = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/golden/files_from/dirs_matches_rsync");
-    let diff = StdCommand::new("diff")
-        .arg("-r")
-        .arg(&golden)
-        .arg(&ours_dst)
-        .status()
-        .unwrap();
-    assert!(diff.success(), "directory trees differ");
+    assert!(compare_trees(&golden, &ours_dst), "directory trees differ");
 }

--- a/tests/interop/filter_complex.rs
+++ b/tests/interop/filter_complex.rs
@@ -6,6 +6,10 @@ use std::fs;
 use std::process::Command as StdCommand;
 use tempfile::tempdir;
 
+#[path = "../util/mod.rs"]
+mod util;
+use util::compare_trees;
+
 #[test]
 #[ignore = "requires rsync"]
 fn complex_filter_cases_match_rsync() {
@@ -72,11 +76,5 @@ fn complex_filter_cases_match_rsync() {
     } else {
         std::path::Path::new("tests/golden/filter_complex/expected")
     };
-    let diff = StdCommand::new("diff")
-        .arg("-r")
-        .arg(diff_target)
-        .arg(&ours_dst)
-        .output()
-        .unwrap();
-    assert!(diff.status.success(), "directory trees differ");
+    assert!(compare_trees(diff_target, &ours_dst), "directory trees differ");
 }

--- a/tests/interop/filter_corpus.rs
+++ b/tests/interop/filter_corpus.rs
@@ -8,6 +8,10 @@ use std::path::Path;
 use std::process::Command as StdCommand;
 use tempfile::tempdir;
 
+#[path = "../util/mod.rs"]
+mod util;
+use util::compare_trees;
+
 fn setup_basic(src: &Path) {
     fs::create_dir_all(src.join("keep/sub")).unwrap();
     fs::create_dir_all(src.join("keep/tmp")).unwrap();
@@ -118,14 +122,8 @@ fn filter_corpus_parity() {
         } else {
             golden_dir.as_path()
         };
-        let diff = StdCommand::new("diff")
-            .arg("-r")
-            .arg(diff_target)
-            .arg(&ours_dst)
-            .output()
-            .unwrap();
         assert!(
-            diff.status.success(),
+            compare_trees(diff_target, &ours_dst),
             "directory trees differ for {:?}",
             path
         );
@@ -172,13 +170,7 @@ fn perdir_rules_excludes_filter_files() {
     let ours_out = ours_cmd.output().unwrap();
     assert!(ours_out.status.success());
 
-    let diff = StdCommand::new("diff")
-        .arg("-r")
-        .arg(&rsync_dst)
-        .arg(&ours_dst)
-        .output()
-        .unwrap();
-    assert!(diff.status.success(), "directory trees differ");
+    assert!(compare_trees(&rsync_dst, &ours_dst), "directory trees differ");
 
     assert!(!ours_dst.join(".rsync-filter").exists());
     assert!(!ours_dst.join("sub/.rsync-filter").exists());
@@ -232,13 +224,7 @@ fn ignores_parent_rsync_filter_with_ff() {
 
     assert_eq!(rsync_output, ours_output);
 
-    let diff = StdCommand::new("diff")
-        .arg("-r")
-        .arg(&rsync_dst)
-        .arg(&ours_dst)
-        .output()
-        .unwrap();
-    assert!(diff.status.success(), "directory trees differ");
+    assert!(compare_trees(&rsync_dst, &ours_dst), "directory trees differ");
 }
 
 #[test]
@@ -300,13 +286,10 @@ fn perdir_sign_parity() {
         } else {
             golden_dir.as_path()
         };
-        let diff = StdCommand::new("diff")
-            .arg("-r")
-            .arg(diff_target)
-            .arg(&ours_dst)
-            .output()
-            .unwrap();
-        assert!(diff.status.success(), "directory trees differ");
+        assert!(
+            compare_trees(diff_target, &ours_dst),
+            "directory trees differ"
+        );
 
         assert!(ours_dst.join("sub/keep.tmp").exists());
         assert!(!ours_dst.join("sub/other.tmp").exists());
@@ -354,13 +337,7 @@ fn perdir_stack_parity() {
     let ours_out = ours_cmd.output().unwrap();
     assert!(ours_out.status.success());
 
-    let diff = StdCommand::new("diff")
-        .arg("-r")
-        .arg(&rsync_dst)
-        .arg(&ours_dst)
-        .output()
-        .unwrap();
-    assert!(diff.status.success(), "directory trees differ");
+    assert!(compare_trees(&rsync_dst, &ours_dst), "directory trees differ");
 
     assert!(ours_dst.join("sub/keep.tmp").exists());
     assert!(ours_dst.join("sub/nested/keep.tmp").exists());


### PR DESCRIPTION
## Summary
- add compare_trees helper to compare directory trees
- use compare_trees instead of `diff` in tests

## Testing
- `make verify-comments` *(fails: additional comments)*
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: multiple test failures)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c1179f9980832380a640576f21b9c5