### PR TITLE
Handle missing partial basis file

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::collapsible_if)]
 
 use std::io::{Read, Seek};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use checksums::ChecksumConfig;
 use filters::ParseError;
@@ -42,6 +42,8 @@ pub enum EngineError {
     MaxAlloc,
     #[error("{1}")]
     Exit(protocol::ExitCode, String),
+    #[error("partial file missing: {0:?}")]
+    MissingPartial(PathBuf),
     #[error("{0}")]
     Other(String),
 }

--- a/crates/engine/src/sender.rs
+++ b/crates/engine/src/sender.rs
@@ -198,10 +198,10 @@ impl Sender {
         } else {
             None
         };
-        let basis_path = if (self.opts.partial || self.opts.append || self.opts.append_verify)
-            && existing_partial.is_some()
-        {
-            existing_partial.clone().unwrap()
+        let basis_path = if self.opts.partial || self.opts.append || self.opts.append_verify {
+            existing_partial
+                .clone()
+                .ok_or_else(|| EngineError::MissingPartial(partial_path.clone()))?
         } else if self.opts.fuzzy && !dest.exists() {
             fuzzy_match(&dest).unwrap_or_else(|| dest.clone())
         } else {


### PR DESCRIPTION
## Summary
- Avoid panic in sender when partial basis file is missing by returning a structured EngineError instead.
- Add `MissingPartial` variant to EngineError to report absent partial files.

## Testing
- `make verify-comments`
- `make lint`
- `cargo nextest run --workspace --no-fail-fast` *(fails: unresolved import in filters tests)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: missing -lacl library during link)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d3faea788323bd5c7728c0772b9d