### PR TITLE
Canonicalize module path in daemon config

### DIFF
--- a/crates/daemon/src/config.rs
+++ b/crates/daemon/src/config.rs
@@ -571,7 +571,8 @@ pub fn parse_config(contents: &str) -> io::Result<DaemonConfig> {
             (false, "refuse options") => cfg.refuse_options = parse_list(&val),
             (true, "path") => {
                 if let Some(m) = current.as_mut() {
-                    m.path = PathBuf::from(val);
+                    let p = PathBuf::from(val);
+                    m.path = fs::canonicalize(&p).unwrap_or(p);
                 }
             }
             (true, "comment") => {


### PR DESCRIPTION
## Summary
- resolve module path symlinks during config parsing

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` (fails: linking with `cc`)
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` (fails: linking with `cc`)


------
https://chatgpt.com/codex/tasks/task_e_68c17b2e78748323a24496ac1046111d