### PR TITLE
feat(core): centralize remote spec parsing

### DIFF
--- a/crates/cli/src/argparse/validation.rs
+++ b/crates/cli/src/argparse/validation.rs
@@ -1,8 +1,7 @@
 // crates/cli/src/argparse/validation.rs
 use std::ffi::OsString;
 
-use crate::utils::parse_remote_spec;
-use crate::{EngineError, RemoteSpec};
+use crate::{EngineError, RemoteSpec, parse_remote_spec};
 use oc_rsync_core::message::ExitCode;
 use oc_rsync_core::transfer::Result;
 

--- a/crates/cli/src/client/run.rs
+++ b/crates/cli/src/client/run.rs
@@ -57,9 +57,10 @@ pub(crate) fn run_client(opts: ClientOpts, matches: &ArgMatches) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::{RemoteSpec, parse_bool, parse_remote_spec};
+    use crate::utils::parse_bool;
     #[allow(unused_imports)]
     use crate::{EngineError, cli_command, spawn_daemon_session};
+    use crate::{RemoteSpec, parse_remote_spec};
     use clap::{FromArgMatches, Parser};
     #[allow(unused_imports)]
     use daemon::authenticate;

--- a/crates/cli/src/exec/transfer.rs
+++ b/crates/cli/src/exec/transfer.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 
 use crate::EngineError;
 use crate::options::ClientOpts;
