### PR TITLE
docs: update rsync version reference

### DIFF
--- a/docs/feature_matrix.md
+++ b/docs/feature_matrix.md
@@ -1,6 +1,6 @@
 # Feature Matrix
 
-This table tracks the implementation status of rsync 3.4.x command-line options.
+This table tracks the implementation status of rsync 3.4.1 command-line options.
 Behavioral differences from upstream rsync are tracked in [gaps.md](gaps.md).
 
 Classic `rsync` protocol versions 30–32 are supported.


### PR DESCRIPTION
## Summary
- refine feature matrix intro to mention rsync 3.4.1 instead of 3.4.x

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command: `nextest`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: no such command: `nextest`)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c17cb3ea1083238d25123112bbb6bd