### PR TITLE
Ensure ACLs stripped unless flag set

### DIFF
--- a/crates/engine/src/receiver.rs
+++ b/crates/engine/src/receiver.rs
@@ -573,6 +573,18 @@ impl Receiver {
                         meta::store_fake_super(dest, meta.uid, meta.gid, meta.mode);
                     }
                 }
+            } else if !self.opts.acls {
+                #[cfg(feature = "acl")]
+                {
+                    meta::write_acl(
+                        dest,
+                        &[],
+                        &[],
+                        meta_opts.fake_super && !meta_opts.super_user,
+                        meta_opts.super_user,
+                    )
+                    .map_err(EngineError::from)?;
+                }
             }
         }
         let _ = (src, dest);


### PR DESCRIPTION
## Summary
- remove existing ACLs when `--acls` is not used
- force receiver to clear ACLs when metadata isn't otherwise applied

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: call to unsafe function `set_var`)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: call to unsafe function `set_var`)*
- `cargo nextest run --tests tests/daemon_acls.rs` *(no tests run)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b2065fe48323bdd4481abd1f4c80