-use crate::utils::{PathSpec, RemoteSpec, RshCommand};
+use crate::utils::RshCommand;
+use crate::{PathSpec, RemoteSpec};
 
 use oc_rsync_core::{
     compress::available_codecs,
@@ -224,8 +225,8 @@ pub(crate) fn execute_transfer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PathSpec;
     use crate::options::cli_command;
-    use crate::utils::PathSpec;
     use clap::FromArgMatches;
     use std::fs;
     use std::path::PathBuf;

--- a/crates/cli/src/exec/transfer/remote_remote.rs
+++ b/crates/cli/src/exec/transfer/remote_remote.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 
 use crate::options::ClientOpts;
 use crate::session::check_session_errors;
-use crate::utils::{PathSpec, RshCommand};
-use crate::{EngineError, spawn_daemon_session};
+use crate::utils::RshCommand;
+use crate::{EngineError, PathSpec, spawn_daemon_session};
 use oc_rsync_core::{
     config::SyncOptions,
     message::CharsetConv,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -27,12 +27,10 @@ pub use client::run;
 pub use daemon::spawn_daemon_session;
 pub use formatter::{ARG_ORDER, dump_help_body, render_help};
 pub use oc_rsync_core::transfer::EngineError;
+pub use oc_rsync_core::{PathSpec, RemoteSpec, is_remote_spec, parse_remote_spec};
 pub use options::{
     ClientOptsBuilder, ProbeOptsBuilder, cli_command, exit_code_from_engine_error,
     exit_code_from_error_kind, validate_paths,
 };
 pub use print::handle_clap_error;
-pub use utils::{
-    PathSpec, RemoteSpec, parse_iconv, parse_logging_flags, parse_remote_spec, parse_rsh,
-    print_version_if_requested,
-};
+pub use utils::{parse_iconv, parse_logging_flags, parse_rsh, print_version_if_requested};

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -39,3 +39,5 @@ pub mod compress {
 pub mod checksums {
     pub use checksums::*;
 }
+
+pub use engine::{PathSpec, RemoteSpec, is_remote_spec, parse_remote_spec};

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -13,6 +13,7 @@ mod cleanup;
 pub use cleanup::fuzzy_match;
 mod delta;
 mod receiver;
+pub mod remote;
 mod sender;
 
 pub mod batch;
@@ -31,6 +32,7 @@ pub use checksums::StrongHash;
 pub use delta::{DeltaIter, Op, compute_delta};
 pub use meta::MetaOpts;
 pub use receiver::{Receiver, ReceiverState};
+pub use remote::{PathSpec, RemoteSpec, is_remote_spec, parse_remote_spec};
 pub use sender::{Sender, SenderState};
 pub const META_OPTS: MetaOpts = meta::META_OPTS;
 

--- a/crates/engine/src/remote.rs
+++ b/crates/engine/src/remote.rs
@@ -1,0 +1,193 @@
+// crates/engine/src/remote.rs
+
+use std::ffi::OsStr;
+use std::path::PathBuf;
+
+use crate::EngineError;
+#[cfg(unix)]
+use std::ffi::OsString;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathSpec {
+    pub path: PathBuf,
+    pub trailing_slash: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemoteSpec {
+    Local(PathSpec),
+    Remote {
+        host: String,
+        path: PathSpec,
+        module: Option<String>,
+    },
+}
+
+#[cfg(unix)]
+fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+    PathBuf::from(OsString::from_vec(bytes.to_vec()))
+}
+
+#[cfg(not(unix))]
+fn path_from_bytes(bytes: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(bytes).to_string())
+}
+
+fn bytes_to_string(bytes: &[u8], what: &str) -> Result<String, EngineError> {
+    std::str::from_utf8(bytes)
+        .map(|s| s.to_string())
+        .map_err(|_| EngineError::Other(format!("{what} not valid UTF-8")))
+}
+
+pub fn parse_remote_spec(input: &OsStr) -> Result<RemoteSpec, EngineError> {
+    let bytes = input.as_encoded_bytes();
+    let (trailing_slash, s) = if bytes != b"/" && bytes.ends_with(b"/") {
+        (true, &bytes[..bytes.len() - 1])
+    } else {
+        (false, bytes)
+    };
+    if let Some(rest) = s.strip_prefix(b"rsync://") {
+        let mut parts = rest.splitn(2, |&b| b == b'/');
+        let host = parts.next().unwrap_or(&[]);
+        let mod_path = parts.next().unwrap_or(&[]);
+        let mut mp = mod_path.splitn(2, |&b| b == b'/');
+        let module = mp.next().unwrap_or(&[]);
+        let path = mp.next().unwrap_or(&[]);
+        let path = if path.is_empty() { b"." } else { path };
+        if host.is_empty() {
+            return Err(EngineError::Other("remote host missing".into()));
+        }
+        if module.is_empty() {
+            return Err(EngineError::Other("remote module missing".into()));
+        }
+        return Ok(RemoteSpec::Remote {
+            host: bytes_to_string(host, "remote host")?,
+            path: PathSpec {
+                path: path_from_bytes(path),
+                trailing_slash,
+            },
+            module: Some(bytes_to_string(module, "remote module")?),
+        });
+    }
+    if !s.is_empty() && s[0] == b'[' {
+        if let Some(end) = s.iter().position(|&b| b == b']') {
+            let host = &s[1..end];
+            if s.get(end + 1) == Some(&b':') {
+                let path = &s[end + 2..];
+                if host.is_empty() {
+                    return Err(EngineError::Other("remote host missing".into()));
+                }
+                if path.is_empty() || path.first() != Some(&b'/') {
+                    return Err(EngineError::Other("remote path missing".into()));
+                }
+                return Ok(RemoteSpec::Remote {
+                    host: bytes_to_string(host, "remote host")?,
+                    path: PathSpec {
+                        path: path_from_bytes(path),
+                        trailing_slash,
+                    },
+                    module: None,
+                });
+            }
+        }
+        return Ok(RemoteSpec::Local(PathSpec {
+            path: path_from_bytes(s),
+            trailing_slash,
+        }));
+    }
+    if let Some(idx) = s.windows(2).position(|w| w == b"::") {
+        let host = &s[..idx];
+        let mod_path = &s[idx + 2..];
+        let mut parts = mod_path.splitn(2, |&b| b == b'/');
+        let module = parts.next().unwrap_or(&[]);
+        let path = parts.next().unwrap_or(&[]);
+        if host.is_empty() {
+            return Err(EngineError::Other("remote host missing".into()));
+        }
+        if module.is_empty() {
+            return Err(EngineError::Other("remote module missing".into()));
+        }
+        let path = if path.is_empty() { b"." } else { path };
+        return Ok(RemoteSpec::Remote {
+            host: bytes_to_string(host, "remote host")?,
+            path: PathSpec {
+                path: path_from_bytes(path),
+                trailing_slash,
+            },
+            module: Some(bytes_to_string(module, "remote module")?),
+        });
+    }
+    if let Some(idx) = s.iter().position(|&b| b == b':') {
+        if idx == 1 {
+            if s[0].is_ascii_alphabetic()
+                && (s.len() == 2 || s.get(2) == Some(&b'/') || s.get(2) == Some(&b'\\'))
+            {
+                return Ok(RemoteSpec::Local(PathSpec {
+                    path: path_from_bytes(s),
+                    trailing_slash,
+                }));
+            }
+        }
+        let host = &s[..idx];
+        let path = &s[idx + 1..];
+        if host.is_empty() {
+            return Err(EngineError::Other("remote host missing".into()));
+        }
+        if path.is_empty() {
+            return Err(EngineError::Other("remote path missing".into()));
+        }
+        return Ok(RemoteSpec::Remote {
+            host: bytes_to_string(host, "remote host")?,
+            path: PathSpec {
+                path: path_from_bytes(path),
+                trailing_slash,
+            },
+            module: None,
+        });
+    }
+    Ok(RemoteSpec::Local(PathSpec {
+        path: path_from_bytes(s),
+        trailing_slash,
+    }))
+}
+
+pub fn is_remote_spec(path: &OsStr) -> bool {
+    matches!(parse_remote_spec(path), Ok(RemoteSpec::Remote { .. }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn classify_remote_specs() {
+        let cases = [
+            "rsync://host/mod/path",
+            "host::mod/path",
+            "host:/abs",
+            "[::1]:/abs",
+        ];
+        for c in cases {
+            assert!(is_remote_spec(OsStr::new(c)));
+            assert!(matches!(
+                parse_remote_spec(OsStr::new(c)),
+                Ok(RemoteSpec::Remote { .. })
+            ));
+        }
+    }
+
+    #[test]
+    fn classify_local_specs() {
+        let cases = ["/abs", "./rel", "C:/tmp", "dir/file"];
+        for c in cases {
+            assert!(!is_remote_spec(OsStr::new(c)));
+            assert!(matches!(
+                parse_remote_spec(OsStr::new(c)),
+                Ok(RemoteSpec::Local(_))
+            ));
+        }
+    }
+}

--- a/crates/engine/src/session/run.rs
+++ b/crates/engine/src/session/run.rs
@@ -23,8 +23,9 @@ use crate::io::io_context;
 use crate::{EngineError, Receiver, Result, Sender};
 
 use super::select_codec;
-use super::setup::{count_entries, is_remote_spec};
+use super::setup::count_entries;
 use super::{DeleteMode, Stats, SyncOptions};
+use crate::is_remote_spec;
 
 fn check_time_limit(start: Instant, opts: &SyncOptions) -> Result<()> {
     if let Some(limit) = opts.stop_after {

--- a/crates/engine/src/session/setup.rs
+++ b/crates/engine/src/session/setup.rs
@@ -1,7 +1,6 @@
 // crates/engine/src/session/setup.rs
 
 use std::fs;
-use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use compress::Codec;
@@ -11,35 +10,6 @@ use walk::walk;
 use crate::Result;
 
 use super::SyncOptions;
-
-pub(crate) fn is_remote_spec(path: &OsStr) -> bool {
-    if let Some(s) = path.to_str() {
-        if s.starts_with("rsync://") || s.starts_with("rsync:/") {
-            return true;
-        }
-        if s.starts_with('[') && s.contains("]:") {
-            return true;
-        }
-        if s.contains("::") {
-            return true;
-        }
-        if let Some(idx) = s.find(':') {
-            if idx == 1 {
-                let bytes = s.as_bytes();
-                if bytes[0].is_ascii_alphabetic()
-                    && bytes
-                        .get(2)
-                        .map(|c| *c == b'/' || *c == b'\\')
-                        .unwrap_or(false)
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-    }
-    false
-}
 
 pub(crate) fn count_entries(
     src_root: &Path,


### PR DESCRIPTION
## Summary
- add shared remote-spec parser and classifier in engine
- replace ad hoc remote checks with shared API
- adjust CLI to use central remote-spec API

## Testing
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines (max 600))*
- `bash tools/check_layers.sh` *(fails: engine -> logging, engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo fmt --all -- --check` *(fails: formatting differences)*
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo test --workspace` *(fails: linking with cc)*

------
https://chatgpt.com/codex/tasks/task_e_68c598a9f0e883238ce89ff42ab7b217