### PR TITLE
Exempt SAFETY comments in comment lint

### DIFF
--- a/tools/comment_lint.sh
+++ b/tools/comment_lint.sh
@@ -11,7 +11,10 @@ while IFS= read -r -d '' file; do
         fail=1
         continue
     fi
-    if tail -n +2 "$file" | grep -E '^[[:space:]]*//' | grep -vE '^[[:space:]]*///' >/dev/null; then
+    if tail -n +2 "$file" \
+        | grep -E '^[[:space:]]*//' \
+        | grep -vE '^[[:space:]]*///' \
+        | grep -vE '^[[:space:]]*//[[:space:]]*SAFETY:' >/dev/null; then
         echo "$file: contains // comments" >&2
         fail=1
     fi


### PR DESCRIPTION
## Summary
- Allow `// SAFETY:` comments in the comment lint script alongside existing `///` exceptions.

## Testing
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines)*
- `bash tools/check_layers.sh` *(fails: engine -> logging; engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check` *(reports diff)*
- `cargo clippy --workspace --all-targets -- -Dwarnings`


------
https://chatgpt.com/codex/tasks/task_e_68c52f6911e8832382615521e0d46d2c