### PR TITLE
chore(core): enforce safety and idiom lints

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,7 @@
 // crates/core/src/lib.rs
 #![doc = include_str!("../../../docs/crates/core/overview.md")]
+#![forbid(unsafe_code)]
+#![deny(rust_2018_idioms, warnings)]
 
 pub mod fs {
     pub use meta::*;


### PR DESCRIPTION
## Summary
- enforce safe and idiomatic Rust in core crate

## Testing
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines (max 600))*
- `bash tools/check_layers.sh` *(fails: engine -> logging; engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo check -p oc-rsync-core` *(fails: missing fields in engine::receiver::metadata)*
- `cargo test -p oc-rsync-core` *(fails: missing fields in engine::receiver::metadata)*


------
https://chatgpt.com/codex/tasks/task_e_68c50ebee0a88323b0e60298e9cdda26