### PR TITLE
Add repo hygiene scripts and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,19 @@ env:
   COLUMNS: 80
 
 jobs:
+  no-binaries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure no binary files are tracked
+        run: |
+          if git ls-files -z | xargs -0 file --mime | grep -v text; then
+            echo "Binary files detected" >&2
+            exit 1
+          fi
+
   readme-version:
+    needs: [no-binaries]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -61,6 +73,15 @@ jobs:
 
       - name: Verify comments
         run: bash tools/comment_lint.sh
+
+      - name: Enforce file and line limits
+        run: bash tools/enforce_limits.sh
+
+      - name: Check crate layering
+        run: bash tools/check_layers.sh
+
+      - name: Ensure no placeholders remain
+        run: bash tools/no_placeholders.sh
 
       - name: Validate interop matrix docs
         run: scripts/check-run-matrix-docs.sh

--- a/tools/check_layers.sh
+++ b/tools/check_layers.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Detect overly deep crate paths that might indicate layering issues.
+# We flag any `use crate::` path with five or more segments.
+
+if git grep -n 'crate::[^;]*::[^;]*::[^;]*::[^;]*::' -- '*.rs' >/dev/null; then
+  echo "Layer violation detected: overly deep crate path" >&2
+  git grep -n 'crate::[^;]*::[^;]*::[^;]*::[^;]*::' -- '*.rs'
+  exit 1
+fi
+
+echo "Layer check passed"

--- a/tools/enforce_limits.sh
+++ b/tools/enforce_limits.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Enforce basic file and line length limits for tracked Rust source files.
+# The script fails if a file exceeds MAX_LINES lines or contains a line
+# longer than MAX_COLS characters.
+
+MAX_LINES=2000
+MAX_COLS=200
+status=0
+
+while IFS= read -r -d '' file; do
+  lines=$(wc -l < "$file")
+  if (( lines > MAX_LINES )); then
+    echo "$file has $lines lines (limit $MAX_LINES)"
+    status=1
+  fi
+  if grep -nE ".{$((MAX_COLS+1))}" "$file" >/dev/null; then
+    echo "$file contains a line over $MAX_COLS characters"
+    status=1
+  fi
+done < <(git ls-files -z '*.rs')
+
+exit $status

--- a/tools/no_placeholders.sh
+++ b/tools/no_placeholders.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure the repository contains no obvious placeholder tokens.
+if git grep -nE 'REPLACEME|PLACEHOLDER|TBD' -- . >/dev/null; then
+  echo "Placeholder token detected" >&2
+  git grep -nE 'REPLACEME|PLACEHOLDER|TBD' -- .
+  exit 1
+fi
+
+echo "No placeholders found"


### PR DESCRIPTION
## Summary
- enforce basic file length limits for Rust sources
- guard against deep module layering and placeholder tokens
- run new hygiene checks in CI and add a binary-file audit job

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --workspace --no-fail-fast` *(fails: call to unsafe function requires unsafe block)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: call to unsafe function requires unsafe block)*
- `make verify-comments`
- `make lint`
- `bash tools/comment_lint.sh && bash tools/enforce_limits.sh && bash tools/check_layers.sh && bash tools/no_placeholders.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1c6c2ff108323addb4fc0094b6820