### PR TITLE
Skip local directory operations for remote destinations

### DIFF
--- a/tests/remote_daemon_hard_links.rs
+++ b/tests/remote_daemon_hard_links.rs
@@ -1,19 +1,20 @@
-// tests/daemon_hard_links.rs
+// tests/remote_daemon_hard_links.rs
+#![cfg(unix)]
+
 use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin;
 use serial_test::serial;
 use std::fs;
-use tempfile::tempdir;
-
-#[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
+use tempfile::tempdir;
 
 mod common;
 use common::daemon::{spawn_daemon, wait_for_daemon};
 
-#[cfg(unix)]
 #[test]
 #[serial]
-fn daemon_preserves_hard_links_multiple() {
+fn remote_source_to_daemon_preserves_hard_links_without_local_dirs() {
     let tmp = tempdir().unwrap();
     let src = tmp.path().join("src");
     let srv = tmp.path().join("srv");
@@ -31,12 +32,20 @@ fn daemon_preserves_hard_links_multiple() {
     let port = daemon.port;
     wait_for_daemon(&mut daemon);
 
-    let src_arg = format!("{}/", src.display());
+    let rsh = tmp.path().join("fake_rsh.sh");
+    fs::write(&rsh, b"#!/bin/sh\nshift\nexec \"$@\"\n").unwrap();
+    fs::set_permissions(&rsh, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let src_arg = format!("fake:{}/", src.display());
     let dest = format!("rsync://127.0.0.1:{port}/mod/");
-    Command::cargo_bin("oc-rsync")
-        .unwrap()
+
+    let rr_bin = cargo_bin("oc-rsync");
+    let rr_dir = rr_bin.parent().unwrap();
+    let path_env = format!("{}:{}", rr_dir.display(), std::env::var("PATH").unwrap());
+    Command::new(rr_bin)
+        .env("PATH", path_env)
         .current_dir(&tmp)
-        .args(["-aH", &src_arg, &dest])
+        .args(["-aH", "--rsh", rsh.to_str().unwrap(), &src_arg, &dest])
         .assert()
         .success();
 


### PR DESCRIPTION
## Summary
- handle remote destination paths without touching the local filesystem
- test daemon hard link transfers for remote destinations

## Testing
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines > 600)*
- `bash tools/check_layers.sh`
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check` *(reports formatting differences)*
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo llvm-cov --workspace --lcov --output-path coverage.lcov --fail-under-lines 95` *(linking with `cc` failed)*
- `cargo test --test daemon_hard_links --test remote_daemon_hard_links` *(linking with `cc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c54dfe9ad083239352ac60a4fc7584