### PR TITLE
Add test for parsing rsync module roots

### DIFF
--- a/crates/cli/tests/remote_spec.rs
+++ b/crates/cli/tests/remote_spec.rs
@@ -1,0 +1,16 @@
+// crates/cli/tests/remote_spec.rs
+use oc_rsync_cli::{RemoteSpec, parse_remote_spec};
+use std::ffi::OsStr;
+use std::path::Path;
+
+#[test]
+fn parses_rsync_module_with_root_path() {
+    let spec = parse_remote_spec(OsStr::new("rsync://host/mod/")).unwrap();
+    match spec {
+        RemoteSpec::Remote { module, path, .. } => {
+            assert_eq!(module.as_deref(), Some("mod"));
+            assert_eq!(path.path, Path::new("."));
+        }
+        RemoteSpec::Local(_) => panic!("expected RemoteSpec::Remote"),
+    }
+}


### PR DESCRIPTION
## Summary
- add regression test for parsing `rsync://host/mod/`

## Testing
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines)*
- `bash tools/check_layers.sh` *(fails: engine -> logging, engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo llvm-cov --workspace --lcov --output-path coverage.lcov --fail-under-lines 95` *(fails: linking with `cc` failed: cannot find -lacl)*
- `cargo test -p oc-rsync-cli` *(fails: could not compile `engine`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5523a2310832381455778655866d4