### PR TITLE
Escape non-UTF8 session errors using octal escapes

### DIFF
--- a/crates/cli/src/session.rs
+++ b/crates/cli/src/session.rs
@@ -4,6 +4,18 @@ use oc_rsync_core::message::CharsetConv;
 use oc_rsync_core::transfer::{EngineError, Result};
 use transport::SshStdioTransport;
 
+fn escape_bytes(bytes: &[u8]) -> String {
+    let mut out = String::new();
+    for &b in bytes {
+        if (b < 0x20 && b != b'\t') || b > 0x7e {
+            out.push_str(&format!("\\#{:03o}", b));
+        } else {
+            out.push(char::from(b));
+        }
+    }
+    out
+}
+
 pub(crate) fn check_session_errors(
     session: &SshStdioTransport,
     iconv: Option<&CharsetConv>,
@@ -13,7 +25,10 @@ pub(crate) fn check_session_errors(
         let msg = if let Some(cv) = iconv {
             cv.decode_remote(&err).into_owned()
         } else {
-            String::from_utf8_lossy(&err).into_owned()
+            match String::from_utf8(err) {
+                Ok(s) => s,
+                Err(e) => escape_bytes(&e.into_bytes()),
+            }
         };
         return Err(EngineError::Other(msg));
     }
@@ -23,19 +38,36 @@ pub(crate) fn check_session_errors(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::time::Duration;
-
-    #[test]
-    fn detects_session_error() {
-        let session = SshStdioTransport::spawn("sh", ["-c", "echo err >&2"]).unwrap();
-        std::thread::sleep(Duration::from_millis(50));
-        assert!(check_session_errors(&session, None).is_err());
-    }
 
     #[test]
     fn ok_on_empty_stderr() {
         let session = SshStdioTransport::spawn("true", std::iter::empty::<&str>()).unwrap();
         std::thread::sleep(Duration::from_millis(50));
         assert!(check_session_errors(&session, None).is_ok());
+    }
+
+    #[test]
+    fn utf8_error_message() {
+        let session = SshStdioTransport::spawn("sh", ["-c", "printf 'err' >&2"]).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        match check_session_errors(&session, None) {
+            Err(EngineError::Other(msg)) => assert_eq!(msg, "err"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn escapes_non_utf8_error() {
+        let session = SshStdioTransport::spawn("sh", ["-c", "printf 'f\\377f' >&2"]).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+        let expected =
+            fs::read_to_string("../../tests/fixtures/rsync-send-nonascii-default.txt").unwrap();
+        let expected = expected.trim_end().trim_start_matches("send");
+        match check_session_errors(&session, None) {
+            Err(EngineError::Other(msg)) => assert_eq!(msg, expected),
+            _ => panic!(),
+        }
     }
 }


### PR DESCRIPTION
## Summary
- decode session stderr using `String::from_utf8`
- fall back to octal-escaped bytes when decoding fails
- add tests for valid and invalid UTF-8 error paths

## Testing
- `cargo fmt --all -- --check`
- `bash tools/comment_lint.sh`
- `bash tools/enforce_limits.sh` *(fails: crates/cli/src/argparse/flags.rs: 746 lines (max 600))*
- `bash tools/check_layers.sh`
- `bash tools/no_placeholders.sh`
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo test -p oc-rsync-cli` *(fails: missing fields `xattr_filter` and `xattr_filter_delete`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba73a8e8832390bf3a0f6e7632b6