### PR TITLE
docs: refresh feature gaps overview

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -2,66 +2,27 @@
 
 All divergences from upstream `rsync` should be recorded here; the previous `docs/differences.md` file is intentionally empty.
 
-This document summarizes parity status across major domains of `oc-rsync`.  Each
-table lists notable features that are either implemented, only partially
-completed, or still missing.  Entries link to the source and corresponding tests
-when available. Do not exceed functionality of upstream at <https://rsync.samba.org> at this stage, prune unused features and/or unreachable code.
+This document summarizes parity status across major domains of `oc-rsync`. Each table lists notable features that are implemented, partially complete, missing, or divergent from upstream behavior. Entries link to the source and corresponding tests when available. Do not exceed functionality of upstream at <https://rsync.samba.org> at this stage, prune unused features and/or unreachable code.
 
-## Interop matrix scenarios
-
-The interoperability matrix builds upstream `rsync 3.4.1` via
-[scripts/interop/run.sh](../scripts/interop/run.sh) and validates behavior with
-[scripts/interop/validate.sh](../scripts/interop/validate.sh). It exercises real
-transfers across the following scenarios:
-
-  - `base`: baseline transfer using [scripts/interop/run.sh](../scripts/interop/run.sh)
-  - `delete`: `--delete` removes extraneous files
-  - `compress_zlib`: zlib negotiation using [codec_negotiation.rs](../tests/interop/codec_negotiation.rs)
-  - `compress_zstd`: zstd negotiation using [codec_negotiation.rs](../tests/interop/codec_negotiation.rs)
-  - `filters`: include/exclude and `.rsync-filter` rules via [filter_complex.rs](../tests/interop/filter_complex.rs)
-  - `metadata`: ACL, xattr and permission preservation validated against [golden fixtures](../tests/interop/golden)
-  - `partial`: `--partial` leaves resumable files in place as demonstrated in [resume.rs](../tests/resume.rs)
-  - `resume`: interrupted transfers resume from partial files in [resume.rs](../tests/resume.rs)
-  - `vanished`: vanished source files handled gracefully
-
-## Parser Parity
+## CLI & Parser
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
-| Comprehensive flag parsing and help text parity | ✅ | [tests/cli_flags.rs](../tests/cli_flags.rs)<br>[crates/cli/tests/help.rs](../crates/cli/tests/help.rs) | [crates/cli/src/argparse.rs](../crates/cli/src/argparse.rs) |
-| Composite `--archive` flag expansion | ✅ | [tests/archive.rs](../tests/archive.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
-| Remote-only option parsing (`--remote-option`) | ✅ | [tests/interop/remote_option.rs](../tests/interop/remote_option.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
-| `--version` output parity | ✅ | [tests/version_output.rs](../tests/version_output.rs) | [crates/cli/src/version.rs](../crates/cli/src/version.rs) |
-| Null-delimited list parsing (`--from0`) | ✅ | [tests/files_from.rs](../tests/files_from.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
-
-Note: [tests/archive.rs](../tests/archive.rs) demonstrates the composite `--archive` flag expansion.
-
-_Future contributors: update this section when adding or fixing CLI parser behaviors._
-
+| Comprehensive flag parsing and help text parity | Implemented | [tests/cli_flags.rs](../tests/cli_flags.rs)<br>[crates/cli/tests/help.rs](../crates/cli/tests/help.rs) | [crates/cli/src/argparse.rs](../crates/cli/src/argparse.rs) |
+| Composite `--archive` flag expansion | Implemented | [tests/archive.rs](../tests/archive.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
+| Remote-only option parsing (`--remote-option`) | Implemented | [tests/interop/remote_option.rs](../tests/interop/remote_option.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
+| `--version` output parity | Implemented | [tests/version_output.rs](../tests/version_output.rs) | [crates/cli/src/version.rs](../crates/cli/src/version.rs) |
+| Null-delimited list parsing (`--from0`) | Implemented | [tests/files_from.rs](../tests/files_from.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
+| `--log-file-format` | Implemented | [tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
+| `--munge-links` option | Implemented | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) | [crates/cli/src/argparse.rs](../crates/cli/src/argparse.rs) |
+| `--dry-run` prevents destination changes | Implemented | [tests/interop/dry_run.rs](../tests/interop/dry_run.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
+| Test-only `--dump-help-body` flag for help text verification | Implemented | [crates/cli/tests/help.rs](../crates/cli/tests/help.rs) | [crates/cli/src/argparse.rs](../crates/cli/src/argparse.rs) |
 
 ## Protocol
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
-| Frame multiplexing and keep-alives | ✅ | [crates/protocol/tests/mux_demux.rs](../crates/protocol/tests/mux_demux.rs) | [crates/protocol/src/mux.rs](../crates/protocol/src/mux.rs) |
-| Version negotiation | ✅ | [crates/protocol/tests/server.rs](../crates/protocol/tests/server.rs) | [crates/protocol/src/server.rs](../crates/protocol/src/server.rs) |
-| Challenge-response authentication | ✅ | [crates/protocol/tests/auth.rs](../crates/protocol/tests/auth.rs) | [crates/protocol/src/server.rs](../crates/protocol/src/server.rs) |
-
-## Exit Codes
-| Feature | Status | Tests | Source |
-| --- | --- | --- | --- |
-| Standard exit code mapping | Implemented | [crates/protocol/tests/exit_codes.rs](../crates/protocol/tests/exit_codes.rs) | [crates/protocol/src/lib.rs](../crates/protocol/src/lib.rs) |
-| Remote exit code propagation | Implemented | [crates/protocol/tests/exit_codes.rs](../crates/protocol/tests/exit_codes.rs) | [crates/protocol/src/demux.rs](../crates/protocol/src/demux.rs) |
-
-## Checksums
-| Feature | Status | Tests | Source |
-| --- | --- | --- | --- |
-| Rolling and strong MD4/MD5/SHA-1/XXHash hashes | ✅ | [crates/checksums/tests/golden.rs](../crates/checksums/tests/golden.rs)<br>[crates/checksums/tests/rsync.rs](../crates/checksums/tests/rsync.rs) | [crates/checksums/src/lib.rs](../crates/checksums/src/lib.rs) |
-
-## Compression
-| Feature | Status | Tests | Source |
-| --- | --- | --- | --- |
-| zstd and zlib codecs | Implemented | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/mod.rs](../crates/compress/src/mod.rs) |
-| `--skip-compress` suffix handling | Implemented | [tests/skip_compress.rs](../tests/skip_compress.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
-| LZ4 codec | Planned post-parity ([#873](https://github.com/oferchen/oc-rsync/pull/873)); `liblz4-dev` no longer required for interop builds | — | — |
+| Frame multiplexing and keep-alives | Implemented | [crates/protocol/tests/mux_demux.rs](../crates/protocol/tests/mux_demux.rs) | [crates/protocol/src/mux.rs](../crates/protocol/src/mux.rs) |
+| Version negotiation | Implemented | [crates/protocol/tests/server.rs](../crates/protocol/tests/server.rs) | [crates/protocol/src/server.rs](../crates/protocol/src/server.rs) |
+| Challenge-response authentication | Implemented | [crates/protocol/tests/auth.rs](../crates/protocol/tests/auth.rs) | [crates/protocol/src/server.rs](../crates/protocol/src/server.rs) |
 
 ## Filters
 | Feature | Status | Tests | Source |
@@ -73,20 +34,10 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | Additional rule modifiers | Implemented | [crates/filters/tests/rule_modifiers.rs](../crates/filters/tests/rule_modifiers.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | CVS ignore semantics (`--cvs-exclude`) | Divergent | [tests/cvs_exclude.rs](../tests/cvs_exclude.rs) *(nested override case fails)* | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 | Complex glob patterns | Implemented | [crates/filters/tests/advanced_globs.rs](../crates/filters/tests/advanced_globs.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
-| `--files-from` directory entries | ✅ | [crates/filters/tests/files_from.rs](../crates/filters/tests/files_from.rs)<br>[tests/files_from_dirs.rs](../tests/files_from_dirs.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs)<br>[crates/cli/src/client.rs](../crates/cli/src/client.rs) |
-| Directory boundary handling | Implemented | [tests/misc.rs](../tests/misc.rs) (`single_star_does_not_cross_directories`<br>`segment_star_does_not_cross_directories`) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
+| `--files-from` directory entries | Implemented | [crates/filters/tests/files_from.rs](../crates/filters/tests/files_from.rs)<br>[tests/files_from_dirs.rs](../tests/files_from_dirs.rs) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs)<br>[crates/cli/src/client.rs](../crates/cli/src/client.rs) |
+| Directory boundary handling | Implemented | [tests/misc.rs](../tests/misc.rs) (`single_star_does_not_cross_directories` / `segment_star_does_not_cross_directories`) | [crates/filters/src/lib.rs](../crates/filters/src/lib.rs) |
 
-## File Selection
-| Feature | Status | Tests | Source |
-| --- | --- | --- | --- |
-| Path-delta encoding with uid/gid tables | Implemented | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
-| Group ID preservation | Implemented | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
-| Extended attributes and ACL entries | Implemented | [crates/engine/tests/flist.rs](../crates/engine/tests/flist.rs) | [crates/filelist/src/lib.rs](../crates/filelist/src/lib.rs) |
-| Batched filesystem traversal | Implemented | [crates/walk/tests/walk.rs](../crates/walk/tests/walk.rs) | [crates/walk/src/lib.rs](../crates/walk/src/lib.rs) |
-| Maximum file-size filtering | Implemented | [crates/walk/tests/walk.rs](../crates/walk/tests/walk.rs) | [crates/walk/src/lib.rs](../crates/walk/src/lib.rs) |
-| `--one-file-system` device boundary | Implemented | [crates/walk/tests/walk.rs](../crates/walk/tests/walk.rs) | [crates/walk/src/lib.rs](../crates/walk/src/lib.rs) |
-
-## Metadata Fidelity
+## Metadata
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
 | Permissions and ownership restoration | Implemented | [crates/meta/tests/chmod.rs](../crates/meta/tests/chmod.rs) | [crates/meta/src/unix/mod.rs](../crates/meta/src/unix/mod.rs) |
@@ -95,36 +46,14 @@ _Future contributors: update this section when adding or fixing CLI parser behav
 | Hard link detection and recreation | Implemented | [tests/hard_links.rs](../tests/hard_links.rs)<br>[crates/engine/tests/links.rs](../crates/engine/tests/links.rs) | [crates/meta/src/lib.rs](../crates/meta/src/lib.rs) |
 | Windows metadata preservation | Implemented | [tests/windows.rs](../tests/windows.rs) | [crates/meta/src/windows/mod.rs](../crates/meta/src/windows/mod.rs) |
 
-Note: Full metadata coverage requires root privileges; unprivileged environments skip ownership changes and related tests.
-
-## Transport
+## Compression
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
-| SSH stdio transport | ✅ | [crates/transport/tests/ssh_stdio.rs](../crates/transport/tests/ssh_stdio.rs) | [crates/transport/src/ssh.rs](../crates/transport/src/ssh.rs) |
-| TCP transport with bandwidth limiting | ✅ | [crates/transport/tests/bwlimit.rs](../crates/transport/tests/bwlimit.rs) | [crates/transport/src/rate.rs](../crates/transport/src/rate.rs) |
-| Extended socket options | ✅ | [crates/transport/tests/sockopts.rs](../crates/transport/tests/sockopts.rs) | [crates/transport/src/tcp.rs](../crates/transport/src/tcp.rs) |
-| Connection error parity (SSH/daemon) | ✅ | [tests/interop/failure_cases.rs](../tests/interop/failure_cases.rs) | [crates/transport/src/ssh.rs](../crates/transport/src/ssh.rs)<br>[crates/transport/src/tcp.rs](../crates/transport/src/tcp.rs) |
+| zstd and zlib codecs | Implemented | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/mod.rs](../crates/compress/src/mod.rs) |
+| `--skip-compress` suffix handling | Implemented | [tests/skip_compress.rs](../tests/skip_compress.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
+| LZ4 codec | Missing | — | — |
 
-## Engine
-| Feature | Status | Tests | Source |
-| --- | --- | --- | --- |
-| In-place updates and resume | ✅ | [crates/engine/tests/resume.rs](../crates/engine/tests/resume.rs) | [crates/engine/src/lib.rs](../crates/engine/src/lib.rs) |
-| Delete policies | ✅ | [crates/engine/tests/delete.rs](../crates/engine/tests/delete.rs) | [crates/engine/src/lib.rs](../crates/engine/src/lib.rs) |
-| `--read-batch` replay | ✅ | [crates/engine/tests/upstream_batch.rs](../crates/engine/tests/upstream_batch.rs) | [crates/engine/src/lib.rs](../crates/engine/src/lib.rs) |
-| `--block-size` semantics | ✅ | [tests/block_size.rs](../tests/block_size.rs) | [crates/engine/src/lib.rs](../crates/engine/src/lib.rs) |
-
-`--block-size` adjusts the delta algorithm's chunk size. To mirror upstream
-behavior, it is typically combined with `--checksum` and `--no-whole-file` so
-that only changed blocks are transferred.
-
-```bash
-$ oc-rsync --checksum --no-whole-file --block-size=4K --stats src/ dst/
-Literal data: 4,096 bytes
-```
-
-The stats output shows that only a single 4 KiB block was sent.
-
-## Daemon Features
+## Daemon
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
 | Module parsing and secrets auth | Implemented | [tests/daemon_config.rs](../tests/daemon_config.rs)<br>[tests/daemon_auth.sh](../tests/daemon_auth.sh) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
@@ -132,7 +61,7 @@ The stats output shows that only a single 4 KiB block was sent.
 | Chroot and uid/gid dropping | Implemented | [tests/daemon.rs](../tests/daemon.rs) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
 | `rsyncd.conf` file parsing | Implemented | [tests/daemon_config.rs](../tests/daemon_config.rs) | [crates/daemon/src/lib.rs](../crates/daemon/src/lib.rs) |
 
-## Messages/Logging
+## Messages
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
 | Custom out-format and log file messages | Implemented | [tests/out_format.rs](../tests/out_format.rs)<br>[tests/log_file.rs](../tests/log_file.rs) | [crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |
@@ -141,23 +70,15 @@ The stats output shows that only a single 4 KiB block was sent.
 | Info and debug flag routing | Implemented | [crates/logging/tests/info_flags.rs](../crates/logging/tests/info_flags.rs) | [crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |
 | JSON and text formatters | Implemented | [crates/logging/tests/levels.rs](../crates/logging/tests/levels.rs) | [crates/logging/src/lib.rs](../crates/logging/src/lib.rs) |
 
-_Future contributors: update this section when adding or fixing message behaviors._
-
-## CLI
+## Exit Codes
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
-| Comprehensive flag parsing via `clap` | ✅ | [tests/cli_flags.rs](../tests/cli_flags.rs) | [crates/cli/src/argparse.rs](../crates/cli/src/argparse.rs) |
-| `--log-file-format` | ✅ | [tests/log_file.rs](../tests/log_file.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
-| `--munge-links` option | ✅ | [tests/symlink_resolution.rs](../tests/symlink_resolution.rs) | [crates/cli/src/argparse.rs](../crates/cli/src/argparse.rs) |
-| `--dry-run` prevents destination changes | ✅ | [tests/interop/dry_run.rs](../tests/interop/dry_run.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
-| Test-only `--dump-help-body` flag for help text verification | Internal | [crates/cli/tests/help.rs](../crates/cli/tests/help.rs) | [crates/cli/src/argparse.rs](../crates/cli/src/argparse.rs) |
-### Outstanding Options
+| Standard exit code mapping | Implemented | [crates/protocol/tests/exit_codes.rs](../crates/protocol/tests/exit_codes.rs) | [crates/protocol/src/lib.rs](../crates/protocol/src/lib.rs) |
+| Remote exit code propagation | Implemented | [crates/protocol/tests/exit_codes.rs](../crates/protocol/tests/exit_codes.rs) | [crates/protocol/src/demux.rs](../crates/protocol/src/demux.rs) |
 
-All CLI flags now have interop coverage verifying parser and message parity with upstream `rsync`. See [tests/interop/outstanding_flags.rs](../tests/interop/outstanding_flags.rs).
-
-## Test Coverage
+## Testing
 | Feature | Status | Tests | Source |
 | --- | --- | --- | --- |
+| Interoperability matrix (base, delete, compress_zlib, compress_zstd, filters, metadata, partial, resume, vanished) | Implemented | [scripts/interop/run.sh](../scripts/interop/run.sh)<br>[scripts/interop/validate.sh](../scripts/interop/validate.sh) | [scripts/interop/run.sh](../scripts/interop/run.sh)<br>[scripts/interop/validate.sh](../scripts/interop/validate.sh) |
 | Workspace coverage via `cargo llvm-cov` (≥95%) | Implemented | [reports/metrics.md](../reports/metrics.md) | [Makefile](../Makefile) |
 | Coverage exclusions documented | Implemented | — | [coverage_exclusions.md](coverage_exclusions.md) |
-


### PR DESCRIPTION
## Summary
- restructure feature gaps doc to focus on CLI, protocol, filters, metadata, compression, daemon, messages, exit codes, and testing
- record notable features with implementation status and source/test links

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: assertion in tests/daemon.rs, 84 tests failed)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(build interrupted)*
- `make verify-comments` *(fails: additional comments in existing files)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c13f15fb888323bfb6055ca6333193