### PR TITLE
test: add daemon guard

### DIFF
--- a/tests/common/daemon.rs
+++ b/tests/common/daemon.rs
@@ -10,6 +10,34 @@ use std::process::{Child, Command as StdCommand};
 use std::thread::sleep;
 use std::time::Duration;
 
+pub struct DaemonGuard(Child);
+
+impl DaemonGuard {
+    pub fn spawn(mut cmd: StdCommand) -> Self {
+        Self(cmd.spawn().unwrap())
+    }
+}
+
+impl std::ops::Deref for DaemonGuard {
+    type Target = Child;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for DaemonGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
 pub struct Daemon {
     child: Child,
     pub port: u16,


### PR DESCRIPTION
## Summary
- add DaemonGuard for spawning and cleaning up test daemons
- use DaemonGuard in daemon tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --no-fail-fast -p oc-rsync --test bin_daemon --test daemon_config` *(fails: linking with `cc` failed: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*
- `make verify-comments`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1c0f5a7448323b138a62d1bf3ec53