### PR TITLE
Fix hard link handling for multiple paths

### DIFF
--- a/crates/engine/tests/links.rs
+++ b/crates/engine/tests/links.rs
@@ -20,6 +20,8 @@ fn hard_links_grouped() {
     fs::write(&file1, b"hi").unwrap();
     let file2 = src.join("b");
     fs::hard_link(&file1, &file2).unwrap();
+    let file3 = src.join("c");
+    fs::hard_link(&file1, &file3).unwrap();
     sync(
         &src,
         &dst,
@@ -33,7 +35,9 @@ fn hard_links_grouped() {
     .unwrap();
     let meta1 = fs::symlink_metadata(dst.join("a")).unwrap();
     let meta2 = fs::symlink_metadata(dst.join("b")).unwrap();
+    let meta3 = fs::symlink_metadata(dst.join("c")).unwrap();
     assert_eq!(meta1.ino(), meta2.ino());
+    assert_eq!(meta1.ino(), meta3.ino());
 }
 
 #[test]

--- a/crates/meta/src/lib.rs
+++ b/crates/meta/src/lib.rs
@@ -182,7 +182,7 @@ pub fn hard_link_id(dev: u64, ino: u64) -> u64 {
 #[cfg(unix)]
 #[derive(Debug, Default)]
 pub struct HardLinks {
-    map: HashMap<u64, (PathBuf, Vec<PathBuf>)>,
+    map: HashMap<u64, Vec<PathBuf>>,
 }
 
 #[cfg(unix)]
@@ -190,29 +190,26 @@ impl HardLinks {
     pub fn register(&mut self, id: u64, path: &Path) -> bool {
         match self.map.entry(id) {
             Entry::Occupied(mut e) => {
-                let (ref first, ref mut others) = *e.get_mut();
-                if path != first && !others.iter().any(|p| p == path) {
-                    others.push(path.to_path_buf());
+                let paths = e.get_mut();
+                if !paths.iter().any(|p| p == path) {
+                    paths.push(path.to_path_buf());
                 }
                 false
             }
             Entry::Vacant(v) => {
-                v.insert((path.to_path_buf(), Vec::new()));
+                v.insert(vec![path.to_path_buf()]);
                 true
             }
         }
     }
 
     pub fn finalize(&mut self) -> io::Result<()> {
-        for (_, (first, mut others)) in std::mem::take(&mut self.map) {
-            let src = if first.exists() {
-                first
-            } else if let Some(pos) = others.iter().position(|p| p.exists()) {
-                others.remove(pos)
-            } else {
+        for (_, mut paths) in std::mem::take(&mut self.map) {
+            let Some(src_idx) = paths.iter().position(|p| p.exists()) else {
                 continue;
             };
-            for dest in others {
+            let src = paths.remove(src_idx);
+            for dest in paths {
                 if dest.exists() {
                     fs::remove_file(&dest)?;
                 }


### PR DESCRIPTION
## Summary
- track all paths for each hard-link group and relink them on finalize
- cover three-member link groups in engine tests

## Testing
- `cargo test daemon_preserves_hard_links_multiple -- --nocapture` *(fails: No such file or directory)*
- `cargo test --workspace` *(fails: append_verify_errors_when_destination_missing, append_errors_when_destination_missing)*
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines (max 600))*
- `MAX_RUST_LINES=800 bash tools/enforce_limits.sh`
- `bash tools/check_layers.sh` *(fails: engine -> logging; engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -Dwarnings`


------
https://chatgpt.com/codex/tasks/task_e_68c535ef4fbc8323b950ae4798d4f52c