### PR TITLE
refactor(cli): remove unsafe env manipulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,9 +1036,9 @@ dependencies = [
  "oc-rsync-core",
  "once_cell",
  "regex",
- "scopeguard",
  "serial_test",
  "shell-words",
+ "temp-env",
  "tempfile",
  "textwrap",
  "time",
@@ -1569,6 +1569,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,7 +15,7 @@ textwrap = "0.16"
 time = { version = "0.3", features = ["macros", "parsing"] }
 regex = "1"
 once_cell = "1"
-scopeguard = "1"
+temp-env = "0.3"
 transport = { path = "../transport" }
 daemon = { path = "../daemon" }
 

--- a/crates/cli/src/branding.rs
+++ b/crates/cli/src/branding.rs
@@ -139,30 +139,24 @@ mod tests {
     #[test]
     #[serial]
     fn env_or_option_respects_precedence() {
-        unsafe {
-            std::env::remove_var("BUILD_REVISION");
-        }
-        assert_eq!(env_or_option("BUILD_REVISION"), Some("unknown".to_string()));
+        temp_env::with_var_unset("BUILD_REVISION", || {
+            assert_eq!(env_or_option("BUILD_REVISION"), Some("unknown".to_string()));
 
-        unsafe {
-            std::env::set_var("BUILD_REVISION", "runtime");
-        }
-        assert_eq!(env_or_option("BUILD_REVISION"), Some("runtime".to_string()));
-        unsafe {
-            std::env::remove_var("BUILD_REVISION");
-        }
+            temp_env::with_var("BUILD_REVISION", Some("runtime"), || {
+                assert_eq!(env_or_option("BUILD_REVISION"), Some("runtime".to_string()));
+            });
 
-        assert_eq!(env_or_option("NON_EXISTENT_KEY"), None);
+            assert_eq!(env_or_option("NON_EXISTENT_KEY"), None);
+        });
     }
 
     #[test]
     #[serial]
     fn program_name_defaults_when_unset() {
-        unsafe {
-            std::env::remove_var("OC_RSYNC_NAME");
-        }
-        if option_env!("OC_RSYNC_NAME").is_none() {
-            assert_eq!(program_name(), "oc-rsync");
-        }
+        temp_env::with_var_unset("OC_RSYNC_NAME", || {
+            if option_env!("OC_RSYNC_NAME").is_none() {
+                assert_eq!(program_name(), "oc-rsync");
+            }
+        });
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![doc = include_str!("../../../docs/crates/cli/lib.md")]
 #![allow(clippy::collapsible_if)]
+#![forbid(unsafe_code)]
 #![deny(unsafe_op_in_unsafe_fn, rust_2018_idioms, warnings)]
 
 mod argparse;

--- a/crates/cli/src/utils/mod.rs
+++ b/crates/cli/src/utils/mod.rs
@@ -5,6 +5,8 @@ use std::env;
 use std::ffi::OsString;
 use std::time::{Duration, SystemTime};
 use std::{ffi::OsStr, io, path::PathBuf};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
 
 use crate::EngineError;
 use clap::ArgMatches;
@@ -323,8 +325,9 @@ pub fn parse_remote_spec(input: &OsStr) -> Result<RemoteSpec> {
             .map_err(|_| EngineError::Other(format!("{what} not valid UTF-8")))
     }
 
+    #[cfg(unix)]
     fn path_from_bytes(bytes: &[u8]) -> PathBuf {
-        PathBuf::from(unsafe { OsString::from_encoded_bytes_unchecked(bytes.to_vec()) })
+        PathBuf::from(OsString::from_vec(bytes.to_vec()))
     }
 
     let bytes = input.as_encoded_bytes();

--- a/crates/cli/tests/branding.rs
+++ b/crates/cli/tests/branding.rs
@@ -1,65 +1,60 @@
 // crates/cli/tests/branding.rs
 use oc_rsync_cli::{branding, cli_command, render_help};
 use serial_test::serial;
-use std::env;
-
-fn set_env_var(key: &str, val: &str) {
-    unsafe {
-        env::set_var(key, val);
-    }
-}
-
-fn remove_env_var(key: &str) {
-    unsafe {
-        env::remove_var(key);
-    }
-}
 
 #[test]
 #[serial]
 fn help_uses_program_name() {
-    set_env_var("OC_RSYNC_NAME", "myrsync");
-    set_env_var("COLUMNS", "80");
-    let version = branding::brand_version();
-    let help = render_help(&cli_command());
-    let first = help.lines().next().unwrap();
-    assert_eq!(first, format!("myrsync {}", version));
-    remove_env_var("OC_RSYNC_NAME");
-    remove_env_var("COLUMNS");
+    temp_env::with_vars(
+        [
+            ("OC_RSYNC_NAME", Some("myrsync")),
+            ("COLUMNS", Some("80")),
+        ],
+        || {
+            let version = branding::brand_version();
+            let help = render_help(&cli_command());
+            let first = help.lines().next().unwrap();
+            assert_eq!(first, format!("myrsync {}", version));
+        },
+    );
 }
 
 #[test]
 #[serial]
 fn upstream_name_does_not_replace_rsyncd_conf() {
-    set_env_var("OC_RSYNC_UPSTREAM_NAME", "ursync");
-    set_env_var("COLUMNS", "80");
-    let help = render_help(&cli_command());
-    assert!(help.contains("rsyncd.conf"));
-    assert!(!help.contains("ursyncd.conf"));
-    remove_env_var("OC_RSYNC_UPSTREAM_NAME");
-    remove_env_var("COLUMNS");
+    temp_env::with_vars(
+        [
+            ("OC_RSYNC_UPSTREAM_NAME", Some("ursync")),
+            ("COLUMNS", Some("80")),
+        ],
+        || {
+            let help = render_help(&cli_command());
+            assert!(help.contains("rsyncd.conf"));
+            assert!(!help.contains("ursyncd.conf"));
+        },
+    );
 }
 
 #[test]
 #[serial]
 fn upstream_name_only_replaces_standalone_rsync() {
-    set_env_var("OC_RSYNC_UPSTREAM_NAME", "ursync");
-    set_env_var(
-        "OC_RSYNC_HELP_HEADER",
-        "rsync rsyncs /path/rsync/bin rsync://host\n",
+    temp_env::with_vars(
+        [
+            ("OC_RSYNC_UPSTREAM_NAME", Some("ursync")),
+            (
+                "OC_RSYNC_HELP_HEADER",
+                Some("rsync rsyncs /path/rsync/bin rsync://host\n"),
+            ),
+            ("OC_RSYNC_HELP_FOOTER", Some("")),
+            ("COLUMNS", Some("120")),
+        ],
+        || {
+            let help = render_help(&cli_command());
+
+            assert!(help.contains("ursync rsyncs /path/rsync/bin rsync://host"));
+            assert!(!help.contains("ursyncs"));
+            assert!(!help.contains("/path/ursync/bin"));
+            assert!(!help.contains("ursync://host"));
+        },
     );
-    set_env_var("OC_RSYNC_HELP_FOOTER", "");
-    set_env_var("COLUMNS", "120");
-
-    let help = render_help(&cli_command());
-
-    assert!(help.contains("ursync rsyncs /path/rsync/bin rsync://host"));
-    assert!(!help.contains("ursyncs"));
-    assert!(!help.contains("/path/ursync/bin"));
-    assert!(!help.contains("ursync://host"));
-
-    remove_env_var("OC_RSYNC_UPSTREAM_NAME");
-    remove_env_var("OC_RSYNC_HELP_HEADER");
-    remove_env_var("OC_RSYNC_HELP_FOOTER");
-    remove_env_var("COLUMNS");
 }

--- a/crates/cli/tests/help_formatting.rs
+++ b/crates/cli/tests/help_formatting.rs
@@ -2,19 +2,6 @@
 use oc_rsync_cli::{cli_command, dump_help_body, render_help};
 use serial_test::serial;
 use std::collections::HashSet;
-use std::env;
-
-fn set_env_var(key: &str, val: &str) {
-    unsafe {
-        env::set_var(key, val);
-    }
-}
-
-fn remove_env_var(key: &str) {
-    unsafe {
-        env::remove_var(key);
-    }
-}
 
 fn extract_options(help: &str) -> String {
     let mut out = String::new();
@@ -55,9 +42,7 @@ fn dump_help_body_lists_unique_options() {
 #[serial]
 fn help_wrapping_matches_upstream_80() {
     let cmd = cli_command();
-    set_env_var("COLUMNS", "80");
-    let ours = render_help(&cmd);
-    remove_env_var("COLUMNS");
+    let ours = temp_env::with_var("COLUMNS", Some("80"), || render_help(&cmd));
     let upstream = include_str!("../../../tests/golden/help/rsync-help-80.txt");
     assert_eq!(extract_options(&ours), extract_options(upstream));
 }
@@ -66,9 +51,7 @@ fn help_wrapping_matches_upstream_80() {
 #[serial]
 fn help_wrapping_matches_upstream_100() {
     let cmd = cli_command();
-    set_env_var("COLUMNS", "100");
-    let ours = render_help(&cmd);
-    remove_env_var("COLUMNS");
+    let ours = temp_env::with_var("COLUMNS", Some("100"), || render_help(&cmd));
     let upstream = include_str!("../../../tests/golden/help/rsync-help-100.txt");
     assert_eq!(extract_options(&ours), extract_options(upstream));
 }
@@ -79,9 +62,7 @@ fn dump_help_body_matches_render_help() {
     let cmd = cli_command();
     let body = dump_help_body(&cmd);
 
-    set_env_var("COLUMNS", "80");
-    let full = render_help(&cmd);
-    remove_env_var("COLUMNS");
+    let full = temp_env::with_var("COLUMNS", Some("80"), || render_help(&cmd));
 
     assert_eq!(body, extract_options(&full));
 }

--- a/crates/cli/tests/options_validation.rs
+++ b/crates/cli/tests/options_validation.rs
@@ -1,19 +1,6 @@
 // crates/cli/tests/options_validation.rs
 use oc_rsync_cli::{ClientOptsBuilder, cli_command, validate_paths};
 use serial_test::serial;
-use std::env;
-
-fn set_env_var(key: &str, val: &str) {
-    unsafe {
-        env::set_var(key, val);
-    }
-}
-
-fn remove_env_var(key: &str) {
-    unsafe {
-        env::remove_var(key);
-    }
-}
 
 #[test]
 fn builder_sets_no_d_alias() {
@@ -28,13 +15,13 @@ fn builder_sets_no_d_alias() {
 #[test]
 #[serial]
 fn builder_respects_protect_args_env() {
-    set_env_var("RSYNC_PROTECT_ARGS", "1");
-    let matches = cli_command()
-        .try_get_matches_from(["prog", "src", "dst"])
-        .unwrap();
-    let opts = ClientOptsBuilder::from_matches(&matches).build().unwrap();
-    assert!(opts.secluded_args);
-    remove_env_var("RSYNC_PROTECT_ARGS");
+    temp_env::with_var("RSYNC_PROTECT_ARGS", Some("1"), || {
+        let matches = cli_command()
+            .try_get_matches_from(["prog", "src", "dst"])
+            .unwrap();
+        let opts = ClientOptsBuilder::from_matches(&matches).build().unwrap();
+        assert!(opts.secluded_args);
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- remove unsafe env var helpers in formatter and use `temp_env`
- add safe env handling in branding and CLI tests
- forbid unsafe code in CLI crate and replace remaining unsafe path conversion

## Testing
- `cargo fmt --all -- --check`
- `bash tools/comment_lint.sh` *(passes)*
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines (max 600))*
- `bash tools/check_layers.sh` *(fails: engine -> logging, engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo test -p oc-rsync-cli` *(fails: missing fields `xattr_filter`, `xattr_filter_delete` in engine)*

------
https://chatgpt.com/codex/tasks/task_e_68c50b7e648c8323a5f5bc394b42a0c3