### PR TITLE
tests: allow daemon writes

### DIFF
--- a/tests/common/daemon.rs
+++ b/tests/common/daemon.rs
@@ -94,7 +94,7 @@ pub fn spawn_daemon(root: &std::path::Path) -> Daemon {
             "--no-detach",
             "--module",
             &format!(
-                "mod={},uid={},gid={},use-chroot=no",
+                "mod={},uid={},gid={},use-chroot=no,read-only=no",
                 root.display(),
                 uid,
                 gid


### PR DESCRIPTION
## Summary
- ensure test helper uses a write-enabled module

## Testing
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines)*
- `MAX_RUST_LINES=1000 bash tools/enforce_limits.sh`
- `bash tools/check_layers.sh` *(fails: engine -> logging; engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check` *(fails: formatting diffs in workspace)*
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo test` *(fails: archive_matches_combination_and_rsync, archive_respects_no_options)*
- `cargo test --test daemon`
- `cargo test --test daemon_network`


------
https://chatgpt.com/codex/tasks/task_e_68c5906822c08323b705a670be5fa8f1