### PR TITLE
test: split acl parity tests

### DIFF
--- a/tests/daemon_acls.rs
+++ b/tests/daemon_acls.rs
@@ -27,6 +27,102 @@ where
     (tmp, src, srv)
 }
 
+#[cfg(feature = "root")]
+fn sync_daemon_acls_server() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let srv_oc = tmp.path().join("srv_oc");
+    let srv_rs = tmp.path().join("srv_rs");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&srv_oc).unwrap();
+    fs::create_dir_all(&srv_rs).unwrap();
+
+    let src_file = src.join("file");
+    fs::write(&src_file, b"hi").unwrap();
+
+    let mut acl = PosixACL::read_acl(&src_file).unwrap();
+    acl.set(Qualifier::User(12345), ACL_READ);
+    acl.set(Qualifier::User(23456), ACL_WRITE);
+    acl.write_acl(&src_file).unwrap();
+
+    let mut dacl = PosixACL::new(0o755);
+    dacl.set(Qualifier::User(12345), ACL_READ);
+    dacl.write_default_acl(&src).unwrap();
+
+    let (mut child_oc, port_oc) = spawn_daemon(&srv_oc);
+    wait_for_daemon(port_oc);
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["-AX", &src_arg, &format!("rsync://127.0.0.1:{port_oc}/mod")])
+        .assert()
+        .success();
+    let _ = child_oc.kill();
+    let _ = child_oc.wait();
+
+    let (mut child_rs, port_rs) = spawn_rsync_daemon(&srv_rs, "");
+    wait_for_daemon(port_rs);
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["-AX", &src_arg, &format!("rsync://127.0.0.1:{port_rs}/mod")])
+        .assert()
+        .success();
+    let _ = child_rs.kill();
+    let _ = child_rs.wait();
+
+    (tmp, srv_oc, srv_rs)
+}
+
+#[cfg(feature = "root")]
+fn sync_daemon_acls_client() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("src");
+    let srv_oc = tmp.path().join("srv_oc");
+    let srv_rs = tmp.path().join("srv_rs");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&srv_oc).unwrap();
+    fs::create_dir_all(&srv_rs).unwrap();
+
+    let src_file = src.join("file");
+    fs::write(&src_file, b"hi").unwrap();
+
+    let mut acl = PosixACL::read_acl(&src_file).unwrap();
+    acl.set(Qualifier::User(12345), ACL_READ);
+    acl.set(Qualifier::User(23456), ACL_WRITE);
+    acl.write_acl(&src_file).unwrap();
+
+    let mut dacl = PosixACL::new(0o755);
+    dacl.set(Qualifier::User(12345), ACL_READ);
+    dacl.write_default_acl(&src).unwrap();
+
+    let (mut child_oc, port_oc) = spawn_rsync_daemon(&srv_oc, "");
+    wait_for_daemon(port_oc);
+    let src_arg = format!("{}/", src.display());
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args([
+            "--acls",
+            &src_arg,
+            &format!("rsync://127.0.0.1:{port_oc}/mod"),
+        ])
+        .assert()
+        .success();
+    let _ = child_oc.kill();
+    let _ = child_oc.wait();
+
+    let (mut child_rs, port_rs) = spawn_rsync_daemon(&srv_rs, "");
+    wait_for_daemon(port_rs);
+    Command::cargo_bin("oc-rsync")
+        .unwrap()
+        .args(["-AX", &src_arg, &format!("rsync://127.0.0.1:{port_rs}/mod")])
+        .assert()
+        .success();
+    let _ = child_rs.kill();
+    let _ = child_rs.wait();
+
+    (tmp, srv_oc, srv_rs)
+}
+
 #[test]
 #[serial]
 fn daemon_preserves_file_acls() {
@@ -445,7 +541,7 @@ fn daemon_inherits_default_acls_rr_client() {
 #[cfg(feature = "root")]
 #[test]
 #[serial]
-fn daemon_acls_match_rsync_server() {
+fn daemon_file_acls_match_rsync_server() {
     if !xattrs_supported() {
         eprintln!("skipping: xattrs unsupported");
         return;
@@ -454,51 +550,25 @@ fn daemon_acls_match_rsync_server() {
         eprintln!("skipping: ACLs unsupported");
         return;
     }
-    let tmp = tempdir().unwrap();
-    let src = tmp.path().join("src");
-    let srv_oc = tmp.path().join("srv_oc");
-    let srv_rs = tmp.path().join("srv_rs");
-    fs::create_dir_all(&src).unwrap();
-    fs::create_dir_all(&srv_oc).unwrap();
-    fs::create_dir_all(&srv_rs).unwrap();
-
-    let src_file = src.join("file");
-    fs::write(&src_file, b"hi").unwrap();
-
-    let mut acl = PosixACL::read_acl(&src_file).unwrap();
-    acl.set(Qualifier::User(12345), ACL_READ);
-    acl.set(Qualifier::User(23456), ACL_WRITE);
-    acl.write_acl(&src_file).unwrap();
-
-    let mut dacl = PosixACL::new(0o755);
-    dacl.set(Qualifier::User(12345), ACL_READ);
-    dacl.write_default_acl(&src).unwrap();
-
-    let (mut child_oc, port_oc) = spawn_daemon(&srv_oc);
-    wait_for_daemon(port_oc);
-    let src_arg = format!("{}/", src.display());
-    Command::cargo_bin("oc-rsync")
-        .unwrap()
-        .args(["-AX", &src_arg, &format!("rsync://127.0.0.1:{port_oc}/mod")])
-        .assert()
-        .success();
-    let _ = child_oc.kill();
-    let _ = child_oc.wait();
-
-    let (mut child_rs, port_rs) = spawn_rsync_daemon(&srv_rs, "");
-    wait_for_daemon(port_rs);
-    Command::cargo_bin("oc-rsync")
-        .unwrap()
-        .args(["-AX", &src_arg, &format!("rsync://127.0.0.1:{port_rs}/mod")])
-        .assert()
-        .success();
-    let _ = child_rs.kill();
-    let _ = child_rs.wait();
-
+    let (_tmp, srv_oc, srv_rs) = sync_daemon_acls_server();
     let acl_oc = PosixACL::read_acl(srv_oc.join("file")).unwrap();
     let acl_rs = PosixACL::read_acl(srv_rs.join("file")).unwrap();
     assert_eq!(acl_oc.entries(), acl_rs.entries());
+}
 
+#[cfg(feature = "root")]
+#[test]
+#[serial]
+fn daemon_default_acls_match_rsync_server() {
+    if !xattrs_supported() {
+        eprintln!("skipping: xattrs unsupported");
+        return;
+    }
+    if !acls_supported() {
+        eprintln!("skipping: ACLs unsupported");
+        return;
+    }
+    let (_tmp, srv_oc, srv_rs) = sync_daemon_acls_server();
     let dacl_oc = PosixACL::read_default_acl(&srv_oc).unwrap();
     let dacl_rs = PosixACL::read_default_acl(&srv_rs).unwrap();
     assert_eq!(dacl_oc.entries(), dacl_rs.entries());
@@ -507,7 +577,7 @@ fn daemon_acls_match_rsync_server() {
 #[cfg(feature = "root")]
 #[test]
 #[serial]
-fn daemon_acls_match_rsync_client() {
+fn daemon_file_acls_match_rsync_client() {
     if !xattrs_supported() {
         eprintln!("skipping: xattrs unsupported");
         return;
@@ -516,55 +586,25 @@ fn daemon_acls_match_rsync_client() {
         eprintln!("skipping: ACLs unsupported");
         return;
     }
-    let tmp = tempdir().unwrap();
-    let src = tmp.path().join("src");
-    let srv_oc = tmp.path().join("srv_oc");
-    let srv_rs = tmp.path().join("srv_rs");
-    fs::create_dir_all(&src).unwrap();
-    fs::create_dir_all(&srv_oc).unwrap();
-    fs::create_dir_all(&srv_rs).unwrap();
-
-    let src_file = src.join("file");
-    fs::write(&src_file, b"hi").unwrap();
-
-    let mut acl = PosixACL::read_acl(&src_file).unwrap();
-    acl.set(Qualifier::User(12345), ACL_READ);
-    acl.set(Qualifier::User(23456), ACL_WRITE);
-    acl.write_acl(&src_file).unwrap();
-
-    let mut dacl = PosixACL::new(0o755);
-    dacl.set(Qualifier::User(12345), ACL_READ);
-    dacl.write_default_acl(&src).unwrap();
-
-    let (mut child_oc, port_oc) = spawn_rsync_daemon(&srv_oc, "");
-    wait_for_daemon(port_oc);
-    let src_arg = format!("{}/", src.display());
-    Command::cargo_bin("oc-rsync")
-        .unwrap()
-        .args([
-            "--acls",
-            &src_arg,
-            &format!("rsync://127.0.0.1:{port_oc}/mod"),
-        ])
-        .assert()
-        .success();
-    let _ = child_oc.kill();
-    let _ = child_oc.wait();
-
-    let (mut child_rs, port_rs) = spawn_rsync_daemon(&srv_rs, "");
-    wait_for_daemon(port_rs);
-    Command::cargo_bin("oc-rsync")
-        .unwrap()
-        .args(["-AX", &src_arg, &format!("rsync://127.0.0.1:{port_rs}/mod")])
-        .assert()
-        .success();
-    let _ = child_rs.kill();
-    let _ = child_rs.wait();
-
+    let (_tmp, srv_oc, srv_rs) = sync_daemon_acls_client();
     let acl_oc = PosixACL::read_acl(srv_oc.join("file")).unwrap();
     let acl_rs = PosixACL::read_acl(srv_rs.join("file")).unwrap();
     assert_eq!(acl_oc.entries(), acl_rs.entries());
+}
 
+#[cfg(feature = "root")]
+#[test]
+#[serial]
+fn daemon_default_acls_match_rsync_client() {
+    if !xattrs_supported() {
+        eprintln!("skipping: xattrs unsupported");
+        return;
+    }
+    if !acls_supported() {
+        eprintln!("skipping: ACLs unsupported");
+        return;
+    }
+    let (_tmp, srv_oc, srv_rs) = sync_daemon_acls_client();
     let dacl_oc = PosixACL::read_default_acl(&srv_oc).unwrap();
     let dacl_rs = PosixACL::read_default_acl(&srv_rs).unwrap();
     assert_eq!(dacl_oc.entries(), dacl_rs.entries());


### PR DESCRIPTION
## Summary
- split daemon ACL parity into file and default ACL tests for server and client directions
- factor shared ACL sync setup into helper functions

## Testing
- `make verify-comments`
- `make lint`
- ⚠️ `cargo nextest run --workspace --no-fail-fast` *(cargo-nextest installation failed)*
- ⚠️ `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(cargo-nextest installation failed)*


------
https://chatgpt.com/codex/tasks/task_e_68c1a1c1f4f88323aec4c73ca969999f