### PR TITLE
Document safety for unsafe blocks

### DIFF
--- a/crates/checksums/src/rolling.rs
+++ b/crates/checksums/src/rolling.rs
@@ -20,6 +20,7 @@ struct Sse42;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 impl RollingChecksum for Sse42 {
     fn checksum(&self, data: &[u8], seed: u32) -> u32 {
+        // SAFETY: CPU feature detection ensures SSE4.2 support and the data slice is valid.
         unsafe { rolling_checksum_sse42(data, seed) }
     }
 }
@@ -30,6 +31,7 @@ struct Avx2;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 impl RollingChecksum for Avx2 {
     fn checksum(&self, data: &[u8], seed: u32) -> u32 {
+        // SAFETY: CPU feature detection ensures AVX2 support and the data slice is valid.
         unsafe { rolling_checksum_avx2(data, seed) }
     }
 }
@@ -48,6 +50,7 @@ struct Avx512;
 ))]
 impl RollingChecksum for Avx512 {
     fn checksum(&self, data: &[u8], seed: u32) -> u32 {
+        // SAFETY: CPU feature detection ensures AVX512 support and the data slice is valid.
         unsafe { rolling_checksum_avx512(data, seed) }
     }
 }

--- a/crates/engine/src/io.rs
+++ b/crates/engine/src/io.rs
@@ -42,6 +42,7 @@ pub fn preallocate(file: &File, len: u64) -> std::io::Result<()> {
     #[cfg(target_os = "macos")]
     {
         use std::os::fd::AsRawFd;
+        // SAFETY: `file` provides a valid descriptor and all libc calls check their return values.
         unsafe {
             let fd = file.as_raw_fd();
             let mut fstore = libc::fstore_t {
@@ -79,6 +80,7 @@ pub fn preallocate(file: &File, len: u64) -> std::io::Result<()> {
     ))]
     {
         use std::os::fd::AsRawFd;
+        // SAFETY: `file` yields a valid descriptor and `posix_fallocate` is checked for errors.
         unsafe {
             let ret = libc::posix_fallocate(file.as_raw_fd(), 0, len as libc::off_t);
             if ret == 0 {

--- a/crates/meta/src/unix/acl.rs
+++ b/crates/meta/src/unix/acl.rs
@@ -101,6 +101,7 @@ pub(crate) fn remove_default_acl(path: &Path) -> io::Result<()> {
     }
 
     let c_path = CString::new(path.as_os_str().as_bytes())?;
+    // SAFETY: `c_path` is a valid, null-terminated C string.
     let ret = unsafe { acl_delete_def_file(c_path.as_ptr()) };
     if ret == 0 {
         Ok(())

--- a/crates/transport/src/tcp.rs
+++ b/crates/transport/src/tcp.rs
@@ -377,6 +377,7 @@ fn borrow_fd(fd: RawFd) -> io::Result<BorrowedFd<'static>> {
             "file descriptor must be non-negative",
         ));
     }
+    // SAFETY: `fd` has been checked to be non-negative and is assumed to remain valid.
     Ok(unsafe { BorrowedFd::borrow_raw(fd) })
 }
 

--- a/src/bin/oc-rsync/stdio.rs
+++ b/src/bin/oc-rsync/stdio.rs
@@ -15,6 +15,7 @@ unsafe extern "C" {
 
 #[cfg(not(target_os = "windows"))]
 fn stdout_stream() -> io::Result<NonNull<libc::FILE>> {
+    // SAFETY: `stdout` is provided by the C runtime and assumed to be a valid pointer.
     unsafe {
         NonNull::new(stdout).ok_or_else(|| io::Error::new(ErrorKind::BrokenPipe, "stdout is null"))
     }
@@ -22,6 +23,7 @@ fn stdout_stream() -> io::Result<NonNull<libc::FILE>> {
 
 #[cfg(not(target_os = "windows"))]
 fn stderr_stream() -> io::Result<NonNull<libc::FILE>> {
+    // SAFETY: `stderr` is provided by the C runtime and assumed to be a valid pointer.
     unsafe {
         NonNull::new(stderr).ok_or_else(|| io::Error::new(ErrorKind::BrokenPipe, "stderr is null"))
     }
@@ -29,6 +31,7 @@ fn stderr_stream() -> io::Result<NonNull<libc::FILE>> {
 
 #[cfg(target_os = "windows")]
 fn stdout_stream() -> io::Result<NonNull<libc::FILE>> {
+    // SAFETY: `__acrt_iob_func` returns a valid pointer for stdout when called with index 1.
     unsafe {
         extern "C" {
             fn __acrt_iob_func(idx: libc::c_uint) -> *mut libc::FILE;
@@ -40,6 +43,7 @@ fn stdout_stream() -> io::Result<NonNull<libc::FILE>> {
 
 #[cfg(target_os = "windows")]
 fn stderr_stream() -> io::Result<NonNull<libc::FILE>> {
+    // SAFETY: `__acrt_iob_func` returns a valid pointer for stderr when called with index 2.
     unsafe {
         extern "C" {
             fn __acrt_iob_func(idx: libc::c_uint) -> *mut libc::FILE;
@@ -53,6 +57,7 @@ pub(crate) fn set_stream_buffer(stream: *mut libc::FILE, mode: libc::c_int) -> i
     if stream.is_null() {
         return Err(io::Error::new(ErrorKind::BrokenPipe, "stream is null"));
     }
+    // SAFETY: `stream` was validated as non-null and the buffer arguments are well-formed.
     let ret = unsafe { libc::setvbuf(stream, ptr::null_mut(), mode, 0) };
     if ret == 0 {
         Ok(())


### PR DESCRIPTION
## Summary
- annotate unsafe blocks across the codebase with `// SAFETY:` rationales
- clarify macOS and POSIX file preallocation safety in engine I/O
- explain file descriptor borrowing safety in SSH transport

## Testing
- `cargo fmt --all -- --check` *(fails: crates/daemon/src/service.rs not formatted; transport/src/ssh/io.rs import order)*
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `bash tools/comment_lint.sh` *(fails: contains // comments)*
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs 746 lines)*
- `bash tools/check_layers.sh` *(fails: engine -> logging; engine -> transport)*
- `bash tools/no_placeholders.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c523fd70d48323841423e3d5455f44