### PR TITLE
docs: clarify ACL feature toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ defaults to the system year. Set this variable when you need reproducible
 builds across years.
 
 If `libacl1-dev` isn't available, disable ACL support with the `no-acl`
-feature set:
+feature set, which retains extended attributes and compression
+(`xattr`, `zlib`, and `zstd`):
 
 ```bash
 cargo build --no-default-features --features no-acl

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,11 +18,12 @@ sudo apt-get install -y build-essential libzstd-dev zlib1g-dev libacl1-dev
 
 Run `scripts/preflight.sh` to verify these dependencies before compiling.
 
-If your system lacks the `libacl` development package, build without ACL
-support using:
+If your system lacks the `libacl` development package, disable ACL support
+using the convenience `no-acl` feature set. This keeps extended attributes
+and compression enabled (`xattr`, `zlib`, and `zstd`):
 
 ```bash
-cargo build --no-default-features --features xattr
+cargo build --no-default-features --features no-acl
 ```
 
 ### RPM packaging


### PR DESCRIPTION
## Summary
- document `cargo build --no-default-features --features no-acl` as the canonical ACL-disabled build
- explain that `no-acl` retains xattr and compression features

## Testing
- `make verify-comments`
- `make lint`
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast` *(fails: call to unsafe function `set_var` requires unsafe block)*
- `env LC_ALL=C LANG=C COLUMNS=80 TZ=UTC cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: call to unsafe function `set_var` requires unsafe block)*

------
https://chatgpt.com/codex/tasks/task_e_68c17cd462188323bd6cfd440969e5c8