### PR TITLE
Serialize env var access and drop multi-line comments

### DIFF
--- a/crates/cli/src/formatter.rs
+++ b/crates/cli/src/formatter.rs
@@ -6,6 +6,7 @@ use regex::Regex;
 use scopeguard::guard;
 use std::env;
 use std::ffi::{OsStr, OsString};
+use std::sync::Mutex;
 use textwrap::{Options as WrapOptions, wrap};
 
 use crate::branding;
@@ -43,6 +44,8 @@ static UPSTREAM_OPTS: Lazy<Vec<(String, String)>> = Lazy::new(|| {
     }
     opts
 });
+
+static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 pub const ARG_ORDER: &[&str] = &[
     "verbose",
@@ -285,13 +288,13 @@ pub fn render_help(_cmd: &Command) -> String {
 }
 
 fn set_env_var<K: AsRef<OsStr>, V: AsRef<OsStr>>(key: K, value: V) {
-    /* SAFETY: our tests serialize access to environment variables using `serial_test`. */
-    unsafe { std::env::set_var(key, value) }
+    let _guard = ENV_LOCK.lock().unwrap();
+    unsafe { std::env::set_var(key, value) };
 }
 
 fn remove_env_var<K: AsRef<OsStr>>(key: K) {
-    /* SAFETY: our tests serialize access to environment variables using `serial_test`. */
-    unsafe { std::env::remove_var(key) }
+    let _guard = ENV_LOCK.lock().unwrap();
+    unsafe { std::env::remove_var(key) };
 }
 
 fn with_env_var<K, V, F, R>(key: K, value: V, f: F) -> R

--- a/crates/cli/tests/branding.rs
+++ b/crates/cli/tests/branding.rs
@@ -2,15 +2,20 @@
 use oc_rsync_cli::{branding, cli_command, render_help};
 use serial_test::serial;
 use std::env;
+use std::sync::{Mutex, OnceLock};
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 fn set_env_var(key: &str, val: &str) {
-    /* SAFETY: tests run serially so environment changes don't race. */
-    unsafe { env::set_var(key, val) }
+    let lock = ENV_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap();
+    unsafe { env::set_var(key, val) };
 }
 
 fn remove_env_var(key: &str) {
-    /* SAFETY: see `set_env_var`. */
-    unsafe { env::remove_var(key) }
+    let lock = ENV_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap();
+    unsafe { env::remove_var(key) };
 }
 
 #[test]

--- a/crates/cli/tests/help_formatting.rs
+++ b/crates/cli/tests/help_formatting.rs
@@ -3,15 +3,20 @@ use oc_rsync_cli::{cli_command, dump_help_body, render_help};
 use serial_test::serial;
 use std::collections::HashSet;
 use std::env;
+use std::sync::{Mutex, OnceLock};
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 fn set_env_var(key: &str, val: &str) {
-    /* SAFETY: tests are run serially so environment mutations don't race. */
-    unsafe { env::set_var(key, val) }
+    let lock = ENV_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap();
+    unsafe { env::set_var(key, val) };
 }
 
 fn remove_env_var(key: &str) {
-    /* SAFETY: see `set_env_var`. */
-    unsafe { env::remove_var(key) }
+    let lock = ENV_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap();
+    unsafe { env::remove_var(key) };
 }
 
 fn extract_options(help: &str) -> String {

--- a/crates/cli/tests/options_validation.rs
+++ b/crates/cli/tests/options_validation.rs
@@ -2,15 +2,20 @@
 use oc_rsync_cli::{ClientOptsBuilder, cli_command, validate_paths};
 use serial_test::serial;
 use std::env;
+use std::sync::{Mutex, OnceLock};
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 fn set_env_var(key: &str, val: &str) {
-    /* SAFETY: tests run serially. */
-    unsafe { env::set_var(key, val) }
+    let lock = ENV_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap();
+    unsafe { env::set_var(key, val) };
 }
 
 fn remove_env_var(key: &str) {
-    /* SAFETY: see `set_env_var`. */
-    unsafe { env::remove_var(key) }
+    let lock = ENV_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = lock.lock().unwrap();
+    unsafe { env::remove_var(key) };
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- lock environment variable mutations and eliminate unsafe comments
- strip inline comments from CLI tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make lint`
- `make verify-comments`


------
https://chatgpt.com/codex/tasks/task_e_68c1524438148323b3c5dc9e3826b4ba