### PR TITLE
Add header comment to exec module

### DIFF
--- a/crates/cli/src/exec/mod.rs
+++ b/crates/cli/src/exec/mod.rs
@@ -1,3 +1,4 @@
+// crates/cli/src/exec/mod.rs
 pub(crate) mod privileges;
 pub(crate) mod transfer;
 


### PR DESCRIPTION
## Summary
- add standard path header to `crates/cli/src/exec/mod.rs`

## Testing
- `cargo fmt --all`
- `make lint`
- `make test` *(fails: linking with `cc` failed: cannot find -lacl)*
- `make verify-comments` *(fails: crates/checksums/src/rolling.rs:115: doc comment; crates/engine/src/io.rs:49: additional comments)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f075361c83238916226190710d76