### PR TITLE
docs: clarify windows support status

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -20,7 +20,7 @@ through 32, corresponding to upstream releases 3.0.9, 3.1.3, and 3.4.1.
 | Linux (armv7) | cross-compiled in CI |
 | FreeBSD | cross-compiled in CI |
 | macOS | builds and basic local sync verified |
-| Windows | under active development; path and permission handling incomplete |
+| Windows | under active development; path normalization and permission/ACL handling incomplete |
 
 ## Cross-platform tests
 

--- a/docs/oc-rsyncd.md
+++ b/docs/oc-rsyncd.md
@@ -12,9 +12,9 @@ oc-rsync --daemon [OPTIONS]
 
 The daemon can be started either directly via `oc-rsync --daemon` or by a service manager. Daemon behaviour and module definitions are controlled by the configuration file `oc-rsyncd.conf(5)`. Clients connect using `oc-rsync(1)` and specify a module name in the `rsync://` URL.
 
-Windows hosts are supported with the same path and metadata semantics as
-Unix systems, including normalization of extended `\\?\` paths and
-propagation of ACLs and timestamps.
+Windows support is under active development. Path normalization and
+permission/ACL handling are incomplete, so behavior may diverge from
+Unix systems.
 
 ## Options
 


### PR DESCRIPTION
## Summary
- document that Windows support is still in progress for oc-rsyncd
- note Windows path and permission handling gaps in compatibility table

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c17ced58c48323a1701e153fce508f