### PR TITLE
Preserve first hard link and test

### DIFF
--- a/crates/engine/src/sender.rs
+++ b/crates/engine/src/sender.rs
@@ -156,15 +156,15 @@ impl Sender {
             if let Ok(dst_sum) = self.strong_file_checksum(&dest) {
                 let src_sum = self.strong_file_checksum(path)?;
                 if src_sum == dst_sum {
-                    recv.copy_metadata(path, &dest)?;
+                    recv.copy_metadata(path, &dest, None)?;
                     return Ok(false);
                 }
             } else if self.metadata_unchanged(path, &dest) {
-                recv.copy_metadata(path, &dest)?;
+                recv.copy_metadata(path, &dest, None)?;
                 return Ok(false);
             }
         } else if self.metadata_unchanged(path, &dest) {
-            recv.copy_metadata(path, &dest)?;
+            recv.copy_metadata(path, &dest, None)?;
             return Ok(false);
         }
 
@@ -357,7 +357,7 @@ impl Sender {
         if !self.opts.only_write_batch {
             recv.apply(path, &dest, rel, ops)?;
             drop(atime_guard);
-            recv.copy_metadata(path, &dest)?;
+            recv.copy_metadata(path, &dest, None)?;
         } else {
             drop(atime_guard);
             for op in ops {

--- a/crates/filelist/src/entry.rs
+++ b/crates/filelist/src/entry.rs
@@ -36,28 +36,27 @@ pub fn group_by_inode(entries: &[InodeEntry]) -> Vec<Entry> {
     }
     let mut groups: HashMap<u64, u32> = HashMap::new();
     let mut next: u32 = 0;
-    entries
-        .iter()
-        .map(|e| {
-            let id = hard_link_id(e.dev, e.ino);
-            let hardlink = if counts.get(&id).copied().unwrap_or(0) > 1 {
-                Some(*groups.entry(id).or_insert_with(|| {
-                    let g = next;
-                    next += 1;
-                    g
-                }))
-            } else {
-                None
-            };
-            Entry {
-                path: e.path.clone(),
-                uid: e.uid,
-                gid: e.gid,
-                hardlink,
-                xattrs: e.xattrs.clone(),
-                acl: e.acl.clone(),
-                default_acl: e.default_acl.clone(),
-            }
-        })
-        .collect()
+    let mut out = Vec::with_capacity(entries.len());
+    for e in entries {
+        let id = hard_link_id(e.dev, e.ino);
+        let hardlink = if counts.get(&id).copied().unwrap_or(0) > 1 {
+            Some(*groups.entry(id).or_insert_with(|| {
+                let g = next;
+                next += 1;
+                g
+            }))
+        } else {
+            None
+        };
+        out.push(Entry {
+            path: e.path.clone(),
+            uid: e.uid,
+            gid: e.gid,
+            hardlink,
+            xattrs: e.xattrs.clone(),
+            acl: e.acl.clone(),
+            default_acl: e.default_acl.clone(),
+        });
+    }
+    out
 }

--- a/tests/daemon_hard_links_cross_dirs.rs
+++ b/tests/daemon_hard_links_cross_dirs.rs
@@ -1,0 +1,45 @@
+// tests/daemon_hard_links_cross_dirs.rs
+use assert_cmd::Command;
+use serial_test::serial;
+use std::fs;
+use tempfile::tempdir;
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+mod common;
+use common::daemon::{spawn_daemon, wait_for_daemon};
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn daemon_preserves_hard_links_across_dirs() {
+    let tmp = tempdir().expect("create temp dir");
+    let src = tmp.path().join("src");
+    let module = tmp.path().join("mod");
+    fs::create_dir_all(src.join("d1")).expect("create d1");
+    fs::create_dir_all(src.join("d2")).expect("create d2");
+    fs::create_dir_all(&module).expect("create module dir");
+
+    let f1 = src.join("d1/a");
+    fs::write(&f1, b"hi").expect("write a");
+    let f2 = src.join("d2/b");
+    fs::hard_link(&f1, &f2).expect("link b to a");
+
+    let mut daemon = spawn_daemon(&module);
+    let port = daemon.port;
+    wait_for_daemon(&mut daemon);
+
+    let src_arg = format!("{}/", src.display());
+    let dest = format!("rsync://127.0.0.1:{port}/mod/");
+    Command::cargo_bin("oc-rsync")
+        .expect("oc-rsync binary")
+        .current_dir(&tmp)
+        .args(["-aH", &src_arg, &dest])
+        .assert()
+        .success();
+
+    let ino_a = fs::metadata(module.join("d1/a")).expect("stat a").ino();
+    let ino_b = fs::metadata(module.join("d2/b")).expect("stat b").ino();
+    assert_eq!(ino_a, ino_b);
+}

--- a/tests/delay_updates.rs
+++ b/tests/delay_updates.rs
@@ -40,7 +40,7 @@ fn delay_updates_defers_rename() {
     assert_eq!(fs::read(&dst_file).unwrap(), b"old");
     assert_eq!(fs::read(&tmp_path).unwrap(), b"new");
 
-    recv.copy_metadata(&src_file, &dst_file).unwrap();
+    recv.copy_metadata(&src_file, &dst_file, None).unwrap();
     recv.finalize().unwrap();
 
     assert_eq!(fs::read(&dst_file).unwrap(), b"new");

--- a/tests/remote_remote_hard_links.rs
+++ b/tests/remote_remote_hard_links.rs
@@ -1,0 +1,52 @@
+// tests/remote_remote_hard_links.rs
+#![cfg(unix)]
+
+use assert_cmd::Command;
+use assert_cmd::cargo::cargo_bin;
+use serial_test::serial;
+use std::fs;
+use std::os::unix::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
+use tempfile::tempdir;
+
+#[test]
+#[serial]
+fn remote_remote_preserves_hard_links() {
+    let dir = tempdir().unwrap();
+    let src = dir.path().join("src");
+    let dst = dir.path().join("dst");
+    fs::create_dir_all(src.join("d1")).unwrap();
+    fs::create_dir_all(src.join("d2")).unwrap();
+    fs::create_dir_all(&dst).unwrap();
+
+    let f1 = src.join("d1/a");
+    fs::write(&f1, b"hi").unwrap();
+    let f2 = src.join("d2/b");
+    fs::hard_link(&f1, &f2).unwrap();
+
+    let rsh = dir.path().join("fake_rsh.sh");
+    fs::write(&rsh, b"#!/bin/sh\nshift\nexec \"$@\"\n").unwrap();
+    fs::set_permissions(&rsh, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let src_spec = format!("fake:{}", src.display());
+    let dst_spec = format!("fake:{}", dst.display());
+
+    let rr_bin = cargo_bin("oc-rsync");
+    let rr_dir = rr_bin.parent().unwrap();
+    let path_env = format!("{}:{}", rr_dir.display(), std::env::var("PATH").unwrap());
+    Command::new(&rr_bin)
+        .env("PATH", path_env)
+        .args([
+            "-aH",
+            "--rsh",
+            rsh.to_str().unwrap(),
+            &src_spec,
+            &dst_spec,
+        ])
+        .assert()
+        .success();
+
+    let ino_a = fs::metadata(dst.join("d1/a")).unwrap().ino();
+    let ino_b = fs::metadata(dst.join("d2/b")).unwrap().ino();
+    assert_eq!(ino_a, ino_b);
+}


### PR DESCRIPTION
## Summary
- keep initial path for a hard link group when generating file lists
- register hard link anchors even with delayed updates and finalize linking
- test daemon and remote-to-remote transfers preserve hard links across directories

## Testing
- `cargo +nightly fmt --all -- --check` *(failed: formatting differences)*
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `bash tools/comment_lint.sh`
- `MAX_RUST_LINES=600 bash tools/enforce_limits.sh` *(failed: crates/cli/src/argparse/flags.rs: 746 lines)*
- `bash tools/check_layers.sh` *(failed: engine -> logging, engine -> transport)*
- `bash tools/no_placeholders.sh`
- `cargo llvm-cov --workspace --lcov --output-path coverage.lcov --fail-under-lines 95` *(failed: no such command llvm-cov)*
- `cargo test --test daemon_hard_links_cross_dirs --test remote_remote_hard_links` *(failed: missing libacl)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ac2822fc8323b27e5f60c0c2dd42