### PR TITLE
cli: gate dump-help arg imports

### DIFF
--- a/crates/cli/src/argparse/builder.rs
+++ b/crates/cli/src/argparse/builder.rs
@@ -2,10 +2,12 @@
 
 use std::env;
 
-use clap::{Arg, ArgAction, ArgMatches, Args, CommandFactory, FromArgMatches, parser::ValueSource};
+use clap::{parser::ValueSource, ArgMatches, Args, CommandFactory, FromArgMatches};
+#[cfg(any(test, feature = "dump-help"))]
+use clap::{Arg, ArgAction};
 
-use crate::EngineError;
 use crate::formatter;
+use crate::EngineError;
 use oc_rsync_core::transfer::Result;
 
 use super::{ClientOpts, ProbeOpts};


### PR DESCRIPTION
## Summary
- gate dump-help Arg and ArgAction imports behind `cfg(test or feature = "dump-help")`

## Testing
- `bash tools/comment_lint.sh`
- `bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines (max 600))*
- `bash tools/check_layers.sh` *(fails: engine -> logging; engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check` *(fails: diff produced)*
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo build`
- `cargo nextest run` *(fails: archive_matches_combination_and_rsync, archive_respects_no_options)*

------
https://chatgpt.com/codex/tasks/task_e_68c55e2f23e48323afd8c257ed2b507f