### PR TITLE
refactor check_layers to use ordered layer list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ These packages enable building upstream rsync for interop and provide system lib
 
 ### 2.3 `check_layers` Agent
 - **Script:** `tools/check_layers.sh`
-- **Purpose:** Enforce module **layering**: `checksums, compress, filters, meta, protocol → transport, engine, logging → cli`. No upward deps.
+- **Purpose:** Enforce module **layering**: `checksums → compress → filters → walk → meta → protocol → engine → logging → core → transport → daemon → cli`. No upward deps.
 - **Run locally:**
   ```sh
   bash tools/check_layers.sh


### PR DESCRIPTION
## Summary
- use ordered layer list to detect upward edges in check_layers agent
- document updated layering order

## Testing
- `bash tools/check_layers.sh` *(fails: engine -> logging, engine -> transport)*

------
https://chatgpt.com/codex/tasks/task_e_68c50874d73c83239dd5117e4f7df61f