### PR TITLE
Drop listener before spawning daemon in tests

### DIFF
--- a/tests/common/daemon.rs
+++ b/tests/common/daemon.rs
@@ -76,6 +76,7 @@ pub fn spawn_daemon(root: &std::path::Path) -> Daemon {
     let (uid, gid) = (0, 0);
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
+    drop(listener);
     let child = StdCommand::cargo_bin("oc-rsync")
         .unwrap()
         .args([
@@ -93,7 +94,6 @@ pub fn spawn_daemon(root: &std::path::Path) -> Daemon {
         ])
         .spawn()
         .unwrap();
-    drop(listener);
     Daemon { child, port }
 }
 
@@ -104,6 +104,7 @@ pub fn spawn_rsync_daemon(root: &std::path::Path, extra: &str) -> Daemon {
     let (uid, gid) = (0, 0);
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
+    drop(listener);
     let conf = format!(
         "uid = {uid}\ngid = {gid}\nuse chroot = false\n[mod]\n  path = {}\n{}",
         root.display(),
@@ -122,7 +123,6 @@ pub fn spawn_rsync_daemon(root: &std::path::Path, extra: &str) -> Daemon {
         ])
         .spawn()
         .unwrap();
-    drop(listener);
     Daemon { child, port }
 }
 


### PR DESCRIPTION
## Summary
- drop bound TCP listener before spawning test daemon so child can bind

## Testing
- `cargo fmt --all`
- `make lint`
- `make verify-comments`
- `cargo nextest run --workspace --no-fail-fast` *(fails: cannot find -lacl)*
- `cargo nextest run --workspace --no-fail-fast --features "cli nightly"` *(fails: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68c2052626208323a5512b9230e2a4e7