### PR TITLE
docs: note LZ4 is out of scope

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -51,7 +51,7 @@ This document summarizes parity status across major domains of `oc-rsync`. Each 
 | --- | --- | --- | --- |
 | zstd and zlib codecs | Implemented | [crates/compress/tests/codecs.rs](../crates/compress/tests/codecs.rs) | [crates/compress/src/mod.rs](../crates/compress/src/mod.rs) |
 | `--skip-compress` suffix handling | Implemented | [tests/skip_compress.rs](../tests/skip_compress.rs) | [crates/cli/src/client.rs](../crates/cli/src/client.rs) |
-| LZ4 codec | Missing | — | — |
+| LZ4 codec | Intentionally out of scope | — | — |
 
 ## Daemon
 | Feature | Status | Tests | Source |


### PR DESCRIPTION
## Summary
- clarify that LZ4 compression is currently out of scope

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: 35 failed, 131 passed, 920 not run; interrupted)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(command interrupted)*
- `make verify-comments` *(fails: additional comments)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1521d7404832399803f3609fa28fd