### PR TITLE
test: fix module root path for daemon hard links

### DIFF
--- a/tests/daemon_hard_links.rs
+++ b/tests/daemon_hard_links.rs
@@ -30,7 +30,7 @@ fn daemon_preserves_hard_links_multiple() {
     wait_for_daemon(&mut daemon);
 
     let src_arg = format!("{}/", src.display());
-    let dest = format!("rsync://127.0.0.1:{port}/mod");
+    let dest = format!("rsync://127.0.0.1:{port}/mod/");
     Command::cargo_bin("oc-rsync")
         .unwrap()
         .args(["-aH", &src_arg, &dest])


### PR DESCRIPTION
## Summary
- fix daemon hard link test to sync into module root

## Testing
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines (max 600))*
- `bash tools/check_layers.sh` *(fails: engine -> logging; engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check` *(fails: formatting diffs printed)*
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo nextest run tests/daemon_hard_links.rs::daemon_preserves_hard_links_multiple` *(fails: linking with cc failed: cannot find -lacl)*

------
https://chatgpt.com/codex/tasks/task_e_68c541062a408323b1aaedf6b6311d45