### PR TITLE
test: serialize daemon hard link test

### DIFF
--- a/tests/daemon_hard_links.rs
+++ b/tests/daemon_hard_links.rs
@@ -1,5 +1,6 @@
 // tests/daemon_hard_links.rs
 use assert_cmd::Command;
+use serial_test::serial;
 use std::fs;
 use tempfile::tempdir;
 
@@ -11,6 +12,7 @@ use common::daemon::{spawn_daemon, wait_for_daemon};
 
 #[cfg(unix)]
 #[test]
+#[serial]
 fn daemon_preserves_hard_links_multiple() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");


### PR DESCRIPTION
## Summary
- ensure daemon hard link test runs serially to avoid interference

## Testing
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` (fails: crates/cli/src/argparse/flags.rs: 746 lines)
- `bash tools/check_layers.sh` (fails: engine -> logging, engine -> transport)
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check` (fails: formatting differences)
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo nextest run tests/daemon_hard_links.rs::daemon_preserves_hard_links_multiple` (fails: could not find libacl, linking failed)


------
https://chatgpt.com/codex/tasks/task_e_68c54327581083238e11e036cc05363a