### PR TITLE
Handle rsync URL paths

### DIFF
--- a/crates/cli/src/exec/transfer.rs
+++ b/crates/cli/src/exec/transfer.rs
@@ -1,6 +1,7 @@
 // crates/cli/src/exec/transfer.rs
 
-use std::path::{Path, PathBuf};
+use std::ffi::OsString;
+use std::path::Path;
 
 use crate::options::ClientOpts;
 use crate::utils::{RemoteSpec, RshCommand};
@@ -51,9 +52,9 @@ pub(crate) fn execute_transfer(
             RemoteSpec::Local(dst),
         ) => {
             let remote_src =
-                PathBuf::from(format!("rsync://{host}/{module}/{}", src.path.display()));
+                OsString::from(format!("rsync://{host}/{module}/{}", src.path.display()));
             sync(
-                &remote_src,
+                Path::new(&remote_src),
                 &dst.path,
                 matcher,
                 &available_codecs(),
@@ -118,10 +119,10 @@ pub(crate) fn execute_transfer(
             },
         ) => {
             let remote_dst =
-                PathBuf::from(format!("rsync://{host}/{module}/{}", dst.path.display()));
+                OsString::from(format!("rsync://{host}/{module}/{}", dst.path.display()));
             sync(
                 &src.path,
-                &remote_dst,
+                Path::new(&remote_dst),
                 matcher,
                 &available_codecs(),
                 sync_opts,

--- a/crates/engine/src/session/run.rs
+++ b/crates/engine/src/session/run.rs
@@ -249,8 +249,8 @@ pub fn sync(
         .write_batch
         .as_ref()
         .and_then(|p| OpenOptions::new().create(true).append(true).open(p).ok());
-    let src_is_remote = is_remote_spec(src);
-    let dst_is_remote = is_remote_spec(dst);
+    let src_is_remote = is_remote_spec(src.as_os_str());
+    let dst_is_remote = is_remote_spec(dst.as_os_str());
     let src_root = if src_is_remote {
         src.to_path_buf()
     } else {

--- a/crates/engine/src/session/setup.rs
+++ b/crates/engine/src/session/setup.rs
@@ -1,6 +1,7 @@
 // crates/engine/src/session/setup.rs
 
 use std::fs;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use compress::Codec;
@@ -11,9 +12,9 @@ use crate::Result;
 
 use super::SyncOptions;
 
-pub(crate) fn is_remote_spec(path: &Path) -> bool {
+pub(crate) fn is_remote_spec(path: &OsStr) -> bool {
     if let Some(s) = path.to_str() {
-        if s.starts_with("rsync://") {
+        if s.starts_with("rsync://") || s.starts_with("rsync:/") {
             return true;
         }
         if s.starts_with('[') && s.contains("]:") {

--- a/tests/daemon_hard_links.rs
+++ b/tests/daemon_hard_links.rs
@@ -40,6 +40,7 @@ fn daemon_preserves_hard_links_multiple() {
         .assert()
         .success();
 
+    assert!(module.join("a").exists());
     assert!(!tmp.path().join("rsync:").exists());
 
     let ino_a = fs::metadata(module.join("a")).expect("stat a").ino();

--- a/tests/daemon_hard_links_subdir.rs
+++ b/tests/daemon_hard_links_subdir.rs
@@ -39,8 +39,9 @@ fn daemon_preserves_hard_links_in_subdir() {
         .args(["-aH", &src_arg, &dest])
         .assert()
         .success();
-
     let sub = module.join("sub");
+    assert!(sub.join("a").exists());
+    assert!(!tmp.path().join("rsync:").exists());
     let ino_a = fs::metadata(sub.join("a")).expect("stat a").ino();
     let ino_b = fs::metadata(sub.join("b")).expect("stat b").ino();
     let ino_c = fs::metadata(sub.join("c")).expect("stat c").ino();

--- a/tests/daemon_sync_attrs.rs
+++ b/tests/daemon_sync_attrs.rs
@@ -49,7 +49,8 @@ fn daemon_preserves_uid_gid_perms() {
         .args(["-a", &src_arg, &format!("rsync://127.0.0.1:{port}/mod")])
         .assert()
         .success();
-
+    assert!(module.join("file").exists());
+    assert!(!tmp.path().join("rsync:").exists());
     let meta = fs::symlink_metadata(module.join("file")).expect("stat file");
     assert_eq!(meta.permissions().mode() & 0o777, 0o741);
     assert_eq!(meta.uid(), 1);
@@ -80,6 +81,8 @@ fn daemon_preserves_hard_links_rr_client() {
         .args(["-aH", &src_arg, &dest])
         .assert()
         .success();
+    assert!(module.join("a").exists());
+    assert!(!tmp.path().join("rsync:").exists());
     let meta1 = fs::symlink_metadata(module.join("a")).expect("stat a");
     let meta2 = fs::symlink_metadata(module.join("b")).expect("stat b");
     assert_eq!(meta1.ino(), meta2.ino());


### PR DESCRIPTION
## Summary
- preserve `rsync://` prefix when constructing remote paths
- ensure rsync URL specs are treated as remote
- test that daemon transfers populate the module and avoid stray `rsync:` dirs

## Testing
- `cargo fmt --all -- --check` *(fails: transport/src/ssh/io.rs requires reformatting)*
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs exceeds line limit)*
- `bash tools/check_layers.sh` *(fails: engine -> logging, engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo nextest run --test daemon_hard_links --test daemon_hard_links_subdir --test daemon_sync_attrs` *(fails: daemon tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c5596bfc44832390759294f5ecb526