### PR TITLE
test: collect file metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ dependencies = [
  "tracing",
  "transport",
  "users",
+ "xattr",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,6 +36,7 @@ assert_cmd = "2"
 insta = { version = "1", features = ["json"] }
 serial_test = "2"
 filetime = "0.2"
+xattr = "1.3"
 
 [features]
 default = []

--- a/tests/interop/checksum_seed.rs
+++ b/tests/interop/checksum_seed.rs
@@ -1,28 +1,86 @@
 // tests/interop/checksum_seed.rs
 #![cfg(feature = "interop")]
 use assert_cmd::Command;
+use filetime::FileTime;
 use std::collections::BTreeMap;
 use std::fs;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Command as StdCommand;
 use tempfile::tempdir;
 
-fn collect(dir: &Path) -> BTreeMap<PathBuf, Vec<u8>> {
-    fn visit(base: &Path, root: &Path, map: &mut BTreeMap<PathBuf, Vec<u8>>) {
+#[derive(Debug, PartialEq, Eq)]
+struct Collected {
+    data: Vec<u8>,
+    mtime: FileTime,
+    #[cfg(unix)]
+    mode: u32,
+    #[cfg(unix)]
+    xattrs: BTreeMap<String, Vec<u8>>,
+}
+
+fn gather(path: &Path, meta: &fs::Metadata) -> Collected {
+    #[cfg(unix)]
+    let mode = meta.permissions().mode();
+    let data = if meta.is_file() {
+        fs::read(path).unwrap()
+    } else if meta.file_type().is_symlink() {
+        fs::read_link(path)
+            .unwrap()
+            .as_os_str()
+            .to_string_lossy()
+            .into_owned()
+            .into_bytes()
+    } else {
+        Vec::new()
+    };
+    let mtime = FileTime::from_last_modification_time(meta);
+    #[cfg(unix)]
+    let mut xattrs = BTreeMap::new();
+    #[cfg(unix)]
+    if let Ok(names) = xattr::list(path) {
+        for name in names {
+            let key = name.to_string_lossy().into_owned();
+            if let Ok(Some(val)) = xattr::get(path, &key) {
+                xattrs.insert(key, val);
+            }
+        }
+    }
+    Collected {
+        data,
+        mtime,
+        #[cfg(unix)]
+        mode,
+        #[cfg(unix)]
+        xattrs,
+    }
+}
+
+fn collect(dir: &Path) -> BTreeMap<PathBuf, Collected> {
+    fn visit(base: &Path, root: &Path, map: &mut BTreeMap<PathBuf, Collected>) {
         for entry in fs::read_dir(base).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();
-            if path.is_dir() {
+            let meta = fs::symlink_metadata(&path).unwrap();
+            let rel = path.strip_prefix(root).unwrap().to_path_buf();
+            if meta.is_dir() {
+                map.insert(rel.clone(), gather(&path, &meta));
                 visit(&path, root, map);
             } else {
-                let rel = path.strip_prefix(root).unwrap().to_path_buf();
-                map.insert(rel, fs::read(&path).unwrap());
+                map.insert(rel, gather(&path, &meta));
             }
         }
     }
     let mut map = BTreeMap::new();
     visit(dir, dir, &mut map);
     map
+}
+
+fn oc_rsync() -> Command {
+    let mut cmd = Command::cargo_bin("oc-rsync").unwrap();
+    cmd.env("LC_ALL", "C").env("TZ", "UTC");
+    cmd
 }
 
 #[test]
@@ -40,8 +98,7 @@ fn checksum_seed_matches_upstream() {
 
     let src_arg = format!("{}/", src.display());
 
-    Command::cargo_bin("oc-rsync")
-        .unwrap()
+    oc_rsync()
         .args([
             "--checksum-seed=1",
             "-r",


### PR DESCRIPTION
## Summary
- capture mode, mtime, and xattrs when collecting test trees
- compare collected metadata to ensure identical copies
- use a deterministic LC_ALL and TZ for metadata-sensitive tests

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: engine tests)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: Broken pipe)*
- `make verify-comments` *(fails: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c117aaec148323bc9c64d528199cd3