### PR TITLE
daemon: allow empty tokens

### DIFF
--- a/crates/daemon/src/auth.rs
+++ b/crates/daemon/src/auth.rs
@@ -135,13 +135,9 @@ pub fn authenticate(
             ));
         }
         Ok((Some(token_str), Vec::new(), no_motd))
+    } else if token_str.is_empty() {
+        Ok((None, Vec::new(), no_motd))
     } else {
-        if token_str.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                "missing token",
-            ));
-        }
         Ok((Some(token_str), Vec::new(), no_motd))
     }
 }
@@ -218,8 +214,10 @@ mod tests {
         let reader = std::io::Cursor::new(b"\n".to_vec());
         let writer = io::sink();
         let mut t = LocalPipeTransport::new(reader, writer);
-        let err = authenticate(&mut t, None, None).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        let (tok, allowed, no_motd) = authenticate(&mut t, None, None).unwrap();
+        assert!(tok.is_none());
+        assert!(allowed.is_empty());
+        assert!(!no_motd);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- allow empty authentication tokens when no path or password is provided
- update daemon auth tests for optional tokens

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: call to unsafe function `remove_var` in crates/cli/src/branding.rs)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: call to unsafe function `remove_var` in crates/cli/src/branding.rs)*
- `cargo nextest run --test daemon_acls daemon_acls_match_rsync_client` *(fails: daemon failed to bind to port 37605: Connection reset by peer (os error 104))*

------
https://chatgpt.com/codex/tasks/task_e_68c175c7950483238b027ad72601c97